### PR TITLE
Fix: stream currentModules instead of force-loading every module (#27)

### DIFF
--- a/notebooks/@tomlarkworthy_module-map.html
+++ b/notebooks/@tomlarkworthy_module-map.html
@@ -16414,10 +16414,11 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/module-map" 
+<script id="@tomlarkworthy/module-map"
   type="text/plain"
   data-mime="application/javascript"
 >
+
 const _1w9yf3l = function _1(md){return(
 md`# Module map`
 )};
@@ -16458,20 +16459,22 @@ async (
 const _1yso65r = function _5(md){return(
 md`### \`currentModules\``
 )};
-const _1fcoh6x = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
-{
-  runtime_variables;
-  const latest = await moduleMap();
-  let dirty = !this || !_.isEqual(new Set(latest.keys()), new Set(this.keys()));
-  if (dirty) {
-    $0.value = latest;
-    $0.dispatchEvent(new Event("input"));
-  }
-  return $0.value;
+const _1fcoh6x = async function _sync_modules($0,moduleSnapshots,runtime,invalidation,Event) {
+    const view = $0;
+    const gen = moduleSnapshots(runtime);
+    invalidation.then(() => {
+        try {
+            gen.return();
+        } catch (e) {
+        }
+    });
+    for await (const snap of gen) {
+        view.value = snap;
+        view.dispatchEvent(new Event('input'));
+    }
+    return view.value;
 };
-const _wi39n0 = async function _currentModules(Inputs,moduleMap){return(
-Inputs.input(await moduleMap())
-)};
+const _wi39n0 = function _currentModules(Inputs,buildModuleSnapshot,runtime) {return (Inputs.input(buildModuleSnapshot(runtime)));};
 const _1gxgyd6 = (G, _) => G.input(_);
 const _1qag34d = function _8(Inputs,currentModules){return(
 Inputs.table([...currentModules.values()], {
@@ -17123,6 +17126,139 @@ const _1pou2g6 = function _submit_summary(resolve_modules,queue,notebookImports,
   notebookImports;
   $0.resolve(summary);
 };
+const _18e6uog = function _buildModuleSnapshot() {return ((runtime, titleCache) => {
+    const records = new Map();
+    const titleOf = (mod, fallback = null) => (titleCache && titleCache.get(mod)) ?? fallback;
+    const ensure = (mod, rec) => {
+        if (mod && !records.has(mod))
+            records.set(mod, rec);
+    };
+    const builtin = runtime._builtin;
+    const bootloader = runtime.bootloader;
+    if (builtin)
+        ensure(builtin, {
+            name: 'builtin',
+            title: 'Standard library',
+            module: builtin,
+            dependsOn: [],
+            dependedBy: []
+        });
+    if (bootloader)
+        ensure(bootloader, {
+            name: 'bootloader',
+            title: 'Bootloader',
+            module: bootloader,
+            dependsOn: [],
+            dependedBy: []
+        });
+    for (const [name, mod] of runtime.mains || new Map())
+        ensure(mod, {
+            name,
+            module: mod,
+            title: titleOf(mod),
+            dependsOn: [],
+            dependedBy: []
+        });
+    const moduleVars = [];
+    for (const v of runtime._variables) {
+        if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+            continue;
+        moduleVars.push(v);
+        const mod = v._value;
+        // resolved module object, or undefined if not yet loaded (we do not force it)
+        if (mod && typeof mod === 'object')
+            ensure(mod, {
+                type: 'module variable',
+                name: v._name.slice(7),
+                module: mod,
+                variable: v,
+                title: titleOf(mod),
+                dependsOn: [],
+                dependedBy: []
+            });
+    }
+    for (const rec of records.values()) {
+        const t = titleOf(rec.module);
+        if (t != null)
+            rec.title = t;
+    }
+    // cross-links from resolved module-variable imports: host(v._module) -> imported(v._value)
+    for (const v of moduleVars) {
+        const host = records.get(v._module);
+        const imported = v._value && typeof v._value === 'object' ? records.get(v._value) : null;
+        if (host && imported) {
+            host.dependsOn.push(imported.name);
+            imported.dependedBy.push(host.name);
+        }
+    }
+    return records;
+});};
+const _1t52h3o = function _moduleSnapshots(buildModuleSnapshot,moduleTitle,forcePeek) {return (function moduleSnapshots(runtime, {background = true, titles = true, settleMs = 1500} = {}) {
+    if (!runtime || !runtime._variables)
+        throw 'Invalid runtime passed to moduleSnapshots';
+    return async function* () {
+        const titleCache = new Map();
+        // module -> resolved title (filled lazily, in the background)
+        const scheduledTitle = new Set();
+        // modules whose title fetch has started
+        const scheduledLoad = new Set();
+        // `module *` variables we have already nudged to load
+        let resolveWake;
+        let wake = new Promise(r => resolveWake = r);
+        const bump = () => {
+            const r = resolveWake;
+            wake = new Promise(res => resolveWake = res);
+            r();
+        };
+        const snapshot = () => buildModuleSnapshot(runtime, titleCache);
+        const sig = m => [...m.values()].map(r => `${ r.name }:${ r.title ?? '' }:${ (r.dependsOn || []).length }`).sort().join('|');
+        // Kick off the slow work (titles, loading not-yet-resolved modules) WITHOUT blocking emission.
+        const schedule = snap => {
+            if (titles) {
+                for (const rec of snap.values()) {
+                    if (rec.title != null || scheduledTitle.has(rec.module))
+                        continue;
+                    scheduledTitle.add(rec.module);
+                    Promise.race([
+                        moduleTitle(rec.module),
+                        new Promise(res => setTimeout(() => res(null), settleMs))
+                    ]).then(t => {
+                        if (t != null) {
+                            titleCache.set(rec.module, t);
+                            bump();
+                        }
+                    }).catch(() => {
+                    });
+                }
+            }
+            if (background) {
+                for (const v of runtime._variables) {
+                    if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+                        continue;
+                    if (v._value && typeof v._value === 'object' || scheduledLoad.has(v))
+                        continue;
+                    scheduledLoad.add(v);
+                    Promise.resolve(forcePeek(v)).then(bump, bump);
+                }
+            }
+        };
+        let lastSig = '';
+        while (true) {
+            const next = snapshot();
+            schedule(next);
+            const s = sig(next);
+            if (s !== lastSig) {
+                lastSig = s;
+                yield next;
+            }
+            // wake on title/load settlement, with a periodic re-scan so live module add/remove is picked up
+            await Promise.race([
+                wake,
+                new Promise(r => setTimeout(r, 3000))
+            ]);
+        }
+    }();
+});};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -17140,8 +17276,8 @@ export default function define(runtime, observer) {
   $def("_1sznqfl", null, ["md"], _1sznqfl);  
   $def("_1798myt", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1798myt);  
   $def("_1yso65r", null, ["md"], _1yso65r);  
-  $def("_1fcoh6x", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1fcoh6x);  
-  $def("_wi39n0", "viewof currentModules", ["Inputs","moduleMap"], _wi39n0);  
+  $def("_1fcoh6x", "sync_modules", ["viewof currentModules","moduleSnapshots","runtime","invalidation","Event"], _1fcoh6x);  
+  $def("_wi39n0", "viewof currentModules", ["Inputs","buildModuleSnapshot","runtime"], _wi39n0);  
   $def("_1gxgyd6", "currentModules", ["Generators","viewof currentModules"], _1gxgyd6);  
   $def("_1qag34d", null, ["Inputs","currentModules"], _1qag34d);  
   $def("_1xamz8j", null, ["md"], _1xamz8j);  
@@ -17189,9 +17325,12 @@ export default function define(runtime, observer) {
   main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
   main.define("spectralCircleOrder", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("spectralCircleOrder", _));  
   main.define("improveOrderSifting", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("improveOrderSifting", _));  
-  main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));
+  main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));  
+  $def("_18e6uog", "buildModuleSnapshot", [], _18e6uog);  
+  $def("_1t52h3o", "moduleSnapshots", ["buildModuleSnapshot","moduleTitle","forcePeek"], _1t52h3o);
   return main;
-}</script>
+}
+</script>
 
 <script id="@tomlarkworthy/module-selection" 
   type="text/plain"


### PR DESCRIPTION
Fixes tomlarkworthy/lopecode-dev#27.

**This PR is a proposal** — the canonical `@tomlarkworthy/module-map` HTML has been updated with the new cells, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps run and additional commits land on this branch.

## Root cause
`viewof currentModules = Inputs.input(await moduleMap())`. `moduleMap()` only resolves after `module_definition_variables` **force-peeks every `module *` variable** (looping until the resolved count stabilises ≈ near-full download). So `currentModules` — and therefore lopepage's `layout → modulePanel → currentModules` chain — can't produce a value until ~all modules have loaded, defeating streaming/incremental load.

## Fix (contained to the module-map module)
Fresh streaming path; `moduleMap()` and its pipeline (`summary`, `submit_summary`, `module_definition_variables`, …) are left **completely intact** for explicit callers.

- **`buildModuleSnapshot(runtime[, titleCache])`** — pure synchronous helper. Builds the module map from what the runtime *already knows*: `builtin`, `bootloader`, `runtime.mains`, and the **already-resolved** `module *` variables (reads `v._value`; never forces an unresolved one). Cross-links (`dependsOn`/`dependedBy`) are derived from resolved module-variable imports.
- **`moduleSnapshots(runtime, {background=true, titles=true, settleMs=1500})`** — async generator. Emits the fast snapshot immediately, then **refines without blocking**: titles are fetched in the background (deferred — first emit carries `title:null`), not-yet-resolved modules are nudged to load in the background, and a periodic re-scan picks up live module add/remove. Re-emits only when the snapshot signature actually changes.
- **`viewof currentModules`** — now `Inputs.input(buildModuleSnapshot(runtime))`: an **instant, synchronous** seed (no `await`, no force-peek). The `viewof currentModules` import surface (≈every notebook depends on it) is preserved.
- **`sync_modules`** — repurposed (it has zero external importers) as the pump: `for await (snap of moduleSnapshots(runtime)) { view.value = snap; dispatch("input") }`, stopped on `invalidation`.

### Naming note
The user-requested name `modules` is already taken by an internal force-load pipeline cell that `moduleMap()` still depends on, so the generator is named `moduleSnapshots`. To keep the broadly-imported `viewof currentModules` symbol stable, `currentModules` is *driven by* the generator (seed + pump) rather than being a bare generator cell.

## Behavioural change (intended, per issue option 3)
`currentModules` is now **partial-then-complete** during cold load instead of complete-but-blocking. Consumers that read it reactively see it grow; consumers that read `viewof currentModules.value` at click-time (e.g. `cc_find_module`, disassemble) get whatever has loaded by then — unchanged in practice since those fire post-load.

## QA (live runtime, file:// paired)
- First snapshot: 45 entries, instant, `title:null`, no force-peek (verified with `background:false`).
- Refinement converges: titles fill to 44/45 in the background, cross-links present (22 entries with deps), every entry has `name`+`module`.
- Module-map circular-graph viz **and** module-selection table both render from the streamed `currentModules`.
- Middle-pane `moduleMap()`-driven viz still renders → the untouched `moduleMap()` pipeline works.
- Console: no errors attributable to module-map (only pre-existing file-sync-over-`file://` attachment-write noise).