### PR TITLE
Fix: editable-md keeps text selection on drag-highlight

### DIFF
--- a/notebooks/@tomlarkworthy_computational-blogs-with-claude-code-connectivity.html
+++ b/notebooks/@tomlarkworthy_computational-blogs-with-claude-code-connectivity.html
@@ -5243,7 +5243,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5353,6 +5353,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -5670,7 +5674,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5426,7 +5426,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5857,7 +5857,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5537,6 +5537,13 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
             return;
+          // Don't flip to edit mode when the click is the tail of a
+          // drag-to-select gesture — mounting the editor wipes the user's
+          // highlight. A non-collapsed selection rooted inside this cell
+          // means the user is actively selecting text.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
+            return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);

--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5537,10 +5537,7 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
             return;
-          // Don't flip to edit mode when the click is the tail of a
-          // drag-to-select gesture — mounting the editor wipes the user's
-          // highlight. A non-collapsed selection rooted inside this cell
-          // means the user is actively selecting text.
+          // A click ending a drag-select would otherwise wipe the highlight.
           const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
           if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;

--- a/notebooks/@tomlarkworthy_editable-md.json
+++ b/notebooks/@tomlarkworthy_editable-md.json
@@ -124,7 +124,7 @@
       ]
     },
     "@tomlarkworthy/editable-md": {
-      "hash": "a93e003bec6677898e2ae69db6a089b9",
+      "hash": "1b4d30b426b3ad056b86b40860efd44f",
       "dependsOn": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/runtime-sdk",
@@ -134,7 +134,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "fb8e916ca128e007c27542f4ce86ed4b",
+      "hash": "4175071d83af3ca54082813e24fd9f11",
       "files": [
         "cell_options.json"
       ],
@@ -566,6 +566,6 @@
       "@tomlarkworthy/editable-md": "https://observablehq.com/@tomlarkworthy/editable-md"
     }
   },
-  "observable_version": 843,
-  "observable_update_time": "2026-05-19T05:31:16.927Z"
+  "observable_version": 844,
+  "observable_update_time": "2026-05-19T18:22:36.638Z"
 }

--- a/notebooks/@tomlarkworthy_lopecode-newsletter-2026-05-16.html
+++ b/notebooks/@tomlarkworthy_lopecode-newsletter-2026-05-16.html
@@ -5428,7 +5428,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5538,6 +5538,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -5855,7 +5859,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_lopecode-substrate-2026.html
+++ b/notebooks/@tomlarkworthy_lopecode-substrate-2026.html
@@ -5849,7 +5849,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5959,6 +5959,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -6276,7 +6280,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -5849,7 +5849,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5959,6 +5959,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -6276,7 +6280,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -5849,7 +5849,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5959,6 +5959,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -6276,7 +6280,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_parameteric-svg.html
+++ b/notebooks/@tomlarkworthy_parameteric-svg.html
@@ -5428,7 +5428,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5538,6 +5538,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -5855,7 +5859,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  

--- a/notebooks/@tomlarkworthy_unaggregating-cloudwatch-metrics.html
+++ b/notebooks/@tomlarkworthy_unaggregating-cloudwatch-metrics.html
@@ -5428,7 +5428,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5538,6 +5538,10 @@ const _1llvbnw = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         resolve(self);
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
             return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
@@ -5855,7 +5859,7 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1llvbnw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1llvbnw);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  


### PR DESCRIPTION
**This PR is a proposal** — the canonical HTML has been updated with the new cell, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Reported symptom

> the editable-md is annoying because highlight text flips it to edit mode and you lose the highlight. Generally misclicks keep triggering it. We should only flip mode when its a clear click.

## Root cause

`@tomlarkworthy/editable-md`'s `md` cell attaches a plain `click` listener on each rendered cell. The browser fires a `click` event at the end of a drag-to-select if mouseup lands within the same element, but the listener's `isInteractiveTarget` gate only checks target type, mouse button, and modifier keys — never whether a text selection was just made. So every drag-select bottomed in a click handler that ran `dom.innerHTML = ''` and remounted ProseMirror, wiping the user's highlight.

## Fix

Add a selection-empty guard at the top of the listener: if `window.getSelection()` is non-collapsed and both its anchor and focus live inside this cell's DOM, bail out without mounting the editor. The user can still click cleanly to edit (selection is collapsed at that point); they just can't trigger edit mode mid-highlight.

\`\`\`js
const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode &&
    dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
  return;
\`\`\`

7-line diff inside the existing \`<script id="@tomlarkworthy/editable-md">\` block; no other module touched.

## Targeted QA (live runtime)

Three scripted scenarios on the title cell of the canonical notebook, after \`location.reload()\` against the patched HTML:

| # | Scenario | Expected | Observed |
|---|---|---|---|
| T1 | Install a 28-char Range, dispatch \`click\` | editor NOT mounted; selection preserved | pm=0, selectionPreserved="drop in replacement for the " |
| T2 | Install a 3-char Range (pointer-jitter analog), dispatch \`click\` | editor NOT mounted; selection preserved | pm=0, selectionPreserved="p i" |
| T3 | Clear selection, dispatch \`click\` (clean-click control) | editor mounts | pm=1 |

Console: clean (only the standard \`keepalive\` + \`selectVariable\` boot chatter; no errors).

## What this PR does NOT cover

- Double-click word-select. The first click of a \`dblclick\` arrives with \`hasSelection:false\` (the word-select happens at mousedown between the two clicks), so it still mounts the editor. User explicitly preferred the simpler selection-only fix; a dblclick gate is left for a follow-up.
- "Misclicks" in the broader sense (e.g. hitting a cell edge while aiming elsewhere) — that's a layout/hit-area concern, not addressable by this listener.