### PR TITLE
Re-jumpgate robocoop-5: latest frame modules from Observable

### DIFF
--- a/notebooks/@tomlarkworthy_robocoop-5.html
+++ b/notebooks/@tomlarkworthy_robocoop-5.html
@@ -2606,15 +2606,15 @@ md`### Layout rendering and docking
 
 \`lp2_ops\` holds the tree operations: \`findHost\`, \`removeLeaf\`, \`dropBeside\`, \`normalize\`, and \`move\`. \`normalize\` collapses emptied stacks and single-child splits, so the tree stays minimal. Dragging a tab onto a pane's edge splits it (left/right/top/bottom); onto its centre merges into that stack. \`lp2_dragOut\` writes the module's \`.js\` source to the drag \`DataTransfer\`, so the same drag can drop the module out to the filesystem.`
 )};
-const _1kgkxiz = function _lp2_host()
+const _1fxe40f = function _lp2_host()
 {
-  const host = document.createElement("div");
-  host.className = "lp2-host";
+  const host = document.createElement('div');
+  host.className = 'lp2-host';
   Object.assign(host.style, {
-    position: "absolute",
-    inset: "0",
-    display: "flex",
-    overflow: "hidden"
+    position: 'absolute',
+    inset: '0',
+    display: 'flex',
+    overflow: 'hidden'
   });
   return host;
 };
@@ -2796,93 +2796,7 @@ const _sx484g = function _lp2_dragOut(){return(
   };
 }
 )};
