### PR TITLE
Sync lopepage-2 fix (deep-link + splitter persistence) into robocoop-4

### DIFF
--- a/notebooks/@tomlarkworthy_robocoop-4.html
+++ b/notebooks/@tomlarkworthy_robocoop-4.html
@@ -33165,7 +33165,7 @@ const _sx484g = function _lp2_dragOut(){return(
   };
 }
 )};
-const _16k1pxm = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anchor,$0,Event,lp2_getPane,lp2_dragOut,lp2_ops,linkTo,lp2_paneRegistry,lp2_renderNode)
+const _1l0f5al = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anchor,$0,Event,lp2_getPane,lp2_dragOut,lp2_ops,linkTo,lp2_paneRegistry,lp2_renderNode)
 {
   const host = lp2_host;
   lp2Model;
@@ -33195,6 +33195,8 @@ const _16k1pxm = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anch
     for (const [name, anc] of saved) {
       const entry = lp2_paneRegistry.get(name);
       if (!entry || !entry.el.isConnected)
+        continue;
+      if (entry.pendingDeepLink)
         continue;
       if (anc.pid) {
         if (!lp2_anchor.restore(entry.el, anc) && anc.raw)
@@ -33568,7 +33570,7 @@ const _12ez53h = function _lp2_renderTab(location)
     return tab;
   };
 };
-const _h04q2g = function _lp2_dropZone()
+const _m7n4c3 = function _lp2_dropZone()
 {
   return (body, tabsEl, node, ctx) => {
     // which edge/centre of `el` the pointer is over: centre = merge, edge = split that side
@@ -33708,45 +33710,47 @@ const _h04q2g = function _lp2_dropZone()
     return zone;
   };
 };
-const _r0xme4 = function _lp2_splitter(){return(
-(node, i, row, wrap, slots, ctx) => {
-  const sp = document.createElement('div');
-  sp.className = 'lp2-splitter';
-  Object.assign(sp.style, {
-    flex: '0 0 6px',
-    cursor: row ? 'col-resize' : 'row-resize',
-    background: '#ddd',
-    flexShrink: 0
-  });
-  sp.addEventListener('pointerdown', e => {
-    e.preventDefault();
-    try {
-      sp.setPointerCapture(e.pointerId);
-    } catch (_) {
-    }
-    const startPos = row ? e.clientX : e.clientY;
-    const wrapSize = row ? wrap.clientWidth : wrap.clientHeight;
-    const s0 = node.sizes[i], s1 = node.sizes[i + 1], total = s0 + s1;
-    const onMove = ev => {
-      const delta = ((row ? ev.clientX : ev.clientY) - startPos) / wrapSize * 100;
-      let n0 = Math.max(5, Math.min(total - 5, s0 + delta));
-      node.sizes[i] = n0;
-      node.sizes[i + 1] = total - n0;
-      slots[i].style.flex = node.sizes[i] + ' 1 0';
-      slots[i + 1].style.flex = node.sizes[i + 1] + ' 1 0';
-    };
-    const onUp = () => {
-      document.removeEventListener('pointermove', onMove);
-      document.removeEventListener('pointerup', onUp);
-      ctx.commit(ctx.getRoot());
-    };
-    document.addEventListener('pointermove', onMove);
-    document.addEventListener('pointerup', onUp);
-  });
-  return sp;
-}
-)};
-const _1re02cd = function _lp2_renderStack(lp2_renderTab,lp2_dropZone){return(
+const _1hs48bp = function _lp2_splitter()
+{
+  return (node, i, row, wrap, slots, ctx) => {
+    const sp = document.createElement('div');
+    sp.className = 'lp2-splitter';
+    Object.assign(sp.style, {
+      flex: '0 0 6px',
+      cursor: row ? 'col-resize' : 'row-resize',
+      background: '#ddd',
+      flexShrink: 0
+    });
+    sp.addEventListener('pointerdown', e => {
+      e.preventDefault();
+      try {
+        sp.setPointerCapture(e.pointerId);
+      } catch (_) {
+      }
+      const startPos = row ? e.clientX : e.clientY;
+      const wrapSize = row ? wrap.clientWidth : wrap.clientHeight;
+      const s0 = node.sizes[i], s1 = node.sizes[i + 1], total = s0 + s1;
+      const onMove = ev => {
+        const delta = ((row ? ev.clientX : ev.clientY) - startPos) / wrapSize * 100;
+        // integer percentages so the layout round-trips through the integer-only #view= DSL
+        const n0 = Math.round(Math.max(5, Math.min(total - 5, s0 + delta)));
+        node.sizes[i] = n0;
+        node.sizes[i + 1] = total - n0;
+        slots[i].style.flex = node.sizes[i] + ' 1 0';
+        slots[i + 1].style.flex = node.sizes[i + 1] + ' 1 0';
+      };
+      const onUp = () => {
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        ctx.commit(ctx.getRoot());
+      };
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+    });
+    return sp;
+  };
+};
+const _nj1uts = function _lp2_renderStack(lp2_renderTab,lp2_dropZone){return(
 (node, ctx) => {
   const wrap = document.createElement('div');
   wrap.className = 'lp2-stack';
@@ -33866,7 +33870,7 @@ const _16ptruj = function _lp2_watchModules(lp2Model,currentModules,$0,Event)
   }
   return `watch ${ names.size } / resolved ${ next.size }${ changed ? ' (updated)' : '' }`;
 };
-const _1buhfep = function _lp2_scrollToCell(lp2_anchor)
+const _td27y7 = function _lp2_scrollToCell(lp2_anchor)
 {
   return (entry, cellName) => {
     // One-shot deep-link: scroll the pane so `cellName` (a variable name, e.g. from @mod#cell) sits at
@@ -33876,12 +33880,18 @@ const _1buhfep = function _lp2_scrollToCell(lp2_anchor)
     // past the last full page, so we can only scroll as far as it goes).
     if (!cellName || !entry || entry.transient)
       return;
+    // Own the pane scroll until the deep-link lands, so a concurrent rerender's scroll-restore
+    // (which captured the pre-deep-link scrollTop) does not clobber it. Cleared on land or give-up.
+    entry.pendingDeepLink = true;
+    const done = () => entry.pendingDeepLink = false;
     let tries = 0, lastSH = -1, stable = 0;
     const attempt = () => {
       const el = entry.el;
       const again = () => {
         if (tries++ < 60)
           window.setTimeout(attempt, 80);
+        else
+          done();
       };
       if (!el || !el.isConnected || !el.clientHeight)
         return again();
@@ -33901,17 +33911,20 @@ const _1buhfep = function _lp2_scrollToCell(lp2_anchor)
         el.__lp2_pinning = false;
       });
       if (Math.abs(el.scrollTop - targetTop) <= 2)
-        return;
+        return done();
       if (el.scrollHeight === lastSH) {
         if (++stable >= 3)
-          return;
+          return done();
       } else {
         stable = 0;
         lastSH = el.scrollHeight;
       }
       return again();
     };
-    attempt();
+    // Defer so the first attempt runs AFTER this rerender's synchronous scroll-restore and after
+    // getPane reparents the (immortal) pane; pendingDeepLink stays true across that window so the
+    // restore skips this pane, then the deferred attempt scrolls the now-settled pane to the cell.
+    window.setTimeout(attempt, 0);
   };
 };
 
@@ -33948,7 +33961,7 @@ export default function define(runtime, observer) {
   $def("_6f57qb", "lp2_renderNode", ["lp2_renderStack","lp2_renderSplit"], _6f57qb);  
   $def("_1r0c4er", "lp2_ops", [], _1r0c4er);  
   $def("_sx484g", "lp2_dragOut", [], _sx484g);  
-  $def("_16k1pxm", "lp2_view", ["lp2_host","lp2Model","lp2_installAnchor","lp2_anchor","viewof lp2Model","Event","lp2_getPane","lp2_dragOut","lp2_ops","linkTo","lp2_paneRegistry","lp2_renderNode"], _16k1pxm);  
+  $def("_1l0f5al", "lp2_view", ["lp2_host","lp2Model","lp2_installAnchor","lp2_anchor","viewof lp2Model","Event","lp2_getPane","lp2_dragOut","lp2_ops","linkTo","lp2_paneRegistry","lp2_renderNode"], _1l0f5al);  
   $def("_1bytrbx", "lp2_probe", ["lp2_view","lp2_paneRegistry"], _1bytrbx);  
   $def("_orvfgz", "lp2_doc_hash", ["md"], _orvfgz);  
   $def("_y2r8d1", "lp2_hash", ["Generators","location"], _y2r8d1);  
@@ -33977,14 +33990,14 @@ export default function define(runtime, observer) {
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
   $def("_12ez53h", "lp2_renderTab", ["location"], _12ez53h);  
-  $def("_h04q2g", "lp2_dropZone", [], _h04q2g);  
-  $def("_r0xme4", "lp2_splitter", [], _r0xme4);  
-  $def("_1re02cd", "lp2_renderStack", ["lp2_renderTab","lp2_dropZone"], _1re02cd);  
+  $def("_m7n4c3", "lp2_dropZone", [], _m7n4c3);  
+  $def("_1hs48bp", "lp2_splitter", [], _1hs48bp);  
+  $def("_nj1uts", "lp2_renderStack", ["lp2_renderTab","lp2_dropZone"], _nj1uts);  
   $def("_a9rn1a", "lp2_renderSplit", ["lp2_splitter"], _a9rn1a);  
   $def("_6vp46e", "viewof lp2_watchedModules", ["Inputs"], _6vp46e);  
   $def("_1hxhexc", "lp2_watchedModules", ["Generators","viewof lp2_watchedModules"], _1hxhexc);  
   $def("_16ptruj", "lp2_watchModules", ["lp2Model","currentModules","viewof lp2_watchedModules","Event"], _16ptruj);  
-  $def("_1buhfep", "lp2_scrollToCell", ["lp2_anchor"], _1buhfep);
+  $def("_td27y7", "lp2_scrollToCell", ["lp2_anchor"], _td27y7);
   return main;
 }</script>
 


### PR DESCRIPTION
Consumer sync for **tomlarkworthy/lopecode#192**. Updates the embedded `@tomlarkworthy/lopepage-2` module in `@tomlarkworthy/robocoop-4` to the version pushed to ObservableHQ (v3683).

Two fixes (full detail in lopecode#192):
- **Deep-link `#cell` to an already-open pane** now scrolls (was a no-op; `lp2_scrollToCell` defers past the rerender scroll-restore, `lp2_view` skips a pane a deep-link owns).
- **Splitter resizes persist to the URL** (`lp2_splitter` rounds `node.sizes` to integers so the layout round-trips the `#view=` DSL).

Single-file diff: the `@tomlarkworthy/lopepage-2` `<script>` block inside `@tomlarkworthy_robocoop-4.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)