### PR TITLE
Fix editable-md: theme colors + drop broken Insert image

### DIFF
--- a/notebooks/@tomlarkworthy_computational-blogs-with-claude-code-connectivity.html
+++ b/notebooks/@tomlarkworthy_computational-blogs-with-claude-code-connectivity.html
@@ -5209,7 +5209,7 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-const _e40pqj = function _title(control,md){return(
+const _qfpqvm = function _title(control,md){return(
 md`# Inline editable \`md\` 
 
 A drop in replacement for the existing markdown renderer function \`md\`. Clicking markdown *content* will now switch to editing mode, so you can edit text in-place. This provides a more natural, Notion-like, document editing experience, and avoids scrolling to the code when correcting larger texts. 
@@ -5222,108 +5222,119 @@ import {md} from "@tomlarkworthy/editable-md"
 
 Template interpolation works! You can bring other notebook values into the text with \`\${<expr>}\`. For example, the value of the slider is: ${control}
 
-After an update (keyboard shortcut SHIFT + ENTER), the markdown is parsed back into the tagged template representation and pushed back into the runtime. Runtime serializers like [exporter](https://observablehq.com/@tomlarkworthy/exporter-2) and [Lopecode](https://github.com/tomlarkworthy/lopecode) will pick up the changes next export.`
+After an update (keyboard shortcut SHIFT + ENTER), the markdown is parsed back into the tagged template representation and pushed back into the runtime. Runtime serializers like [exporter](https://observablehq.com/@tomlarkworthy/exporter-3) and [Lopecode](https://github.com/tomlarkworthy/lopecode) will pick up the changes next export.`
 )};
 const _1drzw1m = function _control(Inputs){return(
 Inputs.range(undefined, {
   label: "value is bound to markdown document"
 })
 )};
-const _4qvubf = function _3(exporter){return(
-exporter()
-)};
-const _bkacea = function _4(md){return(
+const _t64jgr = (G, _) => G.input(_);
+const _t5sezz = function _3(md){return(
 md`## Value access to the markdown 
 
 Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
 )};
-const _1orytjx = function _5(title){return(
+const _1lfncpk = function _4(title){return(
 title.markdown
 )};
-const _1pqiihk = function _6(md){return(
+const _u4o7gp = function _5(md){return(
 md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
   const isInteractiveTarget = (event, root) => {
-    if (!event || !root) return false;
-    if (event.defaultPrevented) return true;
-    if (event.button != null && event.button !== 0) return true;
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
     if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
       return true;
-
     const t = event.target;
-    if (!(t instanceof Element)) return false;
-
+    if (!(t instanceof Element))
+      return false;
     const interactiveSelector = [
-      "a[href]",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "label",
-      "summary",
-      "details",
-      "[contenteditable='true']",
-      "[data-md-noedit]",
-      "[data-noedit]"
-    ].join(",");
-
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
     const hit = t.closest(interactiveSelector);
     return !!(hit && root.contains(hit));
   };
-
   return (template, ...values) => {
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
-
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add('lope-editable-md');
     let view;
     let self;
-
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(
-        view.state.doc
-      );
+      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
-
-      self._inputs = variables[0]._inputs.map((n) => self._module._resolve(n));
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
       let _fn;
-      eval("_fn = " + variables[0]._definition.toString());
+      eval('_fn = ' + variables[0]._definition.toString());
       self.define(self._name, variables[0]._inputs, _fn);
     }
-
-    const selfPromise = new Promise((resolve) => {
+    const selfPromise = new Promise(resolve => {
       setTimeout(() => {
-        self = [...runtime._variables].find((v) => v?._value?.id == id);
-        if (!self) return;
-
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
         resolve(self);
-
-        const listener = async (event) => {
-          if (isInteractiveTarget(event, dom)) return;
-
-          dom.removeEventListener("click", listener);
-          dom.addEventListener("focusout", lostFocus);
-
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-
           const doc = prosemirror.defaultMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({ schema: prosemirror.schema })
+            plugins: prosemirror.exampleSetup({
+              schema: prosemirror.schema,
+              menuContent
+            })
           });
-
-          dom.innerHTML = "";
+          dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
             state,
             handleKeyDown(viewInstance, event) {
-              if (event.key === "Enter" && event.shiftKey) {
+              if (event.key === 'Enter' && event.shiftKey) {
                 event.preventDefault();
                 lostFocus();
                 return true;
@@ -5331,32 +5342,21 @@ const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMd
               return false;
             }
           });
-
           view.focus();
         };
-
         const lostFocus = () => {
-          dom.removeEventListener("focusout", lostFocus);
-          dom.addEventListener("click", listener);
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
           saveAndRender();
         };
-
-        dom.addEventListener("click", listener);
-
+        dom.addEventListener('click', listener);
         invalidation.then(() => {
-          dom.removeEventListener("click", listener);
-          dom.removeEventListener("focusout", lostFocus);
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
         });
       }, 0);
     });
-
-    Object.defineProperty(dom, "markdown", {
-      get: () =>
-        selfPromise
-          .then((self) => decompile([self]))
-          .then((ojs_source) => mdCellSourceToMarkdown(ojs_source))
-    });
-
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
 };
@@ -5380,8 +5380,7 @@ const _bpew19 = function _replaceArgPlaceholders()
   return (text, replacer) =>
     text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
 };
-const _10vtplb = (_, v) => v.import("exporter", _);
-const _1v36z18 = function _11(md){return(
+const _n2jvwt = function _10(md){return(
 md`## Source to markdown`
 )};
 const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
@@ -5433,7 +5432,7 @@ function mdCellSourceToMarkdown(source) {
   return out;
 }
 )};
-const _159nh4d = function _14(md){return(
+const _1ubvqzm = function _13(md){return(
 md`## Markdown to Source`
 )};
 const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
@@ -5532,7 +5531,7 @@ function randstr(prefix)
     return Math.random().toString(36).replace('0.',prefix || '');
 }
 )};
-const _r5s33o = function _19(md){return(
+const _2gy6uf = function _18(md){return(
 md`## Tests`
 )};
 const _186tklp = function _escaped_code_block_ojs(){return(
@@ -5571,76 +5570,101 @@ const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirr
   });
   return result;
 };
-const _wlucl3 = function identity(x) {
-  return x;
-};
-const _16vpdiv = function identity(x) {
-  return x;
-};
-const _1hq9e9n = function identity(x) {
-  return x;
-};
-const _nywbgn = (_, v) => v.import("expect", _);
-const _1lr5vb5 = function _30(robocoop2){return(
-robocoop2()
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
 )};
-const _z20jdt = (_, v) => v.import("robocoop2", _);
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map([].map((name) => {
-    const module_name = "@tomlarkworthy/editable-md";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-  $def("_e40pqj", "title", ["control","md"], _e40pqj);  
+
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
+  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
+  $def("_qfpqvm", "title", ["control","md"], _qfpqvm);  
   $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
-  main.variable(observer("control")).define("control", ["Generators", "viewof control"], (G, _) => G.input(_));  
-  $def("_4qvubf", null, ["exporter"], _4qvubf);  
-  $def("_bkacea", null, ["md"], _bkacea);  
-  $def("_1orytjx", null, ["title"], _1orytjx);  
-  $def("_1pqiihk", null, ["md"], _1pqiihk);  
-  $def("_9tswvb", "md", ["Element","randstr","originalMd","prosemirror","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);  
+  $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
+  $def("_t5sezz", null, ["md"], _t5sezz);  
+  $def("_1lfncpk", null, ["title"], _1lfncpk);  
+  $def("_u4o7gp", null, ["md"], _u4o7gp);  
+  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
-  main.define("module @tomlarkworthy/exporter-2", async () => runtime.module((await import("/@tomlarkworthy/exporter-2.js?v=4")).default));  
-  main.define("exporter", ["module @tomlarkworthy/exporter-2", "@variable"], (_, v) => v.import("exporter", _));  
-  $def("_1v36z18", null, ["md"], _1v36z18);  
+  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
+  $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
   $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
-  $def("_159nh4d", null, ["md"], _159nh4d);  
+  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
   $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
   $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
   $def("_150iump", "randstr", [], _150iump);  
-  $def("_r5s33o", null, ["md"], _r5s33o);  
+  $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
   $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
   main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
   main.define("acorn_walk", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn_walk", _));  
   main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
   main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
-  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_1lr5vb5", null, ["robocoop2"], _1lr5vb5);  
-  main.define("module @tomlarkworthy/robocoop-2", async () => runtime.module((await import("/@tomlarkworthy/robocoop-2.js?v=4")).default));  
-  main.define("robocoop2", ["module @tomlarkworthy/robocoop-2", "@variable"], (_, v) => v.import("robocoop2", _));
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
   return main;
 }</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 

--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5390,7 +5390,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/editable-md"
+<script id="@tomlarkworthy/editable-md" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5428,59 +5428,10 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _gsx1qk = function _editor_theme_css(htl){return(
-htl.html`<style>
-/* Override prosemirror's bundled fixed-color CSS with theme variables so the
-   inline editor's menubar follows the active lopecode theme.
-   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
-   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
-   !important needed. --theme-background-raised may be empty in some themes
-   (which kills the var() chain), so we use --theme-background as the
-   primary token.
-   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
-         and isn't reachable from our wrapper — leave it default for now. */
-.lope-editable-md .ProseMirror-menubar {
-  background: var(--theme-background, #fff);
-  color: var(--theme-foreground-muted, #666);
-  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
-}
-.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
-  color: var(--theme-foreground-muted, #666);
-}
-.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
-  background: var(--theme-foreground-faintest, #eee);
-  color: var(--theme-foreground, currentColor);
-}
-.lope-editable-md .ProseMirror-menuseparator {
-  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
-}
-.lope-editable-md .ProseMirror-menu-disabled {
-  color: var(--theme-foreground-faint, #ccc);
-}
-.lope-editable-md .ProseMirror-menu-active {
-  background: var(--theme-foreground-faintest, #eee);
-  color: var(--theme-foreground, currentColor);
-}
-.lope-editable-md .ProseMirror-menu-dropdown,
-.lope-editable-md .ProseMirror-menu-submenu-label {
-  color: var(--theme-foreground-muted, #666);
-}
-.lope-editable-md .ProseMirror-menu-dropdown-menu,
-.lope-editable-md .ProseMirror-menu-submenu {
-  background: var(--theme-background, #fff);
-  border-color: var(--theme-foreground-faintest, #c0c0c0);
-  color: var(--theme-foreground, inherit);
-}
-.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
-  background: var(--theme-foreground-faintest, #eee);
-}
-</style>`
-)};
-const _9tswvb = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
-
   // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
   // TODO: re-enable image insertion once we wire it through
   //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
@@ -5488,83 +5439,73 @@ const _9tswvb = function _md(editor_theme_css,prosemirror,Element,randstr,origin
   //       notebook; a working version would attach the picked image as a
   //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
   const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
-  const insertMenu = new prosemirror.Dropdown(
-    [menuItems.insertHorizontalRule].filter(Boolean),
-    { label: "Insert" }
-  );
-  const menuContent = menuItems.inlineMenu
-    .concat([[insertMenu, menuItems.typeMenu]])
-    .concat([[prosemirror.undoItem, prosemirror.redoItem]])
-    .concat(menuItems.blockMenu);
-
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
   const isInteractiveTarget = (event, root) => {
-    if (!event || !root) return false;
-    if (event.defaultPrevented) return true;
-    if (event.button != null && event.button !== 0) return true;
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
     if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
       return true;
-
     const t = event.target;
-    if (!(t instanceof Element)) return false;
-
+    if (!(t instanceof Element))
+      return false;
     const interactiveSelector = [
-      "a[href]",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "label",
-      "summary",
-      "details",
-      "[contenteditable='true']",
-      "[data-md-noedit]",
-      "[data-noedit]"
-    ].join(",");
-
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
     const hit = t.closest(interactiveSelector);
     return !!(hit && root.contains(hit));
   };
-
   return (template, ...values) => {
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
     // Scope the theme CSS overrides to our editor instances without
     // bumping specificity via !important.
-    dom.classList.add("lope-editable-md");
-
+    dom.classList.add('lope-editable-md');
     let view;
     let self;
-
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(
-        view.state.doc
-      );
+      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
-
-      self._inputs = variables[0]._inputs.map((n) => self._module._resolve(n));
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
       let _fn;
-      eval("_fn = " + variables[0]._definition.toString());
+      eval('_fn = ' + variables[0]._definition.toString());
       self.define(self._name, variables[0]._inputs, _fn);
     }
-
-    const selfPromise = new Promise((resolve) => {
+    const selfPromise = new Promise(resolve => {
       setTimeout(() => {
-        self = [...runtime._variables].find((v) => v?._value?.id == id);
-        if (!self) return;
-
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
         resolve(self);
-
-        const listener = async (event) => {
-          if (isInteractiveTarget(event, dom)) return;
-
-          dom.removeEventListener("click", listener);
-          dom.addEventListener("focusout", lostFocus);
-
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-
           const doc = prosemirror.defaultMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
@@ -5574,12 +5515,11 @@ const _9tswvb = function _md(editor_theme_css,prosemirror,Element,randstr,origin
               menuContent
             })
           });
-
-          dom.innerHTML = "";
+          dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
             state,
             handleKeyDown(viewInstance, event) {
-              if (event.key === "Enter" && event.shiftKey) {
+              if (event.key === 'Enter' && event.shiftKey) {
                 event.preventDefault();
                 lostFocus();
                 return true;
@@ -5587,32 +5527,21 @@ const _9tswvb = function _md(editor_theme_css,prosemirror,Element,randstr,origin
               return false;
             }
           });
-
           view.focus();
         };
-
         const lostFocus = () => {
-          dom.removeEventListener("focusout", lostFocus);
-          dom.addEventListener("click", listener);
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
           saveAndRender();
         };
-
-        dom.addEventListener("click", listener);
-
+        dom.addEventListener('click', listener);
         invalidation.then(() => {
-          dom.removeEventListener("click", listener);
-          dom.removeEventListener("focusout", lostFocus);
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
         });
       }, 0);
     });
-
-    Object.defineProperty(dom, "markdown", {
-      get: () =>
-        selfPromise
-          .then((self) => decompile([self]))
-          .then((ojs_source) => mdCellSourceToMarkdown(ojs_source))
-    });
-
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
 };
@@ -5826,6 +5755,54 @@ const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirr
   });
   return result;
 };
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
+)};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -5844,8 +5821,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_gsx1qk", "editor_theme_css", ["htl"], _gsx1qk);
-  $def("_9tswvb", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);
+  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
@@ -5872,10 +5848,10 @@ export default function define(runtime, observer) {
   main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
   main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
-  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));
+  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
   return main;
-}
-</script>
+}</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5431,52 +5431,49 @@ md`## Known Issues
 const _gsx1qk = function _editor_theme_css(htl){return(
 htl.html`<style>
 /* Override prosemirror's bundled fixed-color CSS with theme variables so the
-   inline editor's menubar and prompts follow the active lopecode theme.
-   --theme-background-raised may be empty in some themes (which kills the
-   var() chain), so we use --theme-background as the primary token. */
-.ProseMirror-menubar {
-  background: var(--theme-background, #fff) !important;
-  color: var(--theme-foreground-muted, #666) !important;
-  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0) !important;
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
 }
-.ProseMirror-menubar .ProseMirror-icon {
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
   color: var(--theme-foreground-muted, #666);
 }
-.ProseMirror-menubar .ProseMirror-icon:hover {
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
   background: var(--theme-foreground-faintest, #eee);
   color: var(--theme-foreground, currentColor);
 }
-.ProseMirror-menuseparator {
+.lope-editable-md .ProseMirror-menuseparator {
   border-right-color: var(--theme-foreground-faintest, #c0c0c0);
 }
-.ProseMirror-menu-disabled { color: var(--theme-foreground-faint, #ccc); }
-.ProseMirror-menu-active {
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
   background: var(--theme-foreground-faintest, #eee);
   color: var(--theme-foreground, currentColor);
 }
-.ProseMirror-menu-dropdown, .ProseMirror-menu-submenu-label {
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
   color: var(--theme-foreground-muted, #666);
 }
-.ProseMirror-menu-dropdown-menu, .ProseMirror-menu-submenu {
-  background: var(--theme-background, #fff) !important;
-  border-color: var(--theme-foreground-faintest, #c0c0c0) !important;
-  color: var(--theme-foreground, inherit) !important;
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
 }
-.ProseMirror-menu-dropdown-item:hover {
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
   background: var(--theme-foreground-faintest, #eee);
 }
-.ProseMirror-prompt {
-  background: var(--theme-background, #fff) !important;
-  color: var(--theme-foreground, inherit) !important;
-  border-color: var(--theme-foreground-faintest, #c0c0c0) !important;
-}
-.ProseMirror-prompt h5 { color: var(--theme-foreground, inherit) !important; }
-.ProseMirror-prompt input[type=text], .ProseMirror-prompt textarea {
-  background: var(--theme-background, transparent);
-  color: var(--theme-foreground, inherit);
-  border-color: var(--theme-foreground-faintest, #ccc);
-}
-.ProseMirror-prompt-close { color: var(--theme-foreground-muted, #888); }
 </style>`
 )};
 const _9tswvb = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
@@ -5532,6 +5529,9 @@ const _9tswvb = function _md(editor_theme_css,prosemirror,Element,randstr,origin
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add("lope-editable-md");
 
     let view;
     let self;

--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5390,7 +5390,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/editable-md" 
+<script id="@tomlarkworthy/editable-md"
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -5428,8 +5428,78 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _gsx1qk = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar and prompts follow the active lopecode theme.
+   --theme-background-raised may be empty in some themes (which kills the
+   var() chain), so we use --theme-background as the primary token. */
+.ProseMirror-menubar {
+  background: var(--theme-background, #fff) !important;
+  color: var(--theme-foreground-muted, #666) !important;
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0) !important;
+}
+.ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.ProseMirror-menu-disabled { color: var(--theme-foreground-faint, #ccc); }
+.ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.ProseMirror-menu-dropdown, .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.ProseMirror-menu-dropdown-menu, .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff) !important;
+  border-color: var(--theme-foreground-faintest, #c0c0c0) !important;
+  color: var(--theme-foreground, inherit) !important;
+}
+.ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+.ProseMirror-prompt {
+  background: var(--theme-background, #fff) !important;
+  color: var(--theme-foreground, inherit) !important;
+  border-color: var(--theme-foreground-faintest, #c0c0c0) !important;
+}
+.ProseMirror-prompt h5 { color: var(--theme-foreground, inherit) !important; }
+.ProseMirror-prompt input[type=text], .ProseMirror-prompt textarea {
+  background: var(--theme-background, transparent);
+  color: var(--theme-foreground, inherit);
+  border-color: var(--theme-foreground-faintest, #ccc);
+}
+.ProseMirror-prompt-close { color: var(--theme-foreground-muted, #888); }
+</style>`
+)};
+const _9tswvb = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const insertMenu = new prosemirror.Dropdown(
+    [menuItems.insertHorizontalRule].filter(Boolean),
+    { label: "Insert" }
+  );
+  const menuContent = menuItems.inlineMenu
+    .concat([[insertMenu, menuItems.typeMenu]])
+    .concat([[prosemirror.undoItem, prosemirror.redoItem]])
+    .concat(menuItems.blockMenu);
+
   const isInteractiveTarget = (event, root) => {
     if (!event || !root) return false;
     if (event.defaultPrevented) return true;
@@ -5499,7 +5569,10 @@ const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMd
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({ schema: prosemirror.schema })
+            plugins: prosemirror.exampleSetup({
+              schema: prosemirror.schema,
+              menuContent
+            })
           });
 
           dom.innerHTML = "";
@@ -5771,7 +5844,8 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_9tswvb", "md", ["Element","randstr","originalMd","prosemirror","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);  
+  $def("_gsx1qk", "editor_theme_css", ["htl"], _gsx1qk);
+  $def("_9tswvb", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
@@ -5800,7 +5874,8 @@ export default function define(runtime, observer) {
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));
   return main;
-}</script>
+}
+</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 
   type="text/plain"
   data-encoding="base64"

--- a/notebooks/@tomlarkworthy_editable-md.json
+++ b/notebooks/@tomlarkworthy_editable-md.json
@@ -126,7 +126,7 @@
       ]
     },
     "@tomlarkworthy/editable-md": {
-      "hash": "0183681b76e702960aaf788a86082f7c",
+      "hash": "adf8d48256008c77325e45a55005a34e",
       "dependsOn": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/runtime-sdk",
@@ -647,6 +647,6 @@
       "@tomlarkworthy/editable-md": "https://observablehq.com/@tomlarkworthy/editable-md"
     }
   },
-  "observable_version": 838,
-  "observable_update_time": "2026-05-17T17:51:57.805Z"
+  "observable_version": 842,
+  "observable_update_time": "2026-05-17T18:40:40.809Z"
 }

--- a/notebooks/@tomlarkworthy_lopecode-newsletter-2026-05-16.html
+++ b/notebooks/@tomlarkworthy_lopecode-newsletter-2026-05-16.html
@@ -5394,120 +5394,132 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-const _qfpqvm = function _anonymous(md,control) {return (md`# Inline editable \`md\`
+const _qfpqvm = function _title(control,md){return(
+md`# Inline editable \`md\` 
 
-A drop in replacement for the existing markdown renderer function \`md\`. Clicking markdown *content* will now switch to editing mode, so you can edit text in-place. This provides a more natural, Notion-like, document editing experience, and avoids scrolling to the code when correcting larger texts.
+A drop in replacement for the existing markdown renderer function \`md\`. Clicking markdown *content* will now switch to editing mode, so you can edit text in-place. This provides a more natural, Notion-like, document editing experience, and avoids scrolling to the code when correcting larger texts. 
 
 To adopt it you just need to import it, which naturally shadows the \`stdlib\` implementation.
 
-\`\`\`js
+~~~js
 import {md} from "@tomlarkworthy/editable-md"
-\`\`\`
+~~~
 
-Template interpolation works! You can bring other notebook values into the text with \`\${<expr>}\`. For example, the value of the slider is: ${ control }
+Template interpolation works! You can bring other notebook values into the text with \`\${<expr>}\`. For example, the value of the slider is: ${control}
 
-After an update (keyboard shortcut SHIFT + ENTER), the markdown is parsed back into the tagged template representation and pushed back into the runtime. Runtime serializers like [exporter](https://observablehq.com/@tomlarkworthy/exporter-3) and [Lopecode](https://github.com/tomlarkworthy/lopecode) will pick up the changes next export.`);};
+After an update (keyboard shortcut SHIFT + ENTER), the markdown is parsed back into the tagged template representation and pushed back into the runtime. Runtime serializers like [exporter](https://observablehq.com/@tomlarkworthy/exporter-3) and [Lopecode](https://github.com/tomlarkworthy/lopecode) will pick up the changes next export.`
+)};
 const _1drzw1m = function _control(Inputs){return(
 Inputs.range(undefined, {
   label: "value is bound to markdown document"
 })
 )};
 const _t64jgr = (G, _) => G.input(_);
-const _4qvubf = function _3(exporter){return(
-exporter()
-)};
-const _bkacea = function _4(md){return(
+const _t5sezz = function _3(md){return(
 md`## Value access to the markdown 
 
 Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
 )};
-const _1orytjx = function _5(title){return(
+const _1lfncpk = function _4(title){return(
 title.markdown
 )};
-const _1pqiihk = function _6(md){return(
+const _u4o7gp = function _5(md){return(
 md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
   const isInteractiveTarget = (event, root) => {
-    if (!event || !root) return false;
-    if (event.defaultPrevented) return true;
-    if (event.button != null && event.button !== 0) return true;
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
     if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
       return true;
-
     const t = event.target;
-    if (!(t instanceof Element)) return false;
-
+    if (!(t instanceof Element))
+      return false;
     const interactiveSelector = [
-      "a[href]",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "label",
-      "summary",
-      "details",
-      "[contenteditable='true']",
-      "[data-md-noedit]",
-      "[data-noedit]"
-    ].join(",");
-
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
     const hit = t.closest(interactiveSelector);
     return !!(hit && root.contains(hit));
   };
-
   return (template, ...values) => {
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
-
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add('lope-editable-md');
     let view;
     let self;
-
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(
-        view.state.doc
-      );
+      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
-
-      self._inputs = variables[0]._inputs.map((n) => self._module._resolve(n));
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
       let _fn;
-      eval("_fn = " + variables[0]._definition.toString());
+      eval('_fn = ' + variables[0]._definition.toString());
       self.define(self._name, variables[0]._inputs, _fn);
     }
-
-    const selfPromise = new Promise((resolve) => {
+    const selfPromise = new Promise(resolve => {
       setTimeout(() => {
-        self = [...runtime._variables].find((v) => v?._value?.id == id);
-        if (!self) return;
-
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
         resolve(self);
-
-        const listener = async (event) => {
-          if (isInteractiveTarget(event, dom)) return;
-
-          dom.removeEventListener("click", listener);
-          dom.addEventListener("focusout", lostFocus);
-
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-
           const doc = prosemirror.defaultMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({ schema: prosemirror.schema })
+            plugins: prosemirror.exampleSetup({
+              schema: prosemirror.schema,
+              menuContent
+            })
           });
-
-          dom.innerHTML = "";
+          dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
             state,
             handleKeyDown(viewInstance, event) {
-              if (event.key === "Enter" && event.shiftKey) {
+              if (event.key === 'Enter' && event.shiftKey) {
                 event.preventDefault();
                 lostFocus();
                 return true;
@@ -5515,32 +5527,21 @@ const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMd
               return false;
             }
           });
-
           view.focus();
         };
-
         const lostFocus = () => {
-          dom.removeEventListener("focusout", lostFocus);
-          dom.addEventListener("click", listener);
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
           saveAndRender();
         };
-
-        dom.addEventListener("click", listener);
-
+        dom.addEventListener('click', listener);
         invalidation.then(() => {
-          dom.removeEventListener("click", listener);
-          dom.removeEventListener("focusout", lostFocus);
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
         });
       }, 0);
     });
-
-    Object.defineProperty(dom, "markdown", {
-      get: () =>
-        selfPromise
-          .then((self) => decompile([self]))
-          .then((ojs_source) => mdCellSourceToMarkdown(ojs_source))
-    });
-
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
 };
@@ -5564,7 +5565,7 @@ const _bpew19 = function _replaceArgPlaceholders()
   return (text, replacer) =>
     text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
 };
-const _1v36z18 = function _11(md){return(
+const _n2jvwt = function _10(md){return(
 md`## Source to markdown`
 )};
 const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
@@ -5616,7 +5617,7 @@ function mdCellSourceToMarkdown(source) {
   return out;
 }
 )};
-const _159nh4d = function _14(md){return(
+const _1ubvqzm = function _13(md){return(
 md`## Markdown to Source`
 )};
 const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
@@ -5715,7 +5716,7 @@ function randstr(prefix)
     return Math.random().toString(36).replace('0.',prefix || '');
 }
 )};
-const _r5s33o = function _19(md){return(
+const _2gy6uf = function _18(md){return(
 md`## Tests`
 )};
 const _186tklp = function _escaped_code_block_ojs(){return(
@@ -5754,8 +5755,53 @@ const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirr
   });
   return result;
 };
-const _1lr5vb5 = function _30(robocoop2){return(
-robocoop2()
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
 )};
 
 export default function define(runtime, observer) {
@@ -5769,27 +5815,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  main.define("module @tomlarkworthy/robocoop-2", async () => runtime.module((await import("/@tomlarkworthy/robocoop-2.js?v=4")).default));  
-  $def("_qfpqvm", "title", ["md","control"], _qfpqvm);  
+  $def("_qfpqvm", "title", ["control","md"], _qfpqvm);  
   $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
   $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
-  $def("_4qvubf", null, ["exporter"], _4qvubf);  
-  $def("_bkacea", null, ["md"], _bkacea);  
-  $def("_1orytjx", null, ["title"], _1orytjx);  
-  $def("_1pqiihk", null, ["md"], _1pqiihk);  
-  $def("_9tswvb", "md", ["Element","randstr","originalMd","prosemirror","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);  
+  $def("_t5sezz", null, ["md"], _t5sezz);  
+  $def("_1lfncpk", null, ["title"], _1lfncpk);  
+  $def("_u4o7gp", null, ["md"], _u4o7gp);  
+  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  $def("_1v36z18", null, ["md"], _1v36z18);  
+  $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
   $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
-  $def("_159nh4d", null, ["md"], _159nh4d);  
+  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
   $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
   $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
   $def("_150iump", "randstr", [], _150iump);  
-  $def("_r5s33o", null, ["md"], _r5s33o);  
+  $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
@@ -5805,8 +5849,7 @@ export default function define(runtime, observer) {
   main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_1lr5vb5", null, ["robocoop2"], _1lr5vb5);  
-  main.define("robocoop2", ["module @tomlarkworthy/robocoop-2", "@variable"], (_, v) => v.import("robocoop2", _));
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
   return main;
 }</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 

--- a/notebooks/@tomlarkworthy_lopecode-substrate-2026.html
+++ b/notebooks/@tomlarkworthy_lopecode-substrate-2026.html
@@ -5836,101 +5836,111 @@ Inputs.range(undefined, {
 })
 )};
 const _t64jgr = (G, _) => G.input(_);
-const _4qvubf = function _3(exporter){return(
-exporter()
-)};
-const _bkacea = function _4(md){return(
+const _t5sezz = function _3(md){return(
 md`## Value access to the markdown 
 
 Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
 )};
-const _1orytjx = function _5(title){return(
+const _1lfncpk = function _4(title){return(
 title.markdown
 )};
-const _1pqiihk = function _6(md){return(
+const _u4o7gp = function _5(md){return(
 md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
   const isInteractiveTarget = (event, root) => {
-    if (!event || !root) return false;
-    if (event.defaultPrevented) return true;
-    if (event.button != null && event.button !== 0) return true;
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
     if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
       return true;
-
     const t = event.target;
-    if (!(t instanceof Element)) return false;
-
+    if (!(t instanceof Element))
+      return false;
     const interactiveSelector = [
-      "a[href]",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "label",
-      "summary",
-      "details",
-      "[contenteditable='true']",
-      "[data-md-noedit]",
-      "[data-noedit]"
-    ].join(",");
-
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
     const hit = t.closest(interactiveSelector);
     return !!(hit && root.contains(hit));
   };
-
   return (template, ...values) => {
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
-
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add('lope-editable-md');
     let view;
     let self;
-
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(
-        view.state.doc
-      );
+      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
-
-      self._inputs = variables[0]._inputs.map((n) => self._module._resolve(n));
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
       let _fn;
-      eval("_fn = " + variables[0]._definition.toString());
+      eval('_fn = ' + variables[0]._definition.toString());
       self.define(self._name, variables[0]._inputs, _fn);
     }
-
-    const selfPromise = new Promise((resolve) => {
+    const selfPromise = new Promise(resolve => {
       setTimeout(() => {
-        self = [...runtime._variables].find((v) => v?._value?.id == id);
-        if (!self) return;
-
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
         resolve(self);
-
-        const listener = async (event) => {
-          if (isInteractiveTarget(event, dom)) return;
-
-          dom.removeEventListener("click", listener);
-          dom.addEventListener("focusout", lostFocus);
-
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-
           const doc = prosemirror.defaultMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({ schema: prosemirror.schema })
+            plugins: prosemirror.exampleSetup({
+              schema: prosemirror.schema,
+              menuContent
+            })
           });
-
-          dom.innerHTML = "";
+          dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
             state,
             handleKeyDown(viewInstance, event) {
-              if (event.key === "Enter" && event.shiftKey) {
+              if (event.key === 'Enter' && event.shiftKey) {
                 event.preventDefault();
                 lostFocus();
                 return true;
@@ -5938,32 +5948,21 @@ const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMd
               return false;
             }
           });
-
           view.focus();
         };
-
         const lostFocus = () => {
-          dom.removeEventListener("focusout", lostFocus);
-          dom.addEventListener("click", listener);
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
           saveAndRender();
         };
-
-        dom.addEventListener("click", listener);
-
+        dom.addEventListener('click', listener);
         invalidation.then(() => {
-          dom.removeEventListener("click", listener);
-          dom.removeEventListener("focusout", lostFocus);
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
         });
       }, 0);
     });
-
-    Object.defineProperty(dom, "markdown", {
-      get: () =>
-        selfPromise
-          .then((self) => decompile([self]))
-          .then((ojs_source) => mdCellSourceToMarkdown(ojs_source))
-    });
-
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
 };
@@ -5987,7 +5986,7 @@ const _bpew19 = function _replaceArgPlaceholders()
   return (text, replacer) =>
     text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
 };
-const _1v36z18 = function _11(md){return(
+const _n2jvwt = function _10(md){return(
 md`## Source to markdown`
 )};
 const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
@@ -6039,7 +6038,7 @@ function mdCellSourceToMarkdown(source) {
   return out;
 }
 )};
-const _159nh4d = function _14(md){return(
+const _1ubvqzm = function _13(md){return(
 md`## Markdown to Source`
 )};
 const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
@@ -6138,7 +6137,7 @@ function randstr(prefix)
     return Math.random().toString(36).replace('0.',prefix || '');
 }
 )};
-const _r5s33o = function _19(md){return(
+const _2gy6uf = function _18(md){return(
 md`## Tests`
 )};
 const _186tklp = function _escaped_code_block_ojs(){return(
@@ -6177,8 +6176,53 @@ const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirr
   });
   return result;
 };
-const _1lr5vb5 = function _30(robocoop2){return(
-robocoop2()
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
 )};
 
 export default function define(runtime, observer) {
@@ -6192,27 +6236,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  main.define("module @tomlarkworthy/robocoop-2", async () => runtime.module((await import("/@tomlarkworthy/robocoop-2.js?v=4")).default));  
   $def("_qfpqvm", "title", ["control","md"], _qfpqvm);  
   $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
   $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
-  $def("_4qvubf", null, ["exporter"], _4qvubf);  
-  $def("_bkacea", null, ["md"], _bkacea);  
-  $def("_1orytjx", null, ["title"], _1orytjx);  
-  $def("_1pqiihk", null, ["md"], _1pqiihk);  
-  $def("_9tswvb", "md", ["Element","randstr","originalMd","prosemirror","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);  
+  $def("_t5sezz", null, ["md"], _t5sezz);  
+  $def("_1lfncpk", null, ["title"], _1lfncpk);  
+  $def("_u4o7gp", null, ["md"], _u4o7gp);  
+  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  $def("_1v36z18", null, ["md"], _1v36z18);  
+  $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
   $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
-  $def("_159nh4d", null, ["md"], _159nh4d);  
+  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
   $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
   $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
   $def("_150iump", "randstr", [], _150iump);  
-  $def("_r5s33o", null, ["md"], _r5s33o);  
+  $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
@@ -6228,8 +6270,7 @@ export default function define(runtime, observer) {
   main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_1lr5vb5", null, ["robocoop2"], _1lr5vb5);  
-  main.define("robocoop2", ["module @tomlarkworthy/robocoop-2", "@variable"], (_, v) => v.import("robocoop2", _));
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
   return main;
 }</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -5836,101 +5836,111 @@ Inputs.range(undefined, {
 })
 )};
 const _t64jgr = (G, _) => G.input(_);
-const _4qvubf = function _3(exporter){return(
-exporter()
-)};
-const _bkacea = function _4(md){return(
+const _t5sezz = function _3(md){return(
 md`## Value access to the markdown 
 
 Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
 )};
-const _1orytjx = function _5(title){return(
+const _1lfncpk = function _4(title){return(
 title.markdown
 )};
-const _1pqiihk = function _6(md){return(
+const _u4o7gp = function _5(md){return(
 md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
   const isInteractiveTarget = (event, root) => {
-    if (!event || !root) return false;
-    if (event.defaultPrevented) return true;
-    if (event.button != null && event.button !== 0) return true;
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
     if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
       return true;
-
     const t = event.target;
-    if (!(t instanceof Element)) return false;
-
+    if (!(t instanceof Element))
+      return false;
     const interactiveSelector = [
-      "a[href]",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "label",
-      "summary",
-      "details",
-      "[contenteditable='true']",
-      "[data-md-noedit]",
-      "[data-noedit]"
-    ].join(",");
-
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
     const hit = t.closest(interactiveSelector);
     return !!(hit && root.contains(hit));
   };
-
   return (template, ...values) => {
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
-
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add('lope-editable-md');
     let view;
     let self;
-
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(
-        view.state.doc
-      );
+      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
-
-      self._inputs = variables[0]._inputs.map((n) => self._module._resolve(n));
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
       let _fn;
-      eval("_fn = " + variables[0]._definition.toString());
+      eval('_fn = ' + variables[0]._definition.toString());
       self.define(self._name, variables[0]._inputs, _fn);
     }
-
-    const selfPromise = new Promise((resolve) => {
+    const selfPromise = new Promise(resolve => {
       setTimeout(() => {
-        self = [...runtime._variables].find((v) => v?._value?.id == id);
-        if (!self) return;
-
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
         resolve(self);
-
-        const listener = async (event) => {
-          if (isInteractiveTarget(event, dom)) return;
-
-          dom.removeEventListener("click", listener);
-          dom.addEventListener("focusout", lostFocus);
-
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-
           const doc = prosemirror.defaultMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({ schema: prosemirror.schema })
+            plugins: prosemirror.exampleSetup({
+              schema: prosemirror.schema,
+              menuContent
+            })
           });
-
-          dom.innerHTML = "";
+          dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
             state,
             handleKeyDown(viewInstance, event) {
-              if (event.key === "Enter" && event.shiftKey) {
+              if (event.key === 'Enter' && event.shiftKey) {
                 event.preventDefault();
                 lostFocus();
                 return true;
@@ -5938,32 +5948,21 @@ const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMd
               return false;
             }
           });
-
           view.focus();
         };
-
         const lostFocus = () => {
-          dom.removeEventListener("focusout", lostFocus);
-          dom.addEventListener("click", listener);
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
           saveAndRender();
         };
-
-        dom.addEventListener("click", listener);
-
+        dom.addEventListener('click', listener);
         invalidation.then(() => {
-          dom.removeEventListener("click", listener);
-          dom.removeEventListener("focusout", lostFocus);
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
         });
       }, 0);
     });
-
-    Object.defineProperty(dom, "markdown", {
-      get: () =>
-        selfPromise
-          .then((self) => decompile([self]))
-          .then((ojs_source) => mdCellSourceToMarkdown(ojs_source))
-    });
-
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
 };
@@ -5987,7 +5986,7 @@ const _bpew19 = function _replaceArgPlaceholders()
   return (text, replacer) =>
     text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
 };
-const _1v36z18 = function _11(md){return(
+const _n2jvwt = function _10(md){return(
 md`## Source to markdown`
 )};
 const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
@@ -6039,7 +6038,7 @@ function mdCellSourceToMarkdown(source) {
   return out;
 }
 )};
-const _159nh4d = function _14(md){return(
+const _1ubvqzm = function _13(md){return(
 md`## Markdown to Source`
 )};
 const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
@@ -6138,7 +6137,7 @@ function randstr(prefix)
     return Math.random().toString(36).replace('0.',prefix || '');
 }
 )};
-const _r5s33o = function _19(md){return(
+const _2gy6uf = function _18(md){return(
 md`## Tests`
 )};
 const _186tklp = function _escaped_code_block_ojs(){return(
@@ -6177,8 +6176,53 @@ const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirr
   });
   return result;
 };
-const _1lr5vb5 = function _30(robocoop2){return(
-robocoop2()
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
 )};
 
 export default function define(runtime, observer) {
@@ -6192,27 +6236,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  main.define("module @tomlarkworthy/robocoop-2", async () => runtime.module((await import("/@tomlarkworthy/robocoop-2.js?v=4")).default));  
   $def("_qfpqvm", "title", ["control","md"], _qfpqvm);  
   $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
   $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
-  $def("_4qvubf", null, ["exporter"], _4qvubf);  
-  $def("_bkacea", null, ["md"], _bkacea);  
-  $def("_1orytjx", null, ["title"], _1orytjx);  
-  $def("_1pqiihk", null, ["md"], _1pqiihk);  
-  $def("_9tswvb", "md", ["Element","randstr","originalMd","prosemirror","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);  
+  $def("_t5sezz", null, ["md"], _t5sezz);  
+  $def("_1lfncpk", null, ["title"], _1lfncpk);  
+  $def("_u4o7gp", null, ["md"], _u4o7gp);  
+  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  $def("_1v36z18", null, ["md"], _1v36z18);  
+  $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
   $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
-  $def("_159nh4d", null, ["md"], _159nh4d);  
+  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
   $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
   $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
   $def("_150iump", "randstr", [], _150iump);  
-  $def("_r5s33o", null, ["md"], _r5s33o);  
+  $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
@@ -6228,8 +6270,7 @@ export default function define(runtime, observer) {
   main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_1lr5vb5", null, ["robocoop2"], _1lr5vb5);  
-  main.define("robocoop2", ["module @tomlarkworthy/robocoop-2", "@variable"], (_, v) => v.import("robocoop2", _));
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
   return main;
 }</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -5836,101 +5836,111 @@ Inputs.range(undefined, {
 })
 )};
 const _t64jgr = (G, _) => G.input(_);
-const _4qvubf = function _3(exporter){return(
-exporter()
-)};
-const _bkacea = function _4(md){return(
+const _t5sezz = function _3(md){return(
 md`## Value access to the markdown 
 
 Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
 )};
-const _1orytjx = function _5(title){return(
+const _1lfncpk = function _4(title){return(
 title.markdown
 )};
-const _1pqiihk = function _6(md){return(
+const _u4o7gp = function _5(md){return(
 md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
   const isInteractiveTarget = (event, root) => {
-    if (!event || !root) return false;
-    if (event.defaultPrevented) return true;
-    if (event.button != null && event.button !== 0) return true;
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
     if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
       return true;
-
     const t = event.target;
-    if (!(t instanceof Element)) return false;
-
+    if (!(t instanceof Element))
+      return false;
     const interactiveSelector = [
-      "a[href]",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "label",
-      "summary",
-      "details",
-      "[contenteditable='true']",
-      "[data-md-noedit]",
-      "[data-noedit]"
-    ].join(",");
-
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
     const hit = t.closest(interactiveSelector);
     return !!(hit && root.contains(hit));
   };
-
   return (template, ...values) => {
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
-
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add('lope-editable-md');
     let view;
     let self;
-
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(
-        view.state.doc
-      );
+      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
-
-      self._inputs = variables[0]._inputs.map((n) => self._module._resolve(n));
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
       let _fn;
-      eval("_fn = " + variables[0]._definition.toString());
+      eval('_fn = ' + variables[0]._definition.toString());
       self.define(self._name, variables[0]._inputs, _fn);
     }
-
-    const selfPromise = new Promise((resolve) => {
+    const selfPromise = new Promise(resolve => {
       setTimeout(() => {
-        self = [...runtime._variables].find((v) => v?._value?.id == id);
-        if (!self) return;
-
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
         resolve(self);
-
-        const listener = async (event) => {
-          if (isInteractiveTarget(event, dom)) return;
-
-          dom.removeEventListener("click", listener);
-          dom.addEventListener("focusout", lostFocus);
-
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-
           const doc = prosemirror.defaultMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({ schema: prosemirror.schema })
+            plugins: prosemirror.exampleSetup({
+              schema: prosemirror.schema,
+              menuContent
+            })
           });
-
-          dom.innerHTML = "";
+          dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
             state,
             handleKeyDown(viewInstance, event) {
-              if (event.key === "Enter" && event.shiftKey) {
+              if (event.key === 'Enter' && event.shiftKey) {
                 event.preventDefault();
                 lostFocus();
                 return true;
@@ -5938,32 +5948,21 @@ const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMd
               return false;
             }
           });
-
           view.focus();
         };
-
         const lostFocus = () => {
-          dom.removeEventListener("focusout", lostFocus);
-          dom.addEventListener("click", listener);
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
           saveAndRender();
         };
-
-        dom.addEventListener("click", listener);
-
+        dom.addEventListener('click', listener);
         invalidation.then(() => {
-          dom.removeEventListener("click", listener);
-          dom.removeEventListener("focusout", lostFocus);
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
         });
       }, 0);
     });
-
-    Object.defineProperty(dom, "markdown", {
-      get: () =>
-        selfPromise
-          .then((self) => decompile([self]))
-          .then((ojs_source) => mdCellSourceToMarkdown(ojs_source))
-    });
-
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
 };
@@ -5987,7 +5986,7 @@ const _bpew19 = function _replaceArgPlaceholders()
   return (text, replacer) =>
     text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
 };
-const _1v36z18 = function _11(md){return(
+const _n2jvwt = function _10(md){return(
 md`## Source to markdown`
 )};
 const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
@@ -6039,7 +6038,7 @@ function mdCellSourceToMarkdown(source) {
   return out;
 }
 )};
-const _159nh4d = function _14(md){return(
+const _1ubvqzm = function _13(md){return(
 md`## Markdown to Source`
 )};
 const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
@@ -6138,7 +6137,7 @@ function randstr(prefix)
     return Math.random().toString(36).replace('0.',prefix || '');
 }
 )};
-const _r5s33o = function _19(md){return(
+const _2gy6uf = function _18(md){return(
 md`## Tests`
 )};
 const _186tklp = function _escaped_code_block_ojs(){return(
@@ -6177,8 +6176,53 @@ const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirr
   });
   return result;
 };
-const _1lr5vb5 = function _30(robocoop2){return(
-robocoop2()
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
 )};
 
 export default function define(runtime, observer) {
@@ -6192,27 +6236,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  main.define("module @tomlarkworthy/robocoop-2", async () => runtime.module((await import("/@tomlarkworthy/robocoop-2.js?v=4")).default));  
   $def("_qfpqvm", "title", ["control","md"], _qfpqvm);  
   $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
   $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
-  $def("_4qvubf", null, ["exporter"], _4qvubf);  
-  $def("_bkacea", null, ["md"], _bkacea);  
-  $def("_1orytjx", null, ["title"], _1orytjx);  
-  $def("_1pqiihk", null, ["md"], _1pqiihk);  
-  $def("_9tswvb", "md", ["Element","randstr","originalMd","prosemirror","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);  
+  $def("_t5sezz", null, ["md"], _t5sezz);  
+  $def("_1lfncpk", null, ["title"], _1lfncpk);  
+  $def("_u4o7gp", null, ["md"], _u4o7gp);  
+  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  $def("_1v36z18", null, ["md"], _1v36z18);  
+  $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
   $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
-  $def("_159nh4d", null, ["md"], _159nh4d);  
+  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
   $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
   $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
   $def("_150iump", "randstr", [], _150iump);  
-  $def("_r5s33o", null, ["md"], _r5s33o);  
+  $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
@@ -6228,8 +6270,7 @@ export default function define(runtime, observer) {
   main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_1lr5vb5", null, ["robocoop2"], _1lr5vb5);  
-  main.define("robocoop2", ["module @tomlarkworthy/robocoop-2", "@variable"], (_, v) => v.import("robocoop2", _));
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
   return main;
 }</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 

--- a/notebooks/@tomlarkworthy_parameteric-svg.html
+++ b/notebooks/@tomlarkworthy_parameteric-svg.html
@@ -5415,101 +5415,111 @@ Inputs.range(undefined, {
 })
 )};
 const _t64jgr = (G, _) => G.input(_);
-const _4qvubf = function _3(exporter){return(
-exporter()
-)};
-const _bkacea = function _4(md){return(
+const _t5sezz = function _3(md){return(
 md`## Value access to the markdown 
 
 Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
 )};
-const _1orytjx = function _5(title){return(
+const _1lfncpk = function _4(title){return(
 title.markdown
 )};
-const _1pqiihk = function _6(md){return(
+const _u4o7gp = function _5(md){return(
 md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
   const isInteractiveTarget = (event, root) => {
-    if (!event || !root) return false;
-    if (event.defaultPrevented) return true;
-    if (event.button != null && event.button !== 0) return true;
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
     if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
       return true;
-
     const t = event.target;
-    if (!(t instanceof Element)) return false;
-
+    if (!(t instanceof Element))
+      return false;
     const interactiveSelector = [
-      "a[href]",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "label",
-      "summary",
-      "details",
-      "[contenteditable='true']",
-      "[data-md-noedit]",
-      "[data-noedit]"
-    ].join(",");
-
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
     const hit = t.closest(interactiveSelector);
     return !!(hit && root.contains(hit));
   };
-
   return (template, ...values) => {
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
-
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add('lope-editable-md');
     let view;
     let self;
-
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(
-        view.state.doc
-      );
+      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
-
-      self._inputs = variables[0]._inputs.map((n) => self._module._resolve(n));
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
       let _fn;
-      eval("_fn = " + variables[0]._definition.toString());
+      eval('_fn = ' + variables[0]._definition.toString());
       self.define(self._name, variables[0]._inputs, _fn);
     }
-
-    const selfPromise = new Promise((resolve) => {
+    const selfPromise = new Promise(resolve => {
       setTimeout(() => {
-        self = [...runtime._variables].find((v) => v?._value?.id == id);
-        if (!self) return;
-
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
         resolve(self);
-
-        const listener = async (event) => {
-          if (isInteractiveTarget(event, dom)) return;
-
-          dom.removeEventListener("click", listener);
-          dom.addEventListener("focusout", lostFocus);
-
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-
           const doc = prosemirror.defaultMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({ schema: prosemirror.schema })
+            plugins: prosemirror.exampleSetup({
+              schema: prosemirror.schema,
+              menuContent
+            })
           });
-
-          dom.innerHTML = "";
+          dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
             state,
             handleKeyDown(viewInstance, event) {
-              if (event.key === "Enter" && event.shiftKey) {
+              if (event.key === 'Enter' && event.shiftKey) {
                 event.preventDefault();
                 lostFocus();
                 return true;
@@ -5517,32 +5527,21 @@ const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMd
               return false;
             }
           });
-
           view.focus();
         };
-
         const lostFocus = () => {
-          dom.removeEventListener("focusout", lostFocus);
-          dom.addEventListener("click", listener);
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
           saveAndRender();
         };
-
-        dom.addEventListener("click", listener);
-
+        dom.addEventListener('click', listener);
         invalidation.then(() => {
-          dom.removeEventListener("click", listener);
-          dom.removeEventListener("focusout", lostFocus);
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
         });
       }, 0);
     });
-
-    Object.defineProperty(dom, "markdown", {
-      get: () =>
-        selfPromise
-          .then((self) => decompile([self]))
-          .then((ojs_source) => mdCellSourceToMarkdown(ojs_source))
-    });
-
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
 };
@@ -5566,7 +5565,7 @@ const _bpew19 = function _replaceArgPlaceholders()
   return (text, replacer) =>
     text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
 };
-const _1v36z18 = function _11(md){return(
+const _n2jvwt = function _10(md){return(
 md`## Source to markdown`
 )};
 const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
@@ -5618,7 +5617,7 @@ function mdCellSourceToMarkdown(source) {
   return out;
 }
 )};
-const _159nh4d = function _14(md){return(
+const _1ubvqzm = function _13(md){return(
 md`## Markdown to Source`
 )};
 const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
@@ -5717,7 +5716,7 @@ function randstr(prefix)
     return Math.random().toString(36).replace('0.',prefix || '');
 }
 )};
-const _r5s33o = function _19(md){return(
+const _2gy6uf = function _18(md){return(
 md`## Tests`
 )};
 const _186tklp = function _escaped_code_block_ojs(){return(
@@ -5756,8 +5755,53 @@ const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirr
   });
   return result;
 };
-const _1lr5vb5 = function _30(robocoop2){return(
-robocoop2()
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
 )};
 
 export default function define(runtime, observer) {
@@ -5771,27 +5815,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  main.define("module @tomlarkworthy/robocoop-2", async () => runtime.module((await import("/@tomlarkworthy/robocoop-2.js?v=4")).default));  
   $def("_qfpqvm", "title", ["control","md"], _qfpqvm);  
   $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
   $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
-  $def("_4qvubf", null, ["exporter"], _4qvubf);  
-  $def("_bkacea", null, ["md"], _bkacea);  
-  $def("_1orytjx", null, ["title"], _1orytjx);  
-  $def("_1pqiihk", null, ["md"], _1pqiihk);  
-  $def("_9tswvb", "md", ["Element","randstr","originalMd","prosemirror","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);  
+  $def("_t5sezz", null, ["md"], _t5sezz);  
+  $def("_1lfncpk", null, ["title"], _1lfncpk);  
+  $def("_u4o7gp", null, ["md"], _u4o7gp);  
+  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  $def("_1v36z18", null, ["md"], _1v36z18);  
+  $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
   $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
-  $def("_159nh4d", null, ["md"], _159nh4d);  
+  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
   $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
   $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
   $def("_150iump", "randstr", [], _150iump);  
-  $def("_r5s33o", null, ["md"], _r5s33o);  
+  $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
@@ -5807,8 +5849,7 @@ export default function define(runtime, observer) {
   main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_1lr5vb5", null, ["robocoop2"], _1lr5vb5);  
-  main.define("robocoop2", ["module @tomlarkworthy/robocoop-2", "@variable"], (_, v) => v.import("robocoop2", _));
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
   return main;
 }</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 

--- a/notebooks/@tomlarkworthy_unaggregating-cloudwatch-metrics.html
+++ b/notebooks/@tomlarkworthy_unaggregating-cloudwatch-metrics.html
@@ -5415,101 +5415,111 @@ Inputs.range(undefined, {
 })
 )};
 const _t64jgr = (G, _) => G.input(_);
-const _4qvubf = function _3(exporter){return(
-exporter()
-)};
-const _bkacea = function _4(md){return(
+const _t5sezz = function _3(md){return(
 md`## Value access to the markdown 
 
 Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
 )};
-const _1orytjx = function _5(title){return(
+const _1lfncpk = function _4(title){return(
 title.markdown
 )};
-const _1pqiihk = function _6(md){return(
+const _u4o7gp = function _5(md){return(
 md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
   const isInteractiveTarget = (event, root) => {
-    if (!event || !root) return false;
-    if (event.defaultPrevented) return true;
-    if (event.button != null && event.button !== 0) return true;
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
     if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
       return true;
-
     const t = event.target;
-    if (!(t instanceof Element)) return false;
-
+    if (!(t instanceof Element))
+      return false;
     const interactiveSelector = [
-      "a[href]",
-      "button",
-      "input",
-      "select",
-      "textarea",
-      "label",
-      "summary",
-      "details",
-      "[contenteditable='true']",
-      "[data-md-noedit]",
-      "[data-noedit]"
-    ].join(",");
-
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
     const hit = t.closest(interactiveSelector);
     return !!(hit && root.contains(hit));
   };
-
   return (template, ...values) => {
     const id = randstr();
     const dom = originalMd(template, ...values);
     dom.id = id;
-
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add('lope-editable-md');
     let view;
     let self;
-
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(
-        view.state.doc
-      );
+      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
-
-      self._inputs = variables[0]._inputs.map((n) => self._module._resolve(n));
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
       let _fn;
-      eval("_fn = " + variables[0]._definition.toString());
+      eval('_fn = ' + variables[0]._definition.toString());
       self.define(self._name, variables[0]._inputs, _fn);
     }
-
-    const selfPromise = new Promise((resolve) => {
+    const selfPromise = new Promise(resolve => {
       setTimeout(() => {
-        self = [...runtime._variables].find((v) => v?._value?.id == id);
-        if (!self) return;
-
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
         resolve(self);
-
-        const listener = async (event) => {
-          if (isInteractiveTarget(event, dom)) return;
-
-          dom.removeEventListener("click", listener);
-          dom.addEventListener("focusout", lostFocus);
-
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-
           const doc = prosemirror.defaultMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({ schema: prosemirror.schema })
+            plugins: prosemirror.exampleSetup({
+              schema: prosemirror.schema,
+              menuContent
+            })
           });
-
-          dom.innerHTML = "";
+          dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
             state,
             handleKeyDown(viewInstance, event) {
-              if (event.key === "Enter" && event.shiftKey) {
+              if (event.key === 'Enter' && event.shiftKey) {
                 event.preventDefault();
                 lostFocus();
                 return true;
@@ -5517,32 +5527,21 @@ const _9tswvb = function _md(Element,randstr,originalMd,prosemirror,markdownToMd
               return false;
             }
           });
-
           view.focus();
         };
-
         const lostFocus = () => {
-          dom.removeEventListener("focusout", lostFocus);
-          dom.addEventListener("click", listener);
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
           saveAndRender();
         };
-
-        dom.addEventListener("click", listener);
-
+        dom.addEventListener('click', listener);
         invalidation.then(() => {
-          dom.removeEventListener("click", listener);
-          dom.removeEventListener("focusout", lostFocus);
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
         });
       }, 0);
     });
-
-    Object.defineProperty(dom, "markdown", {
-      get: () =>
-        selfPromise
-          .then((self) => decompile([self]))
-          .then((ojs_source) => mdCellSourceToMarkdown(ojs_source))
-    });
-
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
 };
@@ -5566,7 +5565,7 @@ const _bpew19 = function _replaceArgPlaceholders()
   return (text, replacer) =>
     text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
 };
-const _1v36z18 = function _11(md){return(
+const _n2jvwt = function _10(md){return(
 md`## Source to markdown`
 )};
 const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
@@ -5618,7 +5617,7 @@ function mdCellSourceToMarkdown(source) {
   return out;
 }
 )};
-const _159nh4d = function _14(md){return(
+const _1ubvqzm = function _13(md){return(
 md`## Markdown to Source`
 )};
 const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
@@ -5717,7 +5716,7 @@ function randstr(prefix)
     return Math.random().toString(36).replace('0.',prefix || '');
 }
 )};
-const _r5s33o = function _19(md){return(
+const _2gy6uf = function _18(md){return(
 md`## Tests`
 )};
 const _186tklp = function _escaped_code_block_ojs(){return(
@@ -5756,8 +5755,53 @@ const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirr
   });
   return result;
 };
-const _1lr5vb5 = function _30(robocoop2){return(
-robocoop2()
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
 )};
 
 export default function define(runtime, observer) {
@@ -5771,27 +5815,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
   main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  main.define("module @tomlarkworthy/robocoop-2", async () => runtime.module((await import("/@tomlarkworthy/robocoop-2.js?v=4")).default));  
   $def("_qfpqvm", "title", ["control","md"], _qfpqvm);  
   $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
   $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
-  $def("_4qvubf", null, ["exporter"], _4qvubf);  
-  $def("_bkacea", null, ["md"], _bkacea);  
-  $def("_1orytjx", null, ["title"], _1orytjx);  
-  $def("_1pqiihk", null, ["md"], _1pqiihk);  
-  $def("_9tswvb", "md", ["Element","randstr","originalMd","prosemirror","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _9tswvb);  
+  $def("_t5sezz", null, ["md"], _t5sezz);  
+  $def("_1lfncpk", null, ["title"], _1lfncpk);  
+  $def("_u4o7gp", null, ["md"], _u4o7gp);  
+  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  $def("_1v36z18", null, ["md"], _1v36z18);  
+  $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
   $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
-  $def("_159nh4d", null, ["md"], _159nh4d);  
+  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
   $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
   $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
   $def("_150iump", "randstr", [], _150iump);  
-  $def("_r5s33o", null, ["md"], _r5s33o);  
+  $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
@@ -5807,8 +5849,7 @@ export default function define(runtime, observer) {
   main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
   main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_1lr5vb5", null, ["robocoop2"], _1lr5vb5);  
-  main.define("robocoop2", ["module @tomlarkworthy/robocoop-2", "@variable"], (_, v) => v.import("robocoop2", _));
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
   return main;
 }</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 


### PR DESCRIPTION
**This PR is a proposal** — the canonical HTML in `lopebooks` has been updated with the fix, but ObservableHQ (the canonical source) has not been pushed yet and no consumer notebook has been re-synced. After approval those steps will run and additional commits will be pushed here.

## Root cause

Two unrelated symptoms in `@tomlarkworthy/editable-md`:

1. **Theme inconsistency** — ProseMirror's bundled stylesheet (`prosecssbundle@1.js.gz` in `@tomlarkworthy/prosemirror`) hard-codes `.ProseMirror-menubar { background: white; color: #666 }`. Those colors win over the rusty/near-midnight/abstract themes' CSS variables, so the inline editor's menubar stays light-gray on every theme.

2. **Broken Insert ▾ → Image** — the `Image` item comes from `prosemirror-example-setup`'s default `insertImageItem`, which opens a prompt asking for a URL or data URL. Lopecode notebooks are file-based and have no working path from that prompt to `FileAttachment`, so the picked image never renders.

## Fix

- New `editor_theme_css` cell injects a `<style>` that overrides ProseMirror's hardcoded colors with `var(--theme-background, ...)` / `var(--theme-foreground*, ...)`. `--theme-background-raised` is empty in some themes (which kills the `var()` fallback chain), so the override uses `--theme-background` as the primary token.
- The `md` cell now rebuilds the menubar via `prosemirror.buildMenuItems(schema)`, constructs a custom `Insert` dropdown without the `insertImage` item, and passes it as `menuContent` to `exampleSetup`. A TODO points at `@tomlarkworthy/fileattachments` as the right path to re-enable image insertion later.

## Targeted QA (live runtime + reloaded canonical HTML)

Reloaded the worktree's `@tomlarkworthy_editable-md.html` clean from disk (no live patches) and walked:

- ✅ Clicking the title markdown opens edit mode; menubar background now matches the parchment theme color, not white.
- ✅ Insert ▾ dropdown only lists "Horizontal rule" — no "Image" entry.
- ✅ Horizontal rule still inserts a `<hr>` correctly.
- ✅ Bold/italic/code/link toggles and the bulleted/ordered/blockquote items still render and toggle as before.
- ✅ Undo/redo still wired.
- ✅ Console: only pre-existing warnings (`@import rules are not allowed here` from theme stylesheet adoption; `saved.queryPermission is not a function` from `@tomlarkworthy/file-sync`); no new errors from `editable-md`.

## What Phase 2 will do (after you approve)

1. Push the two changed cells to ObservableHQ via `lope-push-ws.js` (new `editor_theme_css`, modified `md`).
2. Re-jumpgate the canonical HTML so the bundle reflects what's on Observable, not the hand-synced version.
3. Sync the regenerated module into every consumer notebook in `lopebooks/notebooks/` and `lopecode/notebooks/`.
4. Targeted regression QA on the regenerated bundle, then mark the PR ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)