-const _1yan973 = function _lp2_add_module(createModule,runtime,realize,location,linkTo,invalidation)
-{
-  const button = document.createElement('button');
-  button.className = 'lp2-add-module';
-  button.title = 'Create module';
-  button.setAttribute('aria-haspopup', 'true');
-  button.setAttribute('aria-expanded', 'false');
-  button.textContent = '+';
-  Object.assign(button.style, {
-    border: 'none', background: 'transparent', padding: '4px 10px',
-    cursor: 'pointer', color: 'var(--theme-foreground)',
-    font: '15px var(--sans-serif, sans-serif)', lineHeight: '1'
-  });
-
-  const popover = document.createElement('div');
-  popover.className = 'lp2-menu';
-  Object.assign(popover.style, {
-    position: 'fixed', display: 'none', zIndex: 1000,
-    background: 'var(--theme-background-a, #fff)', color: 'var(--theme-foreground)',
-    border: '1px solid var(--theme-foreground-fainter)', borderRadius: '4px',
-    boxShadow: '0 4px 16px rgba(0,0,0,.18)', padding: '8px',
-    font: '12px var(--sans-serif, sans-serif)'
-  });
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = '@user/module-name';
-  input.title = 'Enter a module name and press ↵ to create';
-  input.spellcheck = false;
-  Object.assign(input.style, {
-    padding: '4px 8px', border: '1px solid var(--theme-foreground-fainter)',
-    borderRadius: '3px', font: '12px var(--monospace, monospace)',
-    width: '210px', outline: 'none', boxSizing: 'border-box',
-    background: 'var(--theme-background, #fff)', color: 'var(--theme-foreground)'
-  });
-  const hint = document.createElement('div');
-  hint.textContent = '↵ create · esc cancel';
-  Object.assign(hint.style, { marginTop: '5px', color: 'var(--theme-foreground-faint)', fontSize: '11px' });
-  popover.append(input, hint);
-  document.body.appendChild(popover);
-
-  const close = () => { popover.style.display = 'none'; button.setAttribute('aria-expanded', 'false'); };
-  const resetBorder = () => { input.style.borderColor = 'var(--theme-foreground-fainter)'; };
-  const open = () => {
-    const r = button.getBoundingClientRect();
-    popover.style.left = Math.round(Math.min(r.left, window.innerWidth - 240)) + 'px';
-    popover.style.top = Math.round(r.bottom + 2) + 'px';
-    popover.style.display = 'block';
-    button.setAttribute('aria-expanded', 'true');
-    input.value = '';
-    resetBorder();
-    input.focus();
-  };
-  const create = async () => {
-    let name = input.value.trim().split('#')[0].replace(/\/+$/, '');
-    if (!name) { input.style.borderColor = '#e5533d'; return; }
-    if (!name.includes('/')) name = '@user/' + name.replace(/^@+/, '');
-    const src = 'function intro(md){ return md`# ' + name.split('/').pop() + '`; }';
-    const mod = createModule(name, runtime);
-    const [fn] = await realize([src], runtime);
-    mod.variable({}).define('intro', ['md'], fn);
-    close();
-    location.hash = linkTo({ open: name }, { baseURI: location.href });
-  };
-
-  button.addEventListener('click', ev => {
-    ev.stopPropagation();
-    popover.style.display === 'none' ? open() : close();
-  });
-  input.addEventListener('input', resetBorder);
-  input.addEventListener('keydown', ev => {
-    if (ev.key === 'Enter') {
-      ev.preventDefault();
-      create().catch(e => { input.style.borderColor = '#e5533d'; console.error('lp2 create module failed', e); });
-    } else if (ev.key === 'Escape') { ev.preventDefault(); close(); }
-  });
-  const onDocDown = ev => {
-    if (popover.style.display !== 'none' && !popover.contains(ev.target) && !button.contains(ev.target)) close();
-  };
-  document.addEventListener('mousedown', onDocDown);
-  invalidation.then(() => {
-    document.removeEventListener('mousedown', onDocDown);
-    popover.remove();
-    button.remove();
-  });
-  return { button, close };
-};
-const _1l0f5al = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anchor,$0,Event,lp2_getPane,lp2_dragOut,lp2_ops,linkTo,lp2_paneRegistry,lp2_renderNode,lp2_burger,lp2_add_module)
+const _1194mfy = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anchor,$0,Event,lp2_getPane,lp2_dragOut,lp2_ops,linkTo,lp2_paneRegistry,lp2_renderNode,lp2_burger,lp2_add_module)
 {
   const host = lp2_host;
   lp2Model;
@@ -3196,7 +3110,7 @@ const _1y1ubko = function _lp2_page(apply_theme,lp2_host,commandPaletteStyles,co
   root.appendChild(commandPaletteOverlay);
   return root;
 };
-const _1cumx25 = function _lp2_background_jobs(commandPaletteKeybinding,cc_chat,change_listener,commit_history,replay_git,auto_attach,lp2_watchModules,lp2_menu_sync,lp2_menu_defaults)
+const _1q105of = function _lp2_background_jobs(commandPaletteKeybinding,cc_chat,change_listener,commit_history,replay_git,auto_attach,lp2_watchModules,lp2_menu_sync,lp2_menu_defaults)
 {
   // hold references so these orthogonal features' main-loop cells instantiate
   commandPaletteKeybinding;
@@ -3219,7 +3133,7 @@ const _1cumx25 = function _lp2_background_jobs(commandPaletteKeybinding,cc_chat,
   // registers the built-in menu items (download, fork)
   return 'background jobs: command-palette, claude-code-pairing, local-change-history, editor-5, module-watcher, burger-menu';
 };
-const _1rtuk9d = function _lp2_append_to_body(lp2_view,lp2_syncFromUrl,lp2_syncToUrl,lp2_page)
+const _1yumqn = function _lp2_append_to_body(lp2_view,lp2_syncFromUrl,lp2_syncToUrl,lp2_page)
 {
   lp2_view;
   // ensure the layout renders into the host
@@ -3657,7 +3571,7 @@ const _td27y7 = function _lp2_scrollToCell(lp2_anchor)
     window.setTimeout(attempt, 0);
   };
 };
-const _1mnud0c = function _lp2_doc_menu(md){return(
+const _8vk6lr = function _lp2_doc_menu(md){return(
 md`### Burger menu (plugin registry)
 
 A hamburger button docked at the left of the top-left tab bar opens a menu of pluggable items. The registry is the [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lp2-menu"\`; \`lp2MenuItems\` is \`plugins.get("lp2-menu")\`, a reactive array of \`{id, label, svg, action, children, order}\`. \`svg\` is an SVG string, an \`Element\`, or a function returning one; \`children\` nests a submenu; lower \`order\` sorts first.
@@ -3666,26 +3580,33 @@ Plugins (this module's defaults, or any other notebook) register through \`lp2_r
 
 The button and popover are built once by \`lp2_burger\` (immortal, like panes) and reparented into the current top-left tab bar on each layout render. \`lp2_menu_defaults\` registers the built-ins: **Download** and **Fork** via [\`exporter-3\`](https://observablehq.com/@tomlarkworthy/exporter-3)'s \`downloadAnchor\`/\`forkAnchor\`, which serialise every booted main.`
 )};
-const _8wq5dn = function _lp2MenuItems(plugins){return(
-plugins.get("lp2-menu")
+const _1uvdt3f = function _lp2MenuItems(plugins){return(
+plugins.get('lp2-menu')
 )};
-const _p9krt2 = function _lp2_registerMenuItem(plugins){
+const _qcv0dp = function _lp2_registerMenuItem(plugins)
+{
   // id-keyed adapter over the shared plugins bus (set name "lp2-menu"): re-registering an id replaces
   // the prior value; the returned disposer removes only if this exact registration is still current.
-  const handles = new Map();   // id -> remove()
+  const handles = new Map();
+  // id -> remove()
   return item => {
     if (!item || !item.id)
       throw new Error('menu item needs an id');
     const prev = handles.get(item.id);
-    if (prev) prev();                              // replace-by-id
-    const remove = plugins.add("lp2-menu", item);
+    if (prev)
+      prev();
+    // replace-by-id
+    const remove = plugins.add('lp2-menu', item);
     handles.set(item.id, remove);
     return () => {
-      if (handles.get(item.id) === remove) { remove(); handles.delete(item.id); }
+      if (handles.get(item.id) === remove) {
+        remove();
+        handles.delete(item.id);
+      }
     };
   };
 };
-const _6tghw4 = function _lp2_burger(invalidation)
+const _bt1fe2 = function _lp2_burger(invalidation)
 {
   const button = document.createElement('button');
   button.className = 'lp2-burger';
@@ -3769,7 +3690,7 @@ const _6tghw4 = function _lp2_burger(invalidation)
     close
   };
 };
-const _2xf9jm = function _lp2_menu_sync(lp2_burger,lp2MenuItems)
+const _wypj4o = function _lp2_menu_sync(lp2_burger,Element,lp2MenuItems)
 {
   const {list, close} = lp2_burger;
   const bySort = arr => [...arr || []].sort((a, b) => (a.order ?? 100) - (b.order ?? 100) || String(a.label ?? a.id).localeCompare(String(b.label ?? b.id)));
@@ -3812,7 +3733,7 @@ const _2xf9jm = function _lp2_menu_sync(lp2_burger,lp2MenuItems)
       container.appendChild(btn);
       if (item.children && item.children.length) {
         const caret = document.createElement('span');
-        caret.textContent = '▸';
+        caret.textContent = '\u25B8';
         caret.style.opacity = '.6';
         btn.appendChild(caret);
         const sub = document.createElement('div');
@@ -3823,7 +3744,7 @@ const _2xf9jm = function _lp2_menu_sync(lp2_burger,lp2MenuItems)
           ev.stopPropagation();
           const opening = sub.style.display === 'none';
           sub.style.display = opening ? 'block' : 'none';
-          caret.textContent = opening ? '▾' : '▸';
+          caret.textContent = opening ? '\u25BE' : '\u25B8';
         });
       } else
         btn.addEventListener('click', ev => {
@@ -3850,7 +3771,7 @@ const _2xf9jm = function _lp2_menu_sync(lp2_burger,lp2MenuItems)
   }
   return `menu: ${ count } item${ count === 1 ? '' : 's' }`;
 };
-const _hs74kp = function _lp2_menu_defaults(lp2_registerMenuItem,disk_svg,downloadAnchor,forkAnchor,invalidation)
+const _1kos97o = function _lp2_menu_defaults(lp2_registerMenuItem,disk_svg,downloadAnchor,forkAnchor,invalidation)
 {
   // built-in items, registered through the same plugin path any other notebook uses;
   // the anchors carry exporter-3's export behaviour, so acting = clicking a fresh one
@@ -3873,6 +3794,126 @@ const _hs74kp = function _lp2_menu_defaults(lp2_registerMenuItem,disk_svg,downlo
   invalidation.then(() => disposers.forEach(d => d()));
   return 'menu defaults: download, fork';
 };
+const _1af1qr1 = function _lp2_add_module(createModule,runtime,realize,location,linkTo,invalidation)
+{
+  const button = document.createElement('button');
+  button.className = 'lp2-add-module';
+  button.title = 'Create module';
+  button.setAttribute('aria-haspopup', 'true');
+  button.setAttribute('aria-expanded', 'false');
+  button.textContent = '+';
+  Object.assign(button.style, {
+    border: 'none',
+    background: 'transparent',
+    padding: '4px 10px',
+    cursor: 'pointer',
+    color: 'var(--theme-foreground)',
+    font: '15px var(--sans-serif, sans-serif)',
+    lineHeight: '1'
+  });
+  const popover = document.createElement('div');
+  popover.className = 'lp2-menu';
+  Object.assign(popover.style, {
+    position: 'fixed',
+    display: 'none',
+    zIndex: 1000,
+    background: 'var(--theme-background-a, #fff)',
+    color: 'var(--theme-foreground)',
+    border: '1px solid var(--theme-foreground-fainter)',
+    borderRadius: '4px',
+    boxShadow: '0 4px 16px rgba(0,0,0,.18)',
+    padding: '8px',
+    font: '12px var(--sans-serif, sans-serif)'
+  });
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = '@user/module-name';
+  input.title = 'Enter a module name and press \u21B5 to create';
+  input.spellcheck = false;
+  Object.assign(input.style, {
+    padding: '4px 8px',
+    border: '1px solid var(--theme-foreground-fainter)',
+    borderRadius: '3px',
+    font: '12px var(--monospace, monospace)',
+    width: '210px',
+    outline: 'none',
+    boxSizing: 'border-box',
+    background: 'var(--theme-background, #fff)',
+    color: 'var(--theme-foreground)'
+  });
+  const hint = document.createElement('div');
+  hint.textContent = '\u21B5 create \xB7 esc cancel';
+  Object.assign(hint.style, {
+    marginTop: '5px',
+    color: 'var(--theme-foreground-faint)',
+    fontSize: '11px'
+  });
+  popover.append(input, hint);
+  document.body.appendChild(popover);
+  const close = () => {
+    popover.style.display = 'none';
+    button.setAttribute('aria-expanded', 'false');
+  };
+  const resetBorder = () => {
+    input.style.borderColor = 'var(--theme-foreground-fainter)';
+  };
+  const open = () => {
+    const r = button.getBoundingClientRect();
+    popover.style.left = Math.round(Math.min(r.left, window.innerWidth - 240)) + 'px';
+    popover.style.top = Math.round(r.bottom + 2) + 'px';
+    popover.style.display = 'block';
+    button.setAttribute('aria-expanded', 'true');
+    input.value = '';
+    resetBorder();
+    input.focus();
+  };
+  const create = async () => {
+    let name = input.value.trim().split('#')[0].replace(/\/+$/, '');
+    if (!name) {
+      input.style.borderColor = '#e5533d';
+      return;
+    }
+    if (!name.includes('/'))
+      name = '@user/' + name.replace(/^@+/, '');
+    const src = 'function intro(md){ return md`# ' + name.split('/').pop() + '`; }';
+    const mod = createModule(name, runtime);
+    const [fn] = await realize([src], runtime);
+    mod.variable({}).define('intro', ['md'], fn);
+    close();
+    location.hash = linkTo({ open: name }, { baseURI: location.href });
+  };
+  button.addEventListener('click', ev => {
+    ev.stopPropagation();
+    popover.style.display === 'none' ? open() : close();
+  });
+  input.addEventListener('input', resetBorder);
+  input.addEventListener('keydown', ev => {
+    if (ev.key === 'Enter') {
+      ev.preventDefault();
+      create().catch(e => {
+        input.style.borderColor = '#e5533d';
+        console.error('lp2 create module failed', e);
+      });
+    } else if (ev.key === 'Escape') {
+      ev.preventDefault();
+      close();
+    }
+  });
+  const onDocDown = ev => {
+    if (popover.style.display !== 'none' && !popover.contains(ev.target) && !button.contains(ev.target))
+      close();
+  };
+  document.addEventListener('mousedown', onDocDown);
+  invalidation.then(() => {
+    document.removeEventListener('mousedown', onDocDown);
+    popover.remove();
+    button.remove();
+  });
+  return {
+    button,
+    close
+  };
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -3880,18 +3921,17 @@ export default function define(runtime, observer) {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
 
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
   main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
-  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
-  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));
-  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
   main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
   main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
   main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
-  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));
+  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
   $def("_1pg70e1", "lp2_doc_overview", ["md"], _1pg70e1);  
   $def("_1ov8ye5", "lp2_doc_model", ["md"], _1ov8ye5);  
   $def("_1rihrff", "viewof lp2Model", ["Inputs"], _1rihrff);  
@@ -3906,12 +3946,11 @@ export default function define(runtime, observer) {
   $def("_78h40x", "lp2_anchor", ["persistentId"], _78h40x);  
   $def("_d4xe91", "lp2_installAnchor", ["lp2_anchor","ResizeObserver"], _d4xe91);  
   $def("_xwsg4w", "lp2_doc_layout", ["md"], _xwsg4w);  
-  $def("_1kgkxiz", "lp2_host", [], _1kgkxiz);  
+  $def("_1fxe40f", "lp2_host", [], _1fxe40f);  
   $def("_6f57qb", "lp2_renderNode", ["lp2_renderStack","lp2_renderSplit"], _6f57qb);  
   $def("_1r0c4er", "lp2_ops", [], _1r0c4er);  
   $def("_sx484g", "lp2_dragOut", [], _sx484g);  
-  $def("_1yan973", "lp2_add_module", ["createModule","runtime","realize","location","linkTo","invalidation"], _1yan973);
-  $def("_1l0f5al", "lp2_view", ["lp2_host","lp2Model","lp2_installAnchor","lp2_anchor","viewof lp2Model","Event","lp2_getPane","lp2_dragOut","lp2_ops","linkTo","lp2_paneRegistry","lp2_renderNode","lp2_burger","lp2_add_module"], _1l0f5al);
+  $def("_1194mfy", "lp2_view", ["lp2_host","lp2Model","lp2_installAnchor","lp2_anchor","viewof lp2Model","Event","lp2_getPane","lp2_dragOut","lp2_ops","linkTo","lp2_paneRegistry","lp2_renderNode","lp2_burger","lp2_add_module"], _1194mfy);  
   $def("_1bytrbx", "lp2_probe", ["lp2_view","lp2_paneRegistry"], _1bytrbx);  
   $def("_orvfgz", "lp2_doc_hash", ["md"], _orvfgz);  
   $def("_y2r8d1", "lp2_hash", ["Generators","location"], _y2r8d1);  
@@ -3920,14 +3959,28 @@ export default function define(runtime, observer) {
   $def("_1rf2mk0", "lp2_syncToUrl", ["lp2Model","lp2_serializeDSL","lp2_parseDSL","location","lp2_setHash"], _1rf2mk0);  
   $def("_6e8yep", "lp2_doc_mount", ["md"], _6e8yep);  
   $def("_1y1ubko", "lp2_page", ["apply_theme","lp2_host","commandPaletteStyles","commandPaletteOverlay"], _1y1ubko);  
-  $def("_1cumx25", "lp2_background_jobs", ["commandPaletteKeybinding","cc_chat","change_listener","commit_history","replay_git","auto_attach","lp2_watchModules","lp2_menu_sync","lp2_menu_defaults"], _1cumx25);
-  $def("_1rtuk9d", "lp2_append_to_body", ["lp2_view","lp2_syncFromUrl","lp2_syncToUrl","lp2_page"], _1rtuk9d);  
+  $def("_1q105of", "lp2_background_jobs", ["commandPaletteKeybinding","cc_chat","change_listener","commit_history","replay_git","auto_attach","lp2_watchModules","lp2_menu_sync","lp2_menu_defaults"], _1q105of);  
+  $def("_1yumqn", "lp2_append_to_body", ["lp2_view","lp2_syncFromUrl","lp2_syncToUrl","lp2_page"], _1yumqn);  
   $def("_z83rug", null, ["currentModules"], _z83rug);  
+  $def("_12ez53h", "lp2_renderTab", ["location"], _12ez53h);  
+  $def("_m7n4c3", "lp2_dropZone", [], _m7n4c3);  
+  $def("_1hs48bp", "lp2_splitter", [], _1hs48bp);  
+  $def("_nj1uts", "lp2_renderStack", ["lp2_renderTab","lp2_dropZone"], _nj1uts);  
+  $def("_a9rn1a", "lp2_renderSplit", ["lp2_splitter"], _a9rn1a);  
+  $def("_6vp46e", "viewof lp2_watchedModules", ["Inputs"], _6vp46e);  
+  $def("_1hxhexc", "lp2_watchedModules", ["Generators","viewof lp2_watchedModules"], _1hxhexc);  
+  $def("_16ptruj", "lp2_watchModules", ["lp2Model","currentModules","viewof lp2_watchedModules","Event"], _16ptruj);  
+  $def("_td27y7", "lp2_scrollToCell", ["lp2_anchor"], _td27y7);  
+  $def("_8vk6lr", "lp2_doc_menu", ["md"], _8vk6lr);  
+  $def("_1uvdt3f", "lp2MenuItems", ["plugins"], _1uvdt3f);  
+  $def("_qcv0dp", "lp2_registerMenuItem", ["plugins"], _qcv0dp);  
+  $def("_bt1fe2", "lp2_burger", ["invalidation"], _bt1fe2);  
+  $def("_wypj4o", "lp2_menu_sync", ["lp2_burger","Element","lp2MenuItems"], _wypj4o);  
+  $def("_1kos97o", "lp2_menu_defaults", ["lp2_registerMenuItem","disk_svg","downloadAnchor","forkAnchor","invalidation"], _1kos97o);  
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
-  main.define("persistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", _));
-  main.define("createModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("createModule", _));
-  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
+  main.define("persistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", _));  
   main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
   main.define("currentModules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", _));  
   main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
@@ -3940,28 +3993,15 @@ export default function define(runtime, observer) {
   main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
   main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));
-  main.define("disk_svg", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("disk_svg", _));
-  main.define("downloadAnchor", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("downloadAnchor", _));
-  main.define("forkAnchor", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("forkAnchor", _));
-  $def("_12ez53h", "lp2_renderTab", ["location"], _12ez53h);  
-  $def("_m7n4c3", "lp2_dropZone", [], _m7n4c3);  
-  $def("_1hs48bp", "lp2_splitter", [], _1hs48bp);  
-  $def("_nj1uts", "lp2_renderStack", ["lp2_renderTab","lp2_dropZone"], _nj1uts);  
-  $def("_a9rn1a", "lp2_renderSplit", ["lp2_splitter"], _a9rn1a);  
-  $def("_6vp46e", "viewof lp2_watchedModules", ["Inputs"], _6vp46e);  
-  $def("_1hxhexc", "lp2_watchedModules", ["Generators","viewof lp2_watchedModules"], _1hxhexc);  
-  $def("_16ptruj", "lp2_watchModules", ["lp2Model","currentModules","viewof lp2_watchedModules","Event"], _16ptruj);  
-  $def("_td27y7", "lp2_scrollToCell", ["lp2_anchor"], _td27y7);
-  $def("_1mnud0c", "lp2_doc_menu", ["md"], _1mnud0c);
-  $def("_8wq5dn", "lp2MenuItems", ["plugins"], _8wq5dn);
-  $def("_p9krt2", "lp2_registerMenuItem", ["plugins"], _p9krt2);
-  $def("_6tghw4", "lp2_burger", ["invalidation"], _6tghw4);
-  $def("_2xf9jm", "lp2_menu_sync", ["lp2_burger","lp2MenuItems"], _2xf9jm);
-  $def("_hs74kp", "lp2_menu_defaults", ["lp2_registerMenuItem","disk_svg","downloadAnchor","forkAnchor","invalidation"], _hs74kp);
+  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
+  main.define("disk_svg", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("disk_svg", _));  
+  main.define("downloadAnchor", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("downloadAnchor", _));  
+  main.define("forkAnchor", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("forkAnchor", _));  
+  main.define("createModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("createModule", _));  
+  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
+  $def("_1af1qr1", "lp2_add_module", ["createModule","runtime","realize","location","linkTo","invalidation"], _1af1qr1);
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/robocoop-5" 
   type="text/plain"
@@ -9895,80 +9935,64 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-const _13upker = function _1(md){return(
+const _tku1if = function _1(md){return(
 md`# Command Palette
 
-Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open.
+Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open, or pick **Command palette** from the lopepage-2 burger menu (registered on the shared \`"lp2-menu"\` plugin bus).
 
 \`\`\`js
 import {commandPaletteOverlay, commandPaletteStyles, commandPaletteKeybinding} from "@tomlarkworthy/command-palette"
 \`\`\`
 
-## Registering a plugin
+## Registering a command provider
 
-A plugin is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Plugins run on every keystroke; results are merged and sorted by \`score\` (descending).
+A provider is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Providers run on every keystroke; results are merged and sorted by \`score\` (descending).
+
+Providers register on the shared [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lopecode_commands"\` — no import of this notebook needed, so any notebook can extend the palette:
 
 \`\`\`js
-import {viewof commands as commandsView} from "@tomlarkworthy/command-palette"
+import {plugins} from "@tomlarkworthy/plugin-registry"
 {
-  const myPlugin = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
-  const unregister = commandsView.addCommand(myPlugin);
-  invalidation.then(unregister);
+  const provider = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
+  plugins.add("lopecode_commands", provider, {invalidation});
 }
 \`\`\`
 
-## Built-in plugins
+## Built-in providers
 
 - **Module finder** — type a module name to open it.
 - **Cell search** — type to find cells across all loaded modules.`
 )};
-const _1eng7wy = function _commands(Inputs,Event)
-{
-    const input = Inputs.input([]);
-    input.addCommand = function (plugin) {
-        input.value.push(plugin);
-        input.dispatchEvent(new Event('input'));
-        return () => {
-            const i = input.value.indexOf(plugin);
-            if (i >= 0) {
-                input.value.splice(i, 1);
-                input.dispatchEvent(new Event('input'));
-            }
-        };
-    };
-    return input;
-};
-const _7bve6u = (G, _) => G.input(_);
-const _bpk8h7 = function _searchIndex(liveCellMap,modules){return(
+const _yavx6b = function _searchIndex(liveCellMap,modules){return(
 (() => {
-    const index = [];
-    for (const [mod, cells] of liveCellMap.entries()) {
-        const moduleName = modules?.get(mod)?.name ?? '<unknown>';
-        for (const cell of cells) {
-            if (!cell.name && cell.type !== 'import')
-                continue;
-            let source = null;
-            try {
-                const v = cell.variables?.[0];
-                if (v?._definition)
-                    source = v._definition.toString();
-            } catch (e) {
-            }
-            index.push({
-                module: moduleName,
-                name: cell.name ?? null,
-                type: cell.type ?? 'simple',
-                source
-            });
-        }
+  const index = [];
+  for (const [mod, cells] of liveCellMap.entries()) {
+    const moduleName = modules?.get(mod)?.name ?? '<unknown>';
+    for (const cell of cells) {
+      if (!cell.name && cell.type !== 'import')
+        continue;
+      let source = null;
+      try {
+        const v = cell.variables?.[0];
+        if (v?._definition)
+          source = v._definition.toString();
+      } catch (e) {
+      }
+      index.push({
+        module: moduleName,
+        name: cell.name ?? null,
+        type: cell.type ?? 'simple',
+        source
+      });
     }
-    return index;
+  }
+  return index;
 })()
 )};
-const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
+const _rmjyys = function _commandPaletteStyles(theme_assets,htl)
 {
-    theme_assets;
-    return htl.html`<style>
+  theme_assets;
+  return htl.html`<style>
 .command-palette-overlay {
   position: fixed;
   inset: 0;
@@ -10090,15 +10114,15 @@ const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
 }
 </style>`;
 };
-const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
+const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
 {
-    const $commands = $0;
-    let selectedIdx = 0;
-    let results = [];
-    const overlay = document.createElement('div');
-    overlay.className = 'command-palette-overlay';
-    overlay.hidden = true;
-    overlay.innerHTML = `<div class="command-palette-box">
+  let selectedIdx = 0;
+  let results = [];
+  let providers = [];
+  const overlay = document.createElement('div');
+  overlay.className = 'command-palette-overlay';
+  overlay.hidden = true;
+  overlay.innerHTML = `<div class="command-palette-box">
       <input class="command-palette-input" placeholder="Type a command..." autocomplete="off" />
       <div class="command-palette-results"></div>
       <div class="command-palette-hint">
@@ -10107,147 +10131,156 @@ const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
         <span><kbd>Esc</kbd> close</span>
       </div>
     </div>`;
-    const input = overlay.querySelector('.command-palette-input');
-    const resultsContainer = overlay.querySelector('.command-palette-results');
-    function search(query) {
-        if (!query || query.length < 1)
-            return [];
-        const plugins = $commands.value || [];
-        let all = [];
-        for (const plugin of plugins) {
-            try {
-                const out = plugin(query);
-                if (Array.isArray(out))
-                    all = all.concat(out);
-            } catch (e) {
-                console.error('[command-palette] plugin error:', e);
-            }
-        }
-        all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-        return all.slice(0, 50);
+  const input = overlay.querySelector('.command-palette-input');
+  const resultsContainer = overlay.querySelector('.command-palette-results');
+  function search(query) {
+    if (!query || query.length < 1)
+      return [];
+    let all = [];
+    for (const provider of providers) {
+      try {
+        const out = provider(query);
+        if (Array.isArray(out))
+          all = all.concat(out);
+      } catch (e) {
+        console.error('[command-palette] provider error:', e);
+      }
     }
-    function render() {
-        resultsContainer.innerHTML = '';
-        if (results.length === 0 && input.value.length > 0) {
-            resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
-            return;
+    all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    return all.slice(0, 50);
+  }
+  function render() {
+    resultsContainer.innerHTML = '';
+    if (results.length === 0 && input.value.length > 0) {
+      resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
+      return;
+    }
+    results.forEach((r, i) => {
+      const row = document.createElement('a');
+      row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
+      row.href = r.href || '#';
+      row.style.textDecoration = 'none';
+      row.style.color = 'inherit';
+      if (r.module) {
+        const modSpan = document.createElement('span');
+        modSpan.className = 'command-palette-module';
+        modSpan.textContent = r.module;
+        row.appendChild(modSpan);
+      }
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'command-palette-label';
+      labelSpan.textContent = r.label ?? '';
+      row.appendChild(labelSpan);
+      if (r.badge) {
+        const badgeSpan = document.createElement('span');
+        badgeSpan.className = 'command-palette-badge';
+        badgeSpan.textContent = r.badge;
+        row.appendChild(badgeSpan);
+      }
+      if (r.hint) {
+        const hintSpan = document.createElement('span');
+        hintSpan.className = 'command-palette-hint-right';
+        hintSpan.textContent = r.hint;
+        row.appendChild(hintSpan);
+      }
+      row.addEventListener('click', e => {
+        e.preventDefault();
+        close();
+        window.location.href = row.href;
+      });
+      resultsContainer.appendChild(row);
+      if (r.snippet) {
+        const snippet = document.createElement('div');
+        snippet.className = 'command-palette-snippet';
+        if (i === selectedIdx)
+          snippet.style.background = '#eef4ff';
+        if (typeof r.snippet === 'string') {
+          snippet.textContent = r.snippet;
+        } else if (r.snippet instanceof Node) {
+          snippet.appendChild(r.snippet);
         }
-        results.forEach((r, i) => {
-            const row = document.createElement('a');
-            row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
-            row.href = r.href || '#';
-            row.style.textDecoration = 'none';
-            row.style.color = 'inherit';
-            if (r.module) {
-                const modSpan = document.createElement('span');
-                modSpan.className = 'command-palette-module';
-                modSpan.textContent = r.module;
-                row.appendChild(modSpan);
-            }
-            const labelSpan = document.createElement('span');
-            labelSpan.className = 'command-palette-label';
-            labelSpan.textContent = r.label ?? '';
-            row.appendChild(labelSpan);
-            if (r.badge) {
-                const badgeSpan = document.createElement('span');
-                badgeSpan.className = 'command-palette-badge';
-                badgeSpan.textContent = r.badge;
-                row.appendChild(badgeSpan);
-            }
-            if (r.hint) {
-                const hintSpan = document.createElement('span');
-                hintSpan.className = 'command-palette-hint-right';
-                hintSpan.textContent = r.hint;
-                row.appendChild(hintSpan);
-            }
-            row.addEventListener('click', e => {
-                e.preventDefault();
-                close();
-                window.location.href = row.href;
-            });
-            resultsContainer.appendChild(row);
-            if (r.snippet) {
-                const snippet = document.createElement('div');
-                snippet.className = 'command-palette-snippet';
-                if (i === selectedIdx)
-                    snippet.style.background = '#eef4ff';
-                if (typeof r.snippet === 'string') {
-                    snippet.textContent = r.snippet;
-                } else if (r.snippet instanceof Node) {
-                    snippet.appendChild(r.snippet);
-                }
-                snippet.addEventListener('click', e => {
-                    e.preventDefault();
-                    close();
-                    window.location.href = row.href;
-                });
-                resultsContainer.appendChild(snippet);
-            }
+        snippet.addEventListener('click', e => {
+          e.preventDefault();
+          close();
+          window.location.href = row.href;
         });
-    }
-    function open() {
-        overlay.hidden = false;
-        input.value = '';
-        results = [];
-        selectedIdx = 0;
-        render();
-        requestAnimationFrame(() => input.focus());
-    }
-    function close() {
-        overlay.hidden = true;
-        input.blur();
-    }
-    function navigateToSelected() {
-        if (results[selectedIdx]) {
-            const r = results[selectedIdx];
-            close();
-            window.location.href = r.href || '#';
-        }
-    }
-    input.addEventListener('input', () => {
-        results = search(input.value);
-        selectedIdx = 0;
-        render();
+        resultsContainer.appendChild(snippet);
+      }
     });
-    input.addEventListener('keydown', e => {
-        if (e.key === 'ArrowDown') {
-            e.preventDefault();
-            selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'ArrowUp') {
-            e.preventDefault();
-            selectedIdx = Math.max(selectedIdx - 1, 0);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'Enter') {
-            e.preventDefault();
-            navigateToSelected();
-        } else if (e.key === 'Escape') {
-            e.preventDefault();
-            close();
-        }
-    });
-    overlay.addEventListener('click', e => {
-        if (e.target === overlay)
-            close();
-    });
-    invalidation.then(() => overlay.remove());
-    overlay._openPalette = open;
-    overlay._closePalette = close;
-    overlay._isOpen = () => !overlay.hidden;
-    return overlay;
+  }
+  function open() {
+    overlay.hidden = false;
+    input.value = '';
+    results = [];
+    selectedIdx = 0;
+    render();
+    requestAnimationFrame(() => input.focus());
+  }
+  function close() {
+    overlay.hidden = true;
+    input.blur();
+  }
+  function navigateToSelected() {
+    if (results[selectedIdx]) {
+      const r = results[selectedIdx];
+      close();
+      window.location.href = r.href || '#';
+    }
+  }
+  input.addEventListener('input', () => {
+    results = search(input.value);
+    selectedIdx = 0;
+    render();
+  });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIdx = Math.max(selectedIdx - 1, 0);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      navigateToSelected();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay)
+      close();
+  });
+  invalidation.then(() => overlay.remove());
+  overlay._openPalette = open;
+  overlay._closePalette = close;
+  overlay._isOpen = () => !overlay.hidden;
+  // Stable setter fed by command_provider_sync; re-searches live if the palette is open.
+  overlay._setProviders = arr => {
+    providers = arr || [];
+    if (!overlay.hidden) {
+      results = search(input.value);
+      selectedIdx = 0;
+      render();
+    }
+  };
+  return overlay;
 };
-const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,commandPaletteOverlay,invalidation)
+const _1vuj6tn = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,command_provider_sync,commandPaletteOverlay,invalidation)
 {
   cellSearchPlugin;
   moduleFinderPlugin;
-  const handler = (e) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+  command_provider_sync;
+  const handler = e => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
       e.stopPropagation();
       if (commandPaletteOverlay._isOpen()) {
@@ -10257,24 +10290,23 @@ const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinder
       }
     }
   };
-  document.addEventListener("keydown", handler, true);
-  invalidation.then(() =>
-    document.removeEventListener("keydown", handler, true)
-  );
+  document.addEventListener('keydown', handler, true);
+  invalidation.then(() => document.removeEventListener('keydown', handler, true));
   return null;
 };
-const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
+const _104tbig = function _cellSearchPlugin(searchIndex,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
     for (const entry of searchIndex) {
       let score = 0;
       let nameMatch = false;
       let sourceMatch = false;
-      const name = String(entry.name ?? "").toLowerCase();
-      const mod = String(entry.module ?? "").toLowerCase();
+      const name = String(entry.name ?? '').toLowerCase();
+      const mod = String(entry.module ?? '').toLowerCase();
       if (name.length && name.startsWith(q)) {
         score += 150;
         nameMatch = true;
@@ -10289,50 +10321,42 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
         score += 10;
         sourceMatch = true;
       }
-      if (score === 0) continue;
-      const nameStr = String(entry.name ?? "");
-      const modStr = String(entry.module ?? "");
-      const href = linkTo(nameStr ? modStr + "#" + nameStr : modStr);
+      if (score === 0)
+        continue;
+      const nameStr = String(entry.name ?? '');
+      const modStr = String(entry.module ?? '');
+      const href = linkTo(nameStr ? modStr + '#' + nameStr : modStr);
       let snippet = null;
       if (entry.source) {
         const src = String(entry.source);
         const idx = src.toLowerCase().indexOf(q);
         const frag = document.createDocumentFragment();
         if (idx >= 0) {
-          const start = Math.max(
-            0,
-            src.lastIndexOf("\n", Math.max(0, idx - 40)) + 1
-          );
-          const endNL = src.indexOf("\n", idx + query.length + 40);
-          const lineEnd =
-            endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
+          const start = Math.max(0, src.lastIndexOf('\n', Math.max(0, idx - 40)) + 1);
+          const endNL = src.indexOf('\n', idx + query.length + 40);
+          const lineEnd = endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
           const before = src.slice(start, idx);
           const match = src.slice(idx, idx + query.length);
           const after = src.slice(idx + query.length, lineEnd);
           if (start > 0)
-            frag.appendChild(document.createTextNode("\u2026" + before));
-          else frag.appendChild(document.createTextNode(before));
-          const mark = document.createElement("mark");
+            frag.appendChild(document.createTextNode('\u2026' + before));
+          else
+            frag.appendChild(document.createTextNode(before));
+          const mark = document.createElement('mark');
           mark.textContent = match;
           frag.appendChild(mark);
-          frag.appendChild(
-            document.createTextNode(
-              after + (lineEnd < src.length ? "\u2026" : "")
-            )
-          );
+          frag.appendChild(document.createTextNode(after + (lineEnd < src.length ? '\u2026' : '')));
         } else {
-          const firstLine = src.slice(0, src.indexOf("\n", 0));
-          frag.appendChild(
-            document.createTextNode((firstLine || src).slice(0, 120))
-          );
+          const firstLine = src.slice(0, src.indexOf('\n', 0));
+          frag.appendChild(document.createTextNode((firstLine || src).slice(0, 120)));
         }
         snippet = frag;
       }
       out.push({
-        label: nameStr || "(anonymous)",
+        label: nameStr || '(anonymous)',
         module: modStr,
-        badge: entry.type && entry.type !== "simple" ? entry.type : null,
-        hint: sourceMatch && !nameMatch ? "source" : null,
+        badge: entry.type && entry.type !== 'simple' ? entry.type : null,
+        hint: sourceMatch && !nameMatch ? 'source' : null,
         snippet,
         href,
         score
@@ -10340,37 +10364,69 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "cell-search plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'cell-search plugin registered';
 };
-const _lq3msy = function _moduleFinderPlugin(modules,linkTo,$0,invalidation)
+const _1opf5e1 = function _moduleFinderPlugin(currentModules,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  // Use the REACTIVE module set (module-map currentModules), not cell-map's one-shot `modules` snapshot,
+  // so modules created live (e.g. by robocoop-4) are immediately findable. This cell recomputes whenever
+  // currentModules changes; the old plugin is unregistered via invalidation before the new one registers.
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
-    for (const [, info] of modules.entries()) {
-      const name = info?.name ?? "";
-      if (!name) continue;
+    for (const [, info] of currentModules.entries()) {
+      const name = info?.name ?? '';
+      if (!name)
+        continue;
       const lower = name.toLowerCase();
       let score = 0;
-      if (lower === q) score = 1000;
-      else if (lower.startsWith(q)) score = 800;
-      else if (lower.includes(q)) score = 600;
-      if (score === 0) continue;
+      if (lower === q)
+        score = 1000;
+      else if (lower.startsWith(q))
+        score = 800;
+      else if (lower.includes(q))
+        score = 600;
+      if (score === 0)
+        continue;
       out.push({
         label: name,
         href: linkTo(name),
-        hint: "open module",
+        hint: 'open module',
         score
       });
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "module-finder plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'module-finder plugin registered';
+};
+const _1seh1ei = function _cp_menu_register(plugins,commandPaletteOverlay,invalidation)
+{
+  // Surface the palette in the lopepage-2 burger menu so it's discoverable without knowing the
+  // Cmd/Ctrl+K shortcut. Registers straight onto the shared plugin-registry "lp2-menu" set — no
+  // import of lopepage-2; a notebook opts in by adding both modules to its bootconf mains.
+  const isMac = /Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent || '');
+  plugins.add('lp2-menu', {
+    id: 'command-palette',
+    order: 3,
+    label: 'Command palette  ' + (isMac ? '\u2318K' : 'Ctrl+K'),
+    svg: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3"><circle cx="7" cy="7" r="4.2"/><path d="M10.2 10.2 14 14"/></svg>',
+    action: () => commandPaletteOverlay._openPalette()
+  }, { invalidation });
+  return 'registered: command-palette menu item';
+};
+const _7c6wp9 = function _commandProviders(plugins){return(
+plugins.get('lopecode_commands')
+)};
+const _13y9cxb = function _command_provider_sync(commandPaletteOverlay,commandProviders)
+{
+  // Push the current provider set (from the "lopecode_commands" bus) into the stable overlay,
+  // so the overlay is built once yet always searches the live set. Recomputes on every add/remove.
+  commandPaletteOverlay._setProviders(commandProviders);
+  return `command providers: ${ commandProviders.length }`;
 };
 
 export default function define(runtime, observer) {
@@ -10382,20 +10438,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
-  $def("_13upker", null, ["md"], _13upker);  
-  $def("_1eng7wy", "viewof commands", ["Inputs","Event"], _1eng7wy);  
-  $def("_7bve6u", "commands", ["Generators","viewof commands"], _7bve6u);  
-  $def("_bpk8h7", "searchIndex", ["liveCellMap","modules"], _bpk8h7);  
-  $def("_1ptnr90", "commandPaletteStyles", ["theme_assets","htl"], _1ptnr90);  
-  $def("_fomuvm", "commandPaletteOverlay", ["viewof commands","Node","invalidation"], _fomuvm);  
-  $def("_mqy6k9", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","commandPaletteOverlay","invalidation"], _mqy6k9);  
-  $def("_k261kj", "cellSearchPlugin", ["searchIndex","linkTo","viewof commands","invalidation"], _k261kj);  
-  $def("_lq3msy", "moduleFinderPlugin", ["modules","linkTo","viewof commands","invalidation"], _lq3msy);  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
+  $def("_tku1if", null, ["md"], _tku1if);  
+  $def("_yavx6b", "searchIndex", ["liveCellMap","modules"], _yavx6b);  
+  $def("_rmjyys", "commandPaletteStyles", ["theme_assets","htl"], _rmjyys);  
+  $def("_1q8grv4", "commandPaletteOverlay", ["Node","invalidation"], _1q8grv4);  
+  $def("_1vuj6tn", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","command_provider_sync","commandPaletteOverlay","invalidation"], _1vuj6tn);  
+  $def("_104tbig", "cellSearchPlugin", ["searchIndex","linkTo","plugins","invalidation"], _104tbig);  
+  $def("_1opf5e1", "moduleFinderPlugin", ["currentModules","linkTo","plugins","invalidation"], _1opf5e1);  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
   main.define("modules", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("modules", _));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));
+  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
+  $def("_1seh1ei", "cp_menu_register", ["plugins","commandPaletteOverlay","invalidation"], _1seh1ei);  
+  $def("_7c6wp9", "commandProviders", ["plugins"], _7c6wp9);  
+  $def("_13y9cxb", "command_provider_sync", ["commandPaletteOverlay","commandProviders"], _13y9cxb);
   return main;
 }</script>
 <script id="@tomlarkworthy/dataflow-templating/dataflow_templating%401.svg" 
@@ -11040,10 +11101,11 @@ lookupVariable(
   editorModule
 )
 )};
-const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate){return(
-(variable, {
+const _hqns12 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,createCell,findCell,pinOnCreate,getOption,Event,setOption)
+{
+  return (variable, {
     pinned = undefined
-} = {}) => {
+  } = {}) => {
     const host = document.createElement('div');
     let shellDispose = null;
     let heavyDispose = null;
@@ -11051,132 +11113,132 @@ const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate
     let shellEl = null;
     let body = null;
     const clearBody = () => {
-        if (body)
-            body.replaceChildren();
+      if (body)
+        body.replaceChildren();
     };
     const closeHeavy = () => {
-        if (heavyDispose) {
-            heavyDispose();
-            heavyDispose = null;
-        }
-        clearBody();
+      if (heavyDispose) {
+        heavyDispose();
+        heavyDispose = null;
+      }
+      clearBody();
     };
     const openHeavy = () => {
-        if (heavyDispose)
-            return;
-        if (!body)
-            return;
-        heavyDispose = cloneDataflow(editorTemplate, name => {
-            if (name === 'editor_panel') {
-                return {
-                    fulfilled: element => {
-                        if (!element)
-                            return;
-                        if (!body)
-                            return;
-                        if (body.firstChild !== element || body.childNodes.length !== 1) {
-                            body.replaceChildren(element);
-                        }
-                    }
-                };
+      if (heavyDispose)
+        return;
+      if (!body)
+        return;
+      heavyDispose = cloneDataflow(editorTemplate, name => {
+        if (name === 'editor_panel') {
+          return {
+            fulfilled: element => {
+              if (!element)
+                return;
+              if (!body)
+                return;
+              if (body.firstChild !== element || body.childNodes.length !== 1) {
+                body.replaceChildren(element);
+              }
             }
-            if (name === 'selectVariable') {
-                return {
-                    fulfilled: selectVariable => {
-                        if (typeof selectVariable !== 'function')
-                            return;
-                        selectVariable(variable);
-                    }
-                };
-            }
-            return {};
-        });
-    };
-    const syncOpen = () => {
-        const open = !!(editView && editView.value);
-        if (open)
-            openHeavy();
-        else
-            closeHeavy();
-        if (shellEl) {
-            const bodyEl = shellEl.querySelector('.cell-editor-body');
-            if (bodyEl)
-                bodyEl.style.display = open ? 'block' : 'none';
-        }
-    };
-    shellDispose = cloneDataflow(shellTemplate, name => {
-        if (name === 'hotbar_shell') {
-            return {
-                fulfilled: element => {
-                    if (!element)
-                        return;
-                    shellEl = element;
-                    host.replaceChildren(element);
-                    body = element.querySelector('.cell-editor-body');
-                    // Lightweight "add cell below" on the always-present shell,
-                    // so a cell can be inserted without opening the heavy editor.
-                    const hotbar = element.querySelector('.hotbar');
-                    if (hotbar && !hotbar.querySelector('.add-cell-btn')) {
-                        const add = document.createElement('span');
-                        add.className = 'add-cell-btn';
-                        add.textContent = '➕';
-                        add.title = 'Add cell below';
-                        add.style.cssText = 'cursor: pointer; margin-right: 6px;';
-                        add.tabIndex = -1;
-                        add.addEventListener('mousedown', e => e.preventDefault());
-                        add.addEventListener('click', e => {
-                            e.stopPropagation();
-                            createCell({ cell: findCell(variable) });
-                        });
-                        hotbar.prepend(add);
-                    }
-                    if (body)
-                        syncOpen();
-                }
-            };
+          };
         }
         if (name === 'selectVariable') {
-            return {
-                fulfilled: selectVariable => {
-                    if (typeof selectVariable !== 'function')
-                        return;
-                    selectVariable(variable);
-                }
-            };
-        }
-        if (name === 'viewof edit') {
-            return {
-                fulfilled: view => {
-                    if (!view)
-                        return;
-                    editView = view;
-                    const forceOpen = !!(variable?.pid && pinOnCreate.has(variable.pid));
-                    if (forceOpen)
-                        pinOnCreate.delete(variable.pid);
-                    const resolved_pinned = forceOpen || !!getOption(variable, 'pinned', pinned);
-                    view.value = resolved_pinned;
-                    view.dispatchEvent(new Event('input'));
-                    syncOpen();
-                    view.addEventListener('input', () => {
-                        const next = !!view.value;
-                        setOption(variable, 'pinned', next);
-                        syncOpen();
-                    });
-                }
-            };
+          return {
+            fulfilled: selectVariable => {
+              if (typeof selectVariable !== 'function')
+                return;
+              selectVariable(variable);
+            }
+          };
         }
         return {};
+      });
+    };
+    const syncOpen = () => {
+      const open = !!(editView && editView.value);
+      if (open)
+        openHeavy();
+      else
+        closeHeavy();
+      if (shellEl) {
+        const bodyEl = shellEl.querySelector('.cell-editor-body');
+        if (bodyEl)
+          bodyEl.style.display = open ? 'block' : 'none';
+      }
+    };
+    shellDispose = cloneDataflow(shellTemplate, name => {
+      if (name === 'hotbar_shell') {
+        return {
+          fulfilled: element => {
+            if (!element)
+              return;
+            shellEl = element;
+            host.replaceChildren(element);
+            body = element.querySelector('.cell-editor-body');
+            // Lightweight "add cell below" on the always-present shell,
+            // so a cell can be inserted without opening the heavy editor.
+            const hotbar = element.querySelector('.hotbar');
+            if (hotbar && !hotbar.querySelector('.add-cell-btn')) {
+              const add = document.createElement('span');
+              add.className = 'add-cell-btn';
+              add.textContent = '\u2795';
+              add.title = 'Add cell below';
+              add.style.cssText = 'cursor: pointer; margin-right: 6px;';
+              add.tabIndex = -1;
+              add.addEventListener('mousedown', e => e.preventDefault());
+              add.addEventListener('click', e => {
+                e.stopPropagation();
+                createCell({ cell: findCell(variable) });
+              });
+              hotbar.prepend(add);
+            }
+            if (body)
+              syncOpen();
+          }
+        };
+      }
+      if (name === 'selectVariable') {
+        return {
+          fulfilled: selectVariable => {
+            if (typeof selectVariable !== 'function')
+              return;
+            selectVariable(variable);
+          }
+        };
+      }
+      if (name === 'viewof edit') {
+        return {
+          fulfilled: view => {
+            if (!view)
+              return;
+            editView = view;
+            const forceOpen = !!(variable?.pid && pinOnCreate.has(variable.pid));
+            if (forceOpen)
+              pinOnCreate.delete(variable.pid);
+            const resolved_pinned = forceOpen || !!getOption(variable, 'pinned', pinned);
+            view.value = resolved_pinned;
+            view.dispatchEvent(new Event('input'));
+            syncOpen();
+            view.addEventListener('input', () => {
+              const next = !!view.value;
+              setOption(variable, 'pinned', next);
+              syncOpen();
+            });
+          }
+        };
+      }
+      return {};
     });
     host.dispose = () => {
-        closeHeavy();
-        if (shellDispose) {
-            shellDispose();
-            shellDispose = null;
-        }
+      closeHeavy();
+      if (shellDispose) {
+        shellDispose();
+        shellDispose = null;
+      }
     };
     return host;
-}
-)};
+  };
+};
 const _x5ixji = function _hotbar_shell($0,Event,htl,edit)
 {
   const toggle = () => {
@@ -11622,9 +11684,6 @@ async (cell, amount) =>
     }
   })
 )};
-const _pinoncr = function _pinOnCreate(){return(
-new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
-)};
 const _19znal9 = function _createCell($0){return(
 async ({cell, source = "{}" } = {}) =>
   $0.send({
@@ -11686,69 +11745,71 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate)
+const _1efmn99 = async function _command_processor(command,$0,compile_and_update,pinOnCreate,selectVariable,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,$2)
 {
-    if (command.processed)
-        return;
-    let result = undefined;
-    if (command.command == 'createCell') {
-        $0.value = true;
-        // Mark the new variable's pid (identity-stable, no cell-map lookup) so its
-        // cellEditor opens pinned as soon as auto_attach mounts the shell. Keyed by
-        // pid because findCell() lags one reactive tick behind creation here.
-        const newVars = [];
-        result = await compile_and_update('{}', newVars, command.args.cell);
-        const nv = newVars[0];
-        if (nv?.pid) pinOnCreate.add(nv.pid);
-        if (nv) await selectVariable(nv);
-    } else if (command.command == 'deleteCell') {
-        remove_variables(command.args.cell.variables);
-        result = true;
-    } else if (command.command == 'moveCell') {
-        const cellList = $1.value.get(command.args.cell.module.module);
-        const cellIndex = findCellIndex(command.args.cell.variables, cellList);
-        const targetCellIndex = cellIndex + command.args.amount;
-        const targetCell = lookupCellByIndex(targetCellIndex, cellList);
-        if (targetCell) {
-            const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
-            const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
-            const change = targetFirstVariableIndex - currentFirstVariableIndex;
-            const dom = command.args.cell.dom;
-            const preY = dom?.getBoundingClientRect?.().top;
-            command.args.cell.variables.forEach(v => {
-                const currentIndex = findVariableIndex(v);
-                repositionSetElement(runtime._variables, v, currentIndex + change);
-            });
-            await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
-            // Keep moved cell at same screen position so neighbours shift around it.
-            // Cells here have wildly varying heights (some embed 500+ px iframes), so
-            // a one-position move can otherwise jump hundreds of pixels (#163). Poll
-            // for syncers' reactive DOM reorder before measuring postY — the chain
-            // runs on macrotasks, so requestAnimationFrame is not sufficient.
-            if (preY != null && dom?.isConnected) {
-                let postY = preY;
-                for (let i = 0; i < 30 && postY === preY; i++) {
-                    await new Promise(r => setTimeout(r, 50));
-                    if (!dom.isConnected)
-                        break;
-                    postY = dom.getBoundingClientRect().top;
-                }
-                const delta = postY - preY;
-                if (delta !== 0) {
-                    const scroller = dom.closest('.lm_content') || document.scrollingElement;
-                    scroller?.scrollBy?.({
-                        top: delta,
-                        behavior: 'instant'
-                    });
-                }
-            }
+  if (command.processed)
+    return;
+  let result = undefined;
+  if (command.command == 'createCell') {
+    $0.value = true;
+    // Mark the new variable's pid (identity-stable, no cell-map lookup) so its
+    // cellEditor opens pinned as soon as auto_attach mounts the shell. Keyed by
+    // pid because findCell() lags one reactive tick behind creation here.
+    const newVars = [];
+    result = await compile_and_update('{}', newVars, command.args.cell);
+    const nv = newVars[0];
+    if (nv?.pid)
+      pinOnCreate.add(nv.pid);
+    if (nv)
+      await selectVariable(nv);
+  } else if (command.command == 'deleteCell') {
+    remove_variables(command.args.cell.variables);
+    result = true;
+  } else if (command.command == 'moveCell') {
+    const cellList = $1.value.get(command.args.cell.module.module);
+    const cellIndex = findCellIndex(command.args.cell.variables, cellList);
+    const targetCellIndex = cellIndex + command.args.amount;
+    const targetCell = lookupCellByIndex(targetCellIndex, cellList);
+    if (targetCell) {
+      const currentFirstVariableIndex = findVariableIndex(command.args.cell.variables[0]);
+      const targetFirstVariableIndex = findVariableIndex(targetCell.variables[0]);
+      const change = targetFirstVariableIndex - currentFirstVariableIndex;
+      const dom = command.args.cell.dom;
+      const preY = dom?.getBoundingClientRect?.().top;
+      command.args.cell.variables.forEach(v => {
+        const currentIndex = findVariableIndex(v);
+        repositionSetElement(runtime._variables, v, currentIndex + change);
+      });
+      await selectVariable(command.args.cell.variables[0], command.args.cell.dom);
+      // Keep moved cell at same screen position so neighbours shift around it.
+      // Cells here have wildly varying heights (some embed 500+ px iframes), so
+      // a one-position move can otherwise jump hundreds of pixels (#163). Poll
+      // for syncers' reactive DOM reorder before measuring postY — the chain
+      // runs on macrotasks, so requestAnimationFrame is not sufficient.
+      if (preY != null && dom?.isConnected) {
+        let postY = preY;
+        for (let i = 0; i < 30 && postY === preY; i++) {
+          await new Promise(r => setTimeout(r, 50));
+          if (!dom.isConnected)
+            break;
+          postY = dom.getBoundingClientRect().top;
         }
-        result = true;
+        const delta = postY - preY;
+        if (delta !== 0) {
+          const scroller = dom.closest('.lm_content') || document.scrollingElement;
+          scroller?.scrollBy?.({
+            top: delta,
+            behavior: 'instant'
+          });
+        }
+      }
     }
-    if (result) {
-        command.processed = true;
-        $2.resolve(result);
-    }
+    result = true;
+  }
+  if (result) {
+    command.processed = true;
+    $2.resolve(result);
+  }
 };
 const _8iz5z2 = function _59(md){return(
 md`### UI Action`
@@ -12730,6 +12791,11 @@ const _bz6mai = function _test_completion_identifier_deferred(completionFixture)
     throw new Error('bare identifier (no dot) must defer');
   return 'identifier / no-dot bases deferred to the identifier-chain path';
 };
+const _y8yyf = function _pinOnCreate()
+{
+  return new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
+;
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -12745,6 +12811,7 @@ export default function define(runtime, observer) {
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
   main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
   main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
@@ -12773,7 +12840,7 @@ export default function define(runtime, observer) {
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
-  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate"], _1q95xt6);
+  $def("_hqns12", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","createCell","findCell","pinOnCreate","getOption","Event","setOption"], _hqns12);  
   $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
   $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
   $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
@@ -12818,8 +12885,7 @@ export default function define(runtime, observer) {
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
   $def("_1imarq2", null, ["md"], _1imarq2);  
   $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
-  $def("_pinoncr", "pinOnCreate", [], _pinoncr);
-  $def("_19znal9", "createCell", ["viewof command"], _19znal9);
+  $def("_19znal9", "createCell", ["viewof command"], _19znal9);  
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_1toku21", null, ["md"], _1toku21);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
@@ -12829,7 +12895,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate"], _2pkmxz);  
+  $def("_1efmn99", "command_processor", ["command","viewof edit","compile_and_update","pinOnCreate","selectVariable","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","viewof command"], _1efmn99);  
   $def("_8iz5z2", null, ["md"], _8iz5z2);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -12859,8 +12925,9 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
+  $def("_z9vacx", null, ["md"], _z9vacx);  
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));  
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
   $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
@@ -12918,9 +12985,7 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
-  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
-  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  
@@ -12930,7 +12995,8 @@ export default function define(runtime, observer) {
   $def("_quyccp", "test_completion_bool_template_regexp", ["completionFixture"], _quyccp);  
   $def("_1cn3ucr", "test_completion_parenthesised_unwrap", ["completionFixture"], _1cn3ucr);  
   $def("_15vxhca", "test_completion_never_evaluates", ["completionFixture"], _15vxhca);  
-  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);
+  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);  
+  $def("_y8yyf", "pinOnCreate", [], _y8yyf);
   return main;
 }</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
@@ -17069,6 +17135,146 @@ export default function define(runtime, observer) {
   $def("_b5ui8y", "isnode", ["Element","Text"], _b5ui8y);
   return main;
 }</script>
+
+<script id="@tomlarkworthy/invoke-variable" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _zkje0r = function _1(md){return(
+md`# \`invokeVariable(<name>, <module>, overrides = {})\`
+
+Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
+)};
+const _swiym2 = function _invokeVariable(lookupVariable)
+{
+  return async function invokeVariable(name, module, overrides = {}) {
+    if (overrides == null || typeof overrides !== 'object')
+      throw new TypeError('invokeVariable(name, module, {overrides}): overrides must be an object');
+    // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
+    // the caller already holds it); otherwise resolve by (name, module).
+    let variable;
+    if (name && typeof name === 'object' && typeof name._definition !== 'undefined') {
+      variable = name;
+      module = module ?? variable._module;
+    } else {
+      if (typeof name !== 'string' || !name.length)
+        throw new TypeError('invokeVariable(name, module, \u2026): name must be a non-empty string');
+      if (!module)
+        throw new TypeError('invokeVariable(name, module, \u2026): module is required');
+      variable = await lookupVariable(name, module);
+      if (!variable)
+        throw new Error(`invokeVariable: variable "${ name }" not found in module`);
+    }
+    module = module ?? variable._module;
+    const label = variable._name ?? (typeof name === 'string' ? name : '(anonymous)');
+    const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
+    const inputNames = inputs.map(v => v?._name);
+    for (const k of Object.keys(overrides)) {
+      if (!inputNames.includes(k)) {
+        throw new Error(`invokeVariable("${ label }"): override "${ k }" was provided but is not a declared dependency. Declared dependencies: ${ inputNames.filter(Boolean).join(', ') }`);
+      }
+    }
+    const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+    const resolveDependency = async depName => {
+      if (hasOwn(overrides, depName))
+        return overrides[depName];
+      const scopeVar = module?._scope?.get?.(depName) ?? module?._runtime?._builtin?._scope?.get?.(depName);
+      if (scopeVar) {
+        if (scopeVar._value !== undefined)
+          return scopeVar._value;
+        if (scopeVar._promise && typeof scopeVar._promise?.then === 'function')
+          return await scopeVar._promise;
+      }
+      if (typeof module?.value === 'function') {
+        try {
+          return await module.value(depName);
+        } catch (e) {
+        }
+      }
+      if (module?._runtime && typeof module._runtime._global === 'function') {
+        try {
+          const g = module._runtime._global(depName);
+          if (g !== undefined)
+            return g;
+        } catch (e) {
+        }
+      }
+      throw new Error(`invokeVariable("${ label }"): could not resolve dependency "${ depName }" (no override and not found in module/builtins/global)`);
+    };
+    const args = [];
+    for (const dep of inputs) {
+      const depName = dep?._name;
+      if (!depName) {
+        args.push(undefined);
+        continue;
+      }
+      args.push(await resolveDependency(depName));
+    }
+    const def = variable._definition;
+    if (typeof def !== 'function') {
+      throw new Error(`invokeVariable("${ label }"): target variable does not have an invokable function definition`);
+    }
+    return def(...args);
+  };
+};
+const _jtrr9m = function _3(md){return(
+md`### Example
+
+let c = a + b`
+)};
+const _1v2c0s1 = function _a(){return(
+1
+)};
+const _ywl8oh = function _b(){return(
+3
+)};
+const _1mc3tpl = function _c(a,b){return(
+a + b
+)};
+const _o5e50u = function _7(md){return(
+md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
+)};
+const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule)
+)};
+const _smh5by = function _9(md){return(
+md`But we can set b to 20, and then we get the answer 21.`
+)};
+const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule, { b: 20 })
+)};
+const _qh0yhm = function _11(md){return(
+md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
+)};
+const _1hy0qcz = function _invokeVariableModule(thisModule){return(
+thisModule()
+)};
+const _jno7wc = (G, _) => G.input(_);
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_zkje0r", null, ["md"], _zkje0r);  
+  $def("_swiym2", "invokeVariable", ["lookupVariable"], _swiym2);  
+  $def("_jtrr9m", null, ["md"], _jtrr9m);  
+  $def("_1v2c0s1", "a", [], _1v2c0s1);  
+  $def("_ywl8oh", "b", [], _ywl8oh);  
+  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
+  $def("_o5e50u", null, ["md"], _o5e50u);  
+  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
+  $def("_smh5by", null, ["md"], _smh5by);  
+  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
+  $def("_qh0yhm", null, ["md"], _qh0yhm);  
+  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
+  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
+  return main;
+}</script>
 <script id="@tomlarkworthy/isomorphic-git-1-30-1/isomorphic-git-1%401.30.1.bundle.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -20066,35 +20272,33 @@ module -> {
 }
 \`\`\``
 )};
-const _1798myt = function _moduleMap(runtime,keepalive,myModule,$0){return(
-async (
-  _runtime = runtime,
-  {
-    cache = new Map() // module -> {name}
-  } = {}
-) => {
-  if (!_runtime || !_runtime._variables)
-    throw "Invalid runtime passed to moduleMap";
-  keepalive(myModule, "submit_summary");
-  keepalive(myModule, "sync_modules");
-  keepalive(myModule, "currentModules");
-  return await $0.send({
-    runtime: _runtime,
-    cache: cache
-  });
-}
-)};
+const _1hn3uql = function _moduleMap(runtime,keepalive,myModule,$0)
+{
+  return async (_runtime = runtime, {
+    cache = new Map()  // module -> {name}
+  } = {}) => {
+    if (!_runtime || !_runtime._variables)
+      throw 'Invalid runtime passed to moduleMap';
+    keepalive(myModule, 'submit_summary');
+    keepalive(myModule, 'sync_modules');
+    keepalive(myModule, 'currentModules');
+    return await $0.send({
+      runtime: _runtime,
+      cache: cache
+    });
+  };
+};
 const _1yso65r = function _5(md){return(
 md`### \`currentModules\``
 )};
-const _1fcoh6x = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
+const _1e3kr85 = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
 {
   runtime_variables;
   const latest = await moduleMap();
   let dirty = !this || !_.isEqual(new Set(latest.keys()), new Set(this.keys()));
   if (dirty) {
     $0.value = latest;
-    $0.dispatchEvent(new Event("input"));
+    $0.dispatchEvent(new Event('input'));
   }
   return $0.value;
 };
@@ -20102,261 +20306,260 @@ const _wi39n0 = async function _currentModules(Inputs,moduleMap){return(
 Inputs.input(await moduleMap())
 )};
 const _1gxgyd6 = (G, _) => G.input(_);
-const _1qag34d = function _8(Inputs,currentModules){return(
+const _1kxoygl = function _8(Inputs,currentModules){return(
 Inputs.table([...currentModules.values()], {
   format: {
-    dom: (d) => d.innerHTML,
+    dom: d => d.innerHTML,
     specifiers: JSON.stringify,
-    variable: (v) => v._name
+    variable: v => v._name
   }
 })
 )};
 const _1xamz8j = function _9(md){return(
 md`### Visualization`
 )};
-const _1n4p4hn = function _tipTitle(){return(
-([k, c]) => 
-`${k}\ndependsOn: [\n  ${(c[3].dependsOn || []).join(
-  "\n  "
-)}\n]\ndependedBy: [\n  ${(c[3].dependedBy || []).join("\n  ")}\n]`
+const _1sglrv3 = function _tipTitle(){return(
+([k, c]) => `${ k }\ndependsOn: [\n  ${ (c[3].dependsOn || []).join('\n  ') }\n]\ndependedBy: [\n  ${ (c[3].dependedBy || []).join('\n  ') }\n]`
 )};
-const _1kdcb71 = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom)
-{
-  return ({ useSpectral = true } = {}) => {
-    const modules = [...currentModules.values()].filter((m) => m && m.name);
-    const n = modules.length;
-    if (n === 0) return htl.svg`<svg width="1" height="1"></svg>`;
-
-    const indexOf = new Map(modules.map((m, i) => [m.name, i]));
-
-    const undirectedEdges = [];
-    const seen = new Set();
+const _5zbe1k = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom){return(
+({
+  useSpectral = true
+} = {}) => {
+  const modules = [...currentModules.values()].filter(m => m && m.name);
+  const n = modules.length;
+  if (n === 0)
+    return htl.svg`<svg width="1" height="1"></svg>`;
+  const indexOf = new Map(modules.map((m, i) => [
+    m.name,
+    i
+  ]));
+  const undirectedEdges = [];
+  const seen = new Set();
+  for (let i = 0; i < n; i++) {
+    const from = modules[i];
+    for (const toName of from.dependsOn || []) {
+      const j = indexOf.get(toName);
+      if (j == null || j === i)
+        continue;
+      const a = Math.min(i, j), b = Math.max(i, j);
+      const k = `${ a },${ b }`;
+      if (seen.has(k))
+        continue;
+      seen.add(k);
+      undirectedEdges.push([
+        a,
+        b
+      ]);
+    }
+  }
+  const buildCSRLocal = (n, edges) => {
+    const adj = Array.from({ length: n }, () => []);
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      if (a < 0 || b < 0 || a >= n || b >= n)
+        continue;
+      adj[a].push(b);
+      adj[b].push(a);
+    }
+    const deg = new Float64Array(n);
+    let nnz = 0;
     for (let i = 0; i < n; i++) {
-      const from = modules[i];
-      for (const toName of from.dependsOn || []) {
-        const j = indexOf.get(toName);
-        if (j == null || j === i) continue;
-        const a = Math.min(i, j),
-          b = Math.max(i, j);
-        const k = `${a},${b}`;
-        if (seen.has(k)) continue;
-        seen.add(k);
-        undirectedEdges.push([a, b]);
+      const row = adj[i];
+      row.sort((x, y) => x - y);
+      let w = 0;
+      for (let j = 0; j < row.length; j++)
+        if (w === 0 || row[j] !== row[w - 1])
+          row[w++] = row[j];
+      row.length = w;
+      deg[i] = w;
+      nnz += w;
+    }
+    const rowPtr = new Int32Array(n + 1);
+    const colIdx = new Int32Array(nnz);
+    const val = new Float64Array(nnz);
+    let p = 0;
+    for (let i = 0; i < n; i++) {
+      rowPtr[i] = p;
+      const row = adj[i];
+      for (let j = 0; j < row.length; j++) {
+        colIdx[p] = row[j];
+        val[p] = 1;
+        p++;
       }
     }
-
-    const buildCSRLocal = (n, edges) => {
-      const adj = Array.from({ length: n }, () => []);
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        if (a < 0 || b < 0 || a >= n || b >= n) continue;
-        adj[a].push(b);
-        adj[b].push(a);
-      }
-      const deg = new Float64Array(n);
-      let nnz = 0;
-      for (let i = 0; i < n; i++) {
-        const row = adj[i];
-        row.sort((x, y) => x - y);
-        let w = 0;
-        for (let j = 0; j < row.length; j++)
-          if (w === 0 || row[j] !== row[w - 1]) row[w++] = row[j];
-        row.length = w;
-        deg[i] = w;
-        nnz += w;
-      }
-      const rowPtr = new Int32Array(n + 1);
-      const colIdx = new Int32Array(nnz);
-      const val = new Float64Array(nnz);
-      let p = 0;
-      for (let i = 0; i < n; i++) {
-        rowPtr[i] = p;
-        const row = adj[i];
-        for (let j = 0; j < row.length; j++) {
-          colIdx[p] = row[j];
-          val[p] = 1;
-          p++;
-        }
-      }
-      rowPtr[n] = p;
-      return { n, rowPtr, colIdx, val, deg };
+    rowPtr[n] = p;
+    return {
+      n,
+      rowPtr,
+      colIdx,
+      val,
+      deg
     };
-
-    const crossingsCountLocal = (n, edges, order) => {
-      const pos = new Int32Array(n);
-      for (let i = 0; i < n; i++) pos[order[i]] = i;
-
-      const intervals = [];
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        const i = pos[a],
-          j = pos[b];
-        const s = Math.min(i, j),
-          t = Math.max(i, j);
-        if (s === t) continue;
-        intervals.push([s, t]);
-      }
-
-      intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
-      const bit = new Int32Array(n + 1);
-      const add = (i) => {
-        for (let x = i + 1; x <= n; x += x & -x) bit[x]++;
-      };
-      const sum = (i) => {
-        let s = 0;
-        for (let x = i + 1; x > 0; x -= x & -x) s += bit[x];
-        return s;
-      };
-      const range = (l, r) => (r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0));
-
-      let crossings = 0;
-      let k = 0;
-      while (k < intervals.length) {
-        const s = intervals[k][0];
-        let k2 = k;
-        while (k2 < intervals.length && intervals[k2][0] === s) k2++;
-        for (let t = k; t < k2; t++)
-          crossings += range(s + 1, intervals[t][1] - 1);
-        for (let t = k; t < k2; t++) add(intervals[t][1]);
-        k = k2;
-      }
-      return crossings;
+  };
+  const crossingsCountLocal = (n, edges, order) => {
+    const pos = new Int32Array(n);
+    for (let i = 0; i < n; i++)
+      pos[order[i]] = i;
+    const intervals = [];
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      const i = pos[a], j = pos[b];
+      const s = Math.min(i, j), t = Math.max(i, j);
+      if (s === t)
+        continue;
+      intervals.push([
+        s,
+        t
+      ]);
+    }
+    intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
+    const bit = new Int32Array(n + 1);
+    const add = i => {
+      for (let x = i + 1; x <= n; x += x & -x)
+        bit[x]++;
     };
-
-    let orderIdx;
-    if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
-      orderIdx = Int32Array.from(d3.range(n));
-    } else {
-      const csr = buildCSRLocal(n, undirectedEdges);
-
-      const spectral = spectralCircleOrder(csr, {
-        alpha: 0.92,
-        maxIters: 80,
-        tol: 1e-4,
-        seed: 1,
-        passesOrtho: 1
-      });
-
-      const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
-        passes: 1,
-        vertexSequence: "order"
-      });
-
-      const baseline = bestOfRandomOrders(n, undirectedEdges, {
-        R: Math.min(n, 12),
-        seed: 1,
-        postSiftPasses: 0
-      });
-
-      const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
-      orderIdx =
-        baseline?.order && baseline.crossings < cSift
-          ? baseline.order
-          : sifted.order;
+    const sum = i => {
+      let s = 0;
+      for (let x = i + 1; x > 0; x -= x & -x)
+        s += bit[x];
+      return s;
+    };
+    const range = (l, r) => r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0);
+    let crossings = 0;
+    let k = 0;
+    while (k < intervals.length) {
+      const s = intervals[k][0];
+      let k2 = k;
+      while (k2 < intervals.length && intervals[k2][0] === s)
+        k2++;
+      for (let t = k; t < k2; t++)
+        crossings += range(s + 1, intervals[t][1] - 1);
+      for (let t = k; t < k2; t++)
+        add(intervals[t][1]);
+      k = k2;
     }
-
-    const R = 100;
-    const nodes = new Map();
-    for (let p = 0; p < n; p++) {
-      const vid = orderIdx[p] | 0;
-      const a = (p * 2 * Math.PI) / n;
-      const [x, y] = d3.pointRadial(a, R);
-      const deg = (p * 360) / n;
-      nodes.set(modules[vid].name, [x, y, deg, modules[vid]]);
-    }
-
-    const edges = modules.flatMap((from) =>
-      (from.dependsOn || [])
-        .filter((to) => nodes.has(to))
-        .map((to) => [
-          [from.name, nodes.get(from.name)],
-          [to, nodes.get(to)]
-        ])
-    );
-
-    const plot = Plot.plot({
-      inset: 180,
-      aspectRatio: 1,
-      axis: null,
-      marks: [
-        () => htl.svg`<defs>
+    return crossings;
+  };
+  let orderIdx;
+  if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
+    orderIdx = Int32Array.from(d3.range(n));
+  } else {
+    const csr = buildCSRLocal(n, undirectedEdges);
+    const spectral = spectralCircleOrder(csr, {
+      alpha: 0.92,
+      maxIters: 80,
+      tol: 0.0001,
+      seed: 1,
+      passesOrtho: 1
+    });
+    const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
+      passes: 1,
+      vertexSequence: 'order'
+    });
+    const baseline = bestOfRandomOrders(n, undirectedEdges, {
+      R: Math.min(n, 12),
+      seed: 1,
+      postSiftPasses: 0
+    });
+    const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
+    orderIdx = baseline?.order && baseline.crossings < cSift ? baseline.order : sifted.order;
+  }
+  const R = 100;
+  const nodes = new Map();
+  for (let p = 0; p < n; p++) {
+    const vid = orderIdx[p] | 0;
+    const a = p * 2 * Math.PI / n;
+    const [x, y] = d3.pointRadial(a, R);
+    const deg = p * 360 / n;
+    nodes.set(modules[vid].name, [
+      x,
+      y,
+      deg,
+      modules[vid]
+    ]);
+  }
+  const edges = modules.flatMap(from => (from.dependsOn || []).filter(to => nodes.has(to)).map(to => [
+    [
+      from.name,
+      nodes.get(from.name)
+    ],
+    [
+      to,
+      nodes.get(to)
+    ]
+  ]));
+  const plot = Plot.plot({
+    inset: 180,
+    aspectRatio: 1,
+    axis: null,
+    marks: [
+      () => htl.svg`<defs>
           <linearGradient id="gradient">
             <stop offset="15%" stop-color="red" />
             <stop offset="100%" stop-color="gold" />
           </linearGradient>
         </defs>`,
-        Plot.arrow(edges, {
-          x1: ([[, [x1]]]) => x1,
-          y1: ([[, [, y1]]]) => y1,
-          x2: ([, [, [x2]]]) => x2,
-          y2: ([, [, [, y2]]]) => y2,
-          bend: true,
-          stroke: "url(#gradient)",
-          strokeOpacity: 0.5,
-          strokeLinejoin: "miter",
-          headLength: 3,
-          inset: 5
-        }),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] > 180),
-          {
-            textAnchor: "end",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] <= 180),
-          {
-            fontSize: 12,
-            textAnchor: "start",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.tip(
-          nodes.entries(),
-          Plot.pointer({
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            title: tipTitle,
-            maxRadius: Infinity
-          })
-        )
-      ]
-    });
-
-    const xmlns = "http://www.w3.org/2000/svg";
-    const xlink = "http://www.w3.org/1999/xlink";
-    for (const text of plot.querySelectorAll("text")) {
-      const moduleName = text.textContent;
-      let url;
-      try {
-        url = linkTo(moduleName);
-      } catch {
-        continue;
-      }
-      const a = document.createElementNS(xmlns, "a");
-      a.setAttributeNS(null, "href", url);
-      a.setAttributeNS(xlink, "href", url);
-      text.parentNode.insertBefore(a, text);
-      if (isOnObservableCom()) {
-        a.setAttribute("target", "_blank");
-      }
-      a.appendChild(text);
+      Plot.arrow(edges, {
+        x1: ([[, [x1]]]) => x1,
+        y1: ([[, [, y1]]]) => y1,
+        x2: ([, [, [x2]]]) => x2,
+        y2: ([, [, [, y2]]]) => y2,
+        bend: true,
+        stroke: 'url(#gradient)',
+        strokeOpacity: 0.5,
+        strokeLinejoin: 'miter',
+        headLength: 3,
+        inset: 5
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] > 180), {
+        textAnchor: 'end',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] <= 180), {
+        fontSize: 12,
+        textAnchor: 'start',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.tip(nodes.entries(), Plot.pointer({
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        title: tipTitle,
+        maxRadius: Infinity
+      }))
+    ]
+  });
+  const xmlns = 'http://www.w3.org/2000/svg';
+  const xlink = 'http://www.w3.org/1999/xlink';
+  for (const text of plot.querySelectorAll('text')) {
+    const moduleName = text.textContent;
+    let url;
+    try {
+      url = linkTo(moduleName);
+    } catch {
+      continue;
     }
-
-    return plot;
-  };
-};
+    const a = document.createElementNS(xmlns, 'a');
+    a.setAttributeNS(null, 'href', url);
+    a.setAttributeNS(xlink, 'href', url);
+    text.parentNode.insertBefore(a, text);
+    if (isOnObservableCom()) {
+      a.setAttribute('target', '_blank');
+    }
+    a.appendChild(text);
+  }
+  return plot;
+}
+)};
 const _hgwvol = function _12(md){return(
 md`### Random helpers`
 )};
@@ -20367,88 +20570,85 @@ const _1cir47e = (G, _) => G.input(_);
 const _1nfaybn = function _tag(){return(
 Symbol()
 )};
-const _17qqkoj = function _forcePeek()
+const _1lkbrun = function _forcePeek()
 {
   //console.log("force peek");
-  return (variable, { forever = false } = {}) => {
-    if (variable._value) return variable._value;
+  return (variable, {
+    forever = false
+  } = {}) => {
+    if (variable._value)
+      return variable._value;
     let peeker;
     const promise = new Promise((fulfilled, rejected) => {
-      peeker = variable._module
-        .variable({
-          fulfilled,
-          rejected
-        })
-        .define([variable._name], (m) => m);
+      peeker = variable._module.variable({
+        fulfilled,
+        rejected
+      }).define([variable._name], m => m);
     });
-    if (!forever) promise.finally((v) => peeker.delete());
-    return Promise.race([promise, new Promise((_, r) => setTimeout(r, 1000))]);
+    if (!forever)
+      promise.finally(v => peeker.delete());
+    return Promise.race([
+      promise,
+      new Promise((_, r) => setTimeout(r, 1000))
+    ]);
   };
 };
-const _v9hg2i = function _observe(){return(
+const _1qva85d = function _observe(){return(
 (module, variable_name, observer) => {
-  const variable = module
-    .variable(observer)
-    .define(`dynamic observe ${variable_name}`, [variable_name], (m) => m);
+  const variable = module.variable(observer).define(`dynamic observe ${ variable_name }`, [variable_name], m => m);
   return () => variable.delete();
 }
 )};
 const _1bm642i = function _17(md){return(
 md`### Implementation`
 )};
-const _oothhq = function _queue(flowQueue){return(
-flowQueue({ timeout_ms: 15000, dedupe: true })
+const _1f31b1g = function _queue(flowQueue){return(
+flowQueue({
+  timeout_ms: 15000,
+  dedupe: true
+})
 )};
 const _648shl = (G, _) => G.input(_);
 const _1acbzli = function _19(md){return(
 md`We resolve what we can using variables named with prefix \`module\` that hold module values. We \`forcePeek\` the variables to make them resolve, which forces loading of the modules.`
 )};
-const _10dhunq = async function _module_definition_variables(notebookImports,queue)
+const _1g0cuj1 = async function _module_definition_variables(notebookImports,queue)
 {
-  console.log("module_definition_variables");
+  console.log('module_definition_variables');
   notebookImports;
   queue;
   let last_module_count = -1;
   let module_definition_variables = [];
   while (last_module_count < module_definition_variables.length) {
     last_module_count = module_definition_variables.length;
-    module_definition_variables = (
-      await Promise.all(
-        [...queue.runtime._variables]
-          .filter((v) => v._name && v._name.startsWith("module "))
-          .filter((v) => !v._name.startsWith("module <unknown"))
-          .map(async (v) => {
-            try {
-              v._value = await Promise.race([
-                v._definition(),
-                new Promise((_, reject) =>
-                  setTimeout(() => reject(new Error("timeout")), 1000)
-                )
-              ]);
-              return [v];
-            } catch (err) {
-              console.error("error loading module", v._name, err);
-              return [];
-            }
-          })
-      )
-    ).flat();
+    module_definition_variables = (await Promise.all([...queue.runtime._variables].filter(v => v._name && v._name.startsWith('module ')).filter(v => !v._name.startsWith('module <unknown')).map(async v => {
+      try {
+        v._value = await Promise.race([
+          v._definition(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1000))
+        ]);
+        return [v];
+      } catch (err) {
+        console.error('error loading module', v._name, err);
+        return [];
+      }
+    }))).flat();
   }
   return module_definition_variables;
 };
-const _dcxoxy = function _modules(module_definition_variables,queue)
+const _17frsyf = function _modules(module_definition_variables,queue)
 {
-  console.log("modules");
+  console.log('modules');
   module_definition_variables;
-  return [...new Set([...queue.runtime._variables].map((v) => v._module))];
+  return [...new Set([...queue.runtime._variables].map(v => v._module))];
 };
 const _1dqpbvy = function _builtin(queue){return(
 queue.runtime._builtin
 )};
-const _ir3ob0 = function _main_modules(queue,modules,builtin)
+const _13mmmk9 = function _main_modules(queue,modules,builtin)
 {
   const imports = new Set(queue.runtime._modules.values());
-  return modules.filter((m) => !imports.has(m) && m !== builtin);
+  return modules.filter(m => !imports.has(m) && m !== builtin);
 };
 const _yflsv5 = function _bootloaded_mains(queue){return(
 queue.runtime.mains || new Map()
@@ -20456,16 +20656,16 @@ queue.runtime.mains || new Map()
 const _ox2g3b = function _bootloader(queue){return(
 queue.runtime.bootloader
 )};
-const _1turw8j = function _resolve_modules(modules,module_definition_variables,findModuleName)
+const _10ufqkh = function _resolve_modules(modules,module_definition_variables,findModuleName)
 {
-  console.log("resolve_modules");
+  console.log('resolve_modules');
   const module_definitions = new Map();
   const unresolved = [];
-  modules.forEach((m) => {
-    const md = module_definition_variables.find((md) => md._value == m);
+  modules.forEach(m => {
+    const md = module_definition_variables.find(md => md._value == m);
     if (md) {
       module_definitions.set(m, {
-        type: "module variable",
+        type: 'module variable',
         name: findModuleName(md._module._scope, m),
         variable: md
       });
@@ -20473,239 +20673,218 @@ const _1turw8j = function _resolve_modules(modules,module_definition_variables,f
       unresolved.push(m);
     }
   });
-  return { module_definitions, unresolved };
+  return {
+    module_definitions,
+    unresolved
+  };
 };
 const _9fbvam = function _27(md){return(
 md`modules imported via notebook imports do not have module variables, so they are trickier to figure out. We can sniff the page DOM to find the import expressions, and try to map them to the modules we could to resolve earlier`
 )};
-const _1h0lryb = function _notebookImports(main,parser)
+const _1t4ga3d = function _notebookImports(main,parser)
 {
-  console.log("notebookImports");
+  console.log('notebookImports');
   main;
-  return new Map(
-    [...document.querySelectorAll(".observablehq--import")]
-      .map((dom) => [dom, parser.parseCell(dom.textContent)])
-      .map(([dom, node]) => [
-        dom.parentElement,
-        node.body.specifiers.map((s) => ({
-          name: node.body.source.value,
-          dom: dom.parentElement,
-          ast: s,
-          local: s.local.name,
-          imported: s.imported.name
-        }))
-      ])
-  );
+  return new Map([...document.querySelectorAll('.observablehq--import')].map(dom => [
+    dom,
+    parser.parseCell(dom.textContent)
+  ]).map(([dom, node]) => [
+    dom.parentElement,
+    node.body.specifiers.map(s => ({
+      name: node.body.source.value,
+      dom: dom.parentElement,
+      ast: s,
+      local: s.local.name,
+      imported: s.imported.name
+    }))
+  ]));
 };
-const _7t198q = function _notebookImportVariables(runtime,notebookImports)
+const _994hn4 = function _notebookImportVariables(runtime,notebookImports)
 {
-  console.log("notebookImportVariables");
+  console.log('notebookImportVariables');
   return [
-    ...[...runtime._variables] // Observable DOM nodes are referenced in runtime variables
-      .filter(
-        (v) =>
-          v._observer &&
-          v._observer._node &&
-          notebookImports.get(v._observer._node)
-      )
-      .map((v) => ({
-        variable: v,
-        notebookImports: notebookImports.get(v._observer._node)
-      })),
-    ...[
-      ...[...notebookImports.entries()] // visualizer DOM nodes have the variable attached
-        .filter(([pi, vars]) => pi.variable)
-        .map(([pi, vars]) => ({
-          variable: pi.variable,
-          notebookImports: vars
-        }))
-    ]
-  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length); // sort by complexity
+    ...[...runtime._variables]  // Observable DOM nodes are referenced in runtime variables
+.filter(v => v._observer && v._observer._node && notebookImports.get(v._observer._node)).map(v => ({
+      variable: v,
+      notebookImports: notebookImports.get(v._observer._node)
+    })),
+    ...[...[...notebookImports.entries()]  // visualizer DOM nodes have the variable attached
+.filter(([pi, vars]) => pi.variable).map(([pi, vars]) => ({
+        variable: pi.variable,
+        notebookImports: vars
+      }))]
+  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length);  // sort by complexity
 };
-const _1lyens8 = function _pageImportMatch(){return(
-async (notebookImportVariables, modules) => {
-  console.log("pageImportMatch");
-  const backupHas = Map.prototype.has; // Save the original `has` method on Map.prototype
-
-  let currentImport = undefined;
-  const matches = new Map();
-  // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
-  Map.prototype.has = function (...args) {
-    const module = modules.find((m) => m._scope == this);
-    if (currentImport && module) {
-      matches.set(module, {
-        name: currentImport.notebookImports[0].name,
-        type: "notebook import",
-        module: module,
-        dependsOn: [],
-        dependedBy: [],
-        dom: currentImport.notebookImports[0].dom,
-        specifiers: currentImport.notebookImports.map((pi) => ({
-          local: pi.local,
-          imported: pi.imported,
-          variable: pi.variable
-        }))
-      });
-    }
-    return backupHas.call(this, ...args); // Call the original `has` method
-  };
-
-  // Iterate through the notebook imports and define them while capturing `has` calls
-
-  await notebookImportVariables.reduce((chain, pageImportVariable) => {
-    // Call the definition chain
-    return chain.then(async () => {
-      currentImport = pageImportVariable;
-      try {
-        await pageImportVariable.variable._definition();
-      } catch (err) {
-        console.warn(err);
-      }
-      currentImport = undefined;
-    });
-  }, Promise.resolve());
-
-  // Restore the original `has` method after the operations are done
-  Map.prototype.has = backupHas;
-
-  return matches;
-}
-)};
-const _1akt4kz = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+const _xanizk = function _pageImportMatch()
 {
-  console.log("notebookImportMatches");
+  return async (notebookImportVariables, modules) => {
+    console.log('pageImportMatch');
+    const backupHas = Map.prototype.has;
+    // Save the original `has` method on Map.prototype
+    let currentImport = undefined;
+    const matches = new Map();
+    // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
+    Map.prototype.has = function (...args) {
+      const module = modules.find(m => m._scope == this);
+      if (currentImport && module) {
+        matches.set(module, {
+          name: currentImport.notebookImports[0].name,
+          type: 'notebook import',
+          module: module,
+          dependsOn: [],
+          dependedBy: [],
+          dom: currentImport.notebookImports[0].dom,
+          specifiers: currentImport.notebookImports.map(pi => ({
+            local: pi.local,
+            imported: pi.imported,
+            variable: pi.variable
+          }))
+        });
+      }
+      return backupHas.call(this, ...args);  // Call the original `has` method
+    };
+    // Iterate through the notebook imports and define them while capturing `has` calls
+    await notebookImportVariables.reduce((chain, pageImportVariable) => {
+      // Call the definition chain
+      return chain.then(async () => {
+        currentImport = pageImportVariable;
+        try {
+          await pageImportVariable.variable._definition();
+        } catch (err) {
+          console.warn(err);
+        }
+        currentImport = undefined;
+      });
+    }, Promise.resolve());
+    // Restore the original `has` method after the operations are done
+    Map.prototype.has = backupHas;
+    return matches;
+  };
+};
+const _1q5pc6n = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+{
+  console.log('notebookImportMatches');
   return pageImportMatch(notebookImportVariables, modules);
 };
-const _1ang0sg = function _moduleTitle(observeVariable){return(
-async function moduleTitle(module) {
-  const runtime = module._runtime;
-  const vars = [...runtime._variables].filter(
-    (v) => v && v._module === module && v._definition
-  );
-  const candidates = vars.filter((v) => {
-    const n = v._name;
-    if (v._type != 1) return false;
-    if (n == null) return true;
-    if (typeof n !== "string") return true;
-    if (n.startsWith("dynamic observe ")) return false;
-    if (n.startsWith("module ")) return false;
-    return true;
-  });
-
-  if (candidates.length === 0) return null;
-
-  const first = candidates.find(
-    (v) => typeof v._id === "number" && Number.isFinite(v._id)
-  )
-    ? candidates.reduce((a, b) =>
-        (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b
-      )
-    : candidates[0];
-
-  const extract = (v) => {
-    // instanceof cannot be used hear for cross realm
-    if (v == null) return null;
-    if (typeof v === "string") return v.trim() || null;
-    if (v.tagName) {
-      if (v.tagName == "H1") return v.textContent;
-      const h1 = v.querySelector?.("h1");
-      if (h1) return (h1.textContent ?? "").trim() || null;
+const _12o3fj5 = function _moduleTitle(observeVariable)
+{
+  return async function moduleTitle(module) {
+    const runtime = module._runtime;
+    const vars = [...runtime._variables].filter(v => v && v._module === module && v._definition);
+    const candidates = vars.filter(v => {
+      const n = v._name;
+      if (v._type != 1)
+        return false;
+      if (n == null)
+        return true;
+      if (typeof n !== 'string')
+        return true;
+      if (n.startsWith('dynamic observe '))
+        return false;
+      if (n.startsWith('module '))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0)
       return null;
-    }
-    if (v.textContent) return (v.textContent ?? "").trim() || null;
-    const maybeNode = v?.nodeType ? v : null;
-    if (maybeNode?.tagName) return extract(maybeNode);
-    return null;
-  };
-
-  // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
-  // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
-  // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
-  // base_css <style>) out of the live page, breaking the frame. Instead:
-  //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
-  //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
-  //     existing variable reachable and replays its value, adding no intermediate variable (no
-  //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
-  //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
-  if (first._value !== undefined) return extract(first._value);
-  const peekValue = (v) =>
-    new Promise((resolve, reject) => {
+    const first = candidates.find(v => typeof v._id === 'number' && Number.isFinite(v._id)) ? candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b) : candidates[0];
+    const extract = v => {
+      // instanceof cannot be used hear for cross realm
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      const maybeNode = v?.nodeType ? v : null;
+      if (maybeNode?.tagName)
+        return extract(maybeNode);
+      return null;
+    };
+    // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
+    // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
+    // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
+    // base_css <style>) out of the live page, breaking the frame. Instead:
+    //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
+    //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
+    //     existing variable reachable and replays its value, adding no intermediate variable (no
+    //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
+    //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
+    if (first._value !== undefined)
+      return extract(first._value);
+    const peekValue = v => new Promise((resolve, reject) => {
       let settled = false;
       let fireInvalidation;
-      const invalidation = new Promise((r) => (fireInvalidation = r));
+      const invalidation = new Promise(r => fireInvalidation = r);
       const finish = (fn, arg) => {
-        if (settled) return;
+        if (settled)
+          return;
         settled = true;
         fireInvalidation();
         fn(arg);
       };
-      observeVariable(
-        v,
-        {
-          fulfilled: (value) => finish(resolve, value),
-          rejected: (err) => finish(reject, err),
-          pending: () => {}
-        },
-        { invalidation }
-      );
+      observeVariable(v, {
+        fulfilled: value => finish(resolve, value),
+        rejected: err => finish(reject, err),
+        pending: () => {
+        }
+      }, { invalidation });
     });
-  try {
-    return extract(await peekValue(first));
-  } catch (err) {
-    return "Err";
-  }
-}
-)};
-const _197sgjt = async function _titles(modules,moduleTitle)
+    try {
+      return extract(await peekValue(first));
+    } catch (err) {
+      return 'Err';
+    }
+  };
+};
+const _ze3jk0 = async function _titles(modules,moduleTitle)
 {
-  const map = new Map(
-    await Promise.all(
-      [...modules].map(async (m) => [
-        m,
-        await Promise.race([
-          moduleTitle(m),
-          new Promise((resolve) =>
-            setTimeout(() => resolve("<TIMEOUT LOADING TITLE>"), 250)
-          )
-        ]).catch((e) => `err: ${e}`)
-      ])
-    )
-  );
+  const map = new Map(await Promise.all([...modules].map(async m => [
+    m,
+    await Promise.race([
+      moduleTitle(m),
+      new Promise(resolve => setTimeout(() => resolve('<TIMEOUT LOADING TITLE>'), 250))
+    ]).catch(e => `err: ${ e }`)
+  ])));
   return map;
 };
-const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
+const _pnpoh8 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
 {
-  console.log("generate summary");
+  console.log('generate summary');
   const modules = new Map([
-    ...main_modules.map((main_module) => [
+    ...main_modules.map(main_module => [
       main_module,
       {
-        name: "main",
+        name: 'main',
         module: main_module,
         title: titles.get(main_module),
         dependsOn: [],
         dependedBy: []
       }
     ]),
-    ...(bootloader
-      ? [
-          [
-            bootloader,
-            {
-              name: "bootloader",
-              title: "Bootloader",
-              module: bootloader,
-              dependsOn: [],
-              dependedBy: []
-            }
-          ]
-        ]
-      : []),
+    ...bootloader ? [[
+        bootloader,
+        {
+          name: 'bootloader',
+          title: 'Bootloader',
+          module: bootloader,
+          dependsOn: [],
+          dependedBy: []
+        }
+      ]] : [],
     [
       builtin,
       {
-        name: "builtin",
-        title: "Standard library",
+        name: 'builtin',
+        title: 'Standard library',
         module: builtin,
         dependsOn: [],
         dependedBy: []
@@ -20737,30 +20916,21 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   ]);
   // add cross links
   // notebookImportVariables[0].variable._module == main
-  [...notebookImportMatches.keys()].forEach((m) => {
+  [...notebookImportMatches.keys()].forEach(m => {
     const hostModule = modules.get(main_modules[0]);
     const importedModule = modules.get(m);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
     importedModule.dependedBy.push(main_modules[0].name);
   });
-
-  module_definition_variables.forEach((v) => {
+  module_definition_variables.forEach(v => {
     const hostModule = modules.get(v._module);
     const importedModule = modules.get(v._value);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
@@ -20768,11 +20938,11 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   });
   return modules;
 };
-const _1pou2g6 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
+const _hhecn4 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
 {
   resolve_modules;
   queue;
-  console.log("submit_summary");
+  console.log('submit_summary');
   notebookImports;
   $0.resolve(summary);
 };
@@ -20786,47 +20956,47 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
-  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));
-  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));  
+  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));  
   $def("_1w9yf3l", null, ["md"], _1w9yf3l);  
   $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
   $def("_1sznqfl", null, ["md"], _1sznqfl);  
-  $def("_1798myt", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1798myt);  
+  $def("_1hn3uql", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1hn3uql);  
   $def("_1yso65r", null, ["md"], _1yso65r);  
-  $def("_1fcoh6x", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1fcoh6x);  
+  $def("_1e3kr85", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1e3kr85);  
   $def("_wi39n0", "viewof currentModules", ["Inputs","moduleMap"], _wi39n0);  
   $def("_1gxgyd6", "currentModules", ["Generators","viewof currentModules"], _1gxgyd6);  
-  $def("_1qag34d", null, ["Inputs","currentModules"], _1qag34d);  
+  $def("_1kxoygl", null, ["Inputs","currentModules"], _1kxoygl);  
   $def("_1xamz8j", null, ["md"], _1xamz8j);  
-  $def("_1n4p4hn", "tipTitle", [], _1n4p4hn);  
-  $def("_1kdcb71", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _1kdcb71);  
+  $def("_1sglrv3", "tipTitle", [], _1sglrv3);  
+  $def("_5zbe1k", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _5zbe1k);  
   $def("_hgwvol", null, ["md"], _hgwvol);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
   $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_1nfaybn", "tag", [], _1nfaybn);  
-  $def("_17qqkoj", "forcePeek", [], _17qqkoj);  
-  $def("_v9hg2i", "observe", [], _v9hg2i);  
+  $def("_1lkbrun", "forcePeek", [], _1lkbrun);  
+  $def("_1qva85d", "observe", [], _1qva85d);  
   $def("_1bm642i", null, ["md"], _1bm642i);  
-  $def("_oothhq", "viewof queue", ["flowQueue"], _oothhq);  
+  $def("_1f31b1g", "viewof queue", ["flowQueue"], _1f31b1g);  
   $def("_648shl", "queue", ["Generators","viewof queue"], _648shl);  
   $def("_1acbzli", null, ["md"], _1acbzli);  
-  $def("_10dhunq", "module_definition_variables", ["notebookImports","queue"], _10dhunq);  
-  $def("_dcxoxy", "modules", ["module_definition_variables","queue"], _dcxoxy);  
+  $def("_1g0cuj1", "module_definition_variables", ["notebookImports","queue"], _1g0cuj1);  
+  $def("_17frsyf", "modules", ["module_definition_variables","queue"], _17frsyf);  
   $def("_1dqpbvy", "builtin", ["queue"], _1dqpbvy);  
-  $def("_ir3ob0", "main_modules", ["queue","modules","builtin"], _ir3ob0);  
+  $def("_13mmmk9", "main_modules", ["queue","modules","builtin"], _13mmmk9);  
   $def("_yflsv5", "bootloaded_mains", ["queue"], _yflsv5);  
   $def("_ox2g3b", "bootloader", ["queue"], _ox2g3b);  
-  $def("_1turw8j", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _1turw8j);  
+  $def("_10ufqkh", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _10ufqkh);  
   $def("_9fbvam", null, ["md"], _9fbvam);  
-  $def("_1h0lryb", "notebookImports", ["main","parser"], _1h0lryb);  
-  $def("_7t198q", "notebookImportVariables", ["runtime","notebookImports"], _7t198q);  
-  $def("_1lyens8", "pageImportMatch", [], _1lyens8);  
-  $def("_1akt4kz", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1akt4kz);  
-  $def("_1ang0sg", "moduleTitle", ["observeVariable"], _1ang0sg);
-  $def("_197sgjt", "titles", ["modules","moduleTitle"], _197sgjt);  
-  $def("_11z3pt0", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _11z3pt0);  
-  $def("_1pou2g6", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _1pou2g6);  
+  $def("_1t4ga3d", "notebookImports", ["main","parser"], _1t4ga3d);  
+  $def("_994hn4", "notebookImportVariables", ["runtime","notebookImports"], _994hn4);  
+  $def("_xanizk", "pageImportMatch", [], _xanizk);  
+  $def("_1q5pc6n", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1q5pc6n);  
+  $def("_12o3fj5", "moduleTitle", ["observeVariable"], _12o3fj5);  
+  $def("_ze3jk0", "titles", ["modules","moduleTitle"], _ze3jk0);  
+  $def("_pnpoh8", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _pnpoh8);  
+  $def("_hhecn4", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _hhecn4);  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
@@ -20840,8 +21010,8 @@ export default function define(runtime, observer) {
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
   main.define("viewof runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
-  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));
-  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));  
   main.define("spectralCircleOrder", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("spectralCircleOrder", _));  
   main.define("improveOrderSifting", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("improveOrderSifting", _));  
   main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));
@@ -32242,167 +32412,6 @@ export default function define(runtime, observer) {
   $def("_1fuihc", null, [], _1fuihc);
   return main;
 }</script>
-
-<script id="@tomlarkworthy/invoke-variable" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _zkje0r = function _1(md){return(
-md`# \`invokeVariable(<name>, <module>, overrides = {})\`
-
-Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
-)};
-const _kfe4ll = function _invokeVariable(lookupVariable){return(
-async function invokeVariable(name, module, overrides = {}) {
-  if (overrides == null || typeof overrides !== "object")
-    throw new TypeError(
-      "invokeVariable(name, module, {overrides}): overrides must be an object"
-    );
-
-  // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
-  // the caller already holds it); otherwise resolve by (name, module).
-  let variable;
-  if (name && typeof name === "object" && typeof name._definition !== "undefined") {
-    variable = name;
-    module = module ?? variable._module;
-  } else {
-    if (typeof name !== "string" || !name.length)
-      throw new TypeError(
-        "invokeVariable(name, module, …): name must be a non-empty string"
-      );
-    if (!module)
-      throw new TypeError("invokeVariable(name, module, …): module is required");
-    variable = await lookupVariable(name, module);
-    if (!variable)
-      throw new Error(`invokeVariable: variable "${name}" not found in module`);
-  }
-  module = module ?? variable._module;
-  const label = variable._name ?? (typeof name === "string" ? name : "(anonymous)");
-
-  const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
-  const inputNames = inputs.map((v) => v?._name);
-
-  for (const k of Object.keys(overrides)) {
-    if (!inputNames.includes(k)) {
-      throw new Error(
-        `invokeVariable("${label}"): override "${k}" was provided but is not a declared dependency. Declared dependencies: ${inputNames
-          .filter(Boolean)
-          .join(", ")}`
-      );
-    }
-  }
-
-  const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
-
-  const resolveDependency = async (depName) => {
-    if (hasOwn(overrides, depName)) return overrides[depName];
-
-    const scopeVar =
-      module?._scope?.get?.(depName) ??
-      module?._runtime?._builtin?._scope?.get?.(depName);
-
-    if (scopeVar) {
-      if (scopeVar._value !== undefined) return scopeVar._value;
-      if (scopeVar._promise && typeof scopeVar._promise?.then === "function")
-        return await scopeVar._promise;
-    }
-
-    if (typeof module?.value === "function") {
-      try {
-        return await module.value(depName);
-      } catch (e) {}
-    }
-
-    if (module?._runtime && typeof module._runtime._global === "function") {
-      try {
-        const g = module._runtime._global(depName);
-        if (g !== undefined) return g;
-      } catch (e) {}
-    }
-
-    throw new Error(
-      `invokeVariable("${label}"): could not resolve dependency "${depName}" (no override and not found in module/builtins/global)`
-    );
-  };
-
-  const args = [];
-  for (const dep of inputs) {
-    const depName = dep?._name;
-    if (!depName) {
-      args.push(undefined);
-      continue;
-    }
-    args.push(await resolveDependency(depName));
-  }
-
-  const def = variable._definition;
-  if (typeof def !== "function") {
-    throw new Error(
-      `invokeVariable("${label}"): target variable does not have an invokable function definition`
-    );
-  }
-  return def(...args);
-}
-)};
-const _jtrr9m = function _3(md){return(
-md`### Example
-
-let c = a + b`
-)};
-const _1v2c0s1 = function _a(){return(
-1
-)};
-const _ywl8oh = function _b(){return(
-3
-)};
-const _1mc3tpl = function _c(a,b){return(
-a + b
-)};
-const _o5e50u = function _7(md){return(
-md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
-)};
-const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule)
-)};
-const _smh5by = function _9(md){return(
-md`But we can set b to 20, and then we get the answer 21.`
-)};
-const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule, { b: 20 })
-)};
-const _qh0yhm = function _11(md){return(
-md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
-)};
-const _1hy0qcz = function _invokeVariableModule(thisModule){return(
-thisModule()
-)};
-const _jno7wc = (G, _) => G.input(_);
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_zkje0r", null, ["md"], _zkje0r);  
-  $def("_kfe4ll", "invokeVariable", ["lookupVariable"], _kfe4ll);  
-  $def("_jtrr9m", null, ["md"], _jtrr9m);  
-  $def("_1v2c0s1", "a", [], _1v2c0s1);  
-  $def("_ywl8oh", "b", [], _ywl8oh);  
-  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
-  $def("_o5e50u", null, ["md"], _o5e50u);  
-  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
-  $def("_smh5by", null, ["md"], _smh5by);  
-  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
-  $def("_qh0yhm", null, ["md"], _qh0yhm);  
-  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
-  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
-  return main;
-}
-</script>
 
 <!-- Bootloader -->
 <script id="bootconf.json"


### PR DESCRIPTION
Re-jumpgated `@tomlarkworthy/robocoop-5` from ObservableHQ to pull recently-landed frame features.

## What changed
Five frame modules bumped to their current Observable versions:
- `@tomlarkworthy/command-palette`
- `@tomlarkworthy/editor-5` — includes the reactive `currentModules` fix (cells in runtime-created modules are now editable)
- `@tomlarkworthy/invoke-variable`
- `@tomlarkworthy/lopepage-2`
- `@tomlarkworthy/module-map`

`robocoop-5`, `robocoop-5-engine`, `robocoop-5-srctools` came out **byte-identical** (no churn). Bootconf `mains`, `hash` (`#view=R100(S75(robocoop-5),S25(robocoop-5-srctools))`), `headless`, and the `file://syntax.css` attachment are all preserved. `.json` sidecar unchanged.

## Verification
- Booted in Playwright on the lopepage-2 frame: both panes render (robocoop-5 chat UI + srctools), `currentModules` is a reactive `Map(52)`.
- Console: no errors/page errors (only benign `blob:null` boot aborts + an unrelated inputs-reference demo `.mov`).
- Confirmed editor-5 in the export carries the `currentModules` import and no longer has the stale `moduleMap(runtime)` one-shot snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)