### PR TITLE
Fix: markdown escaping leaks into ${...} placeholders, breaking the md template

### DIFF
--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5609,7 +5609,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -5643,10 +5643,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -5674,7 +5676,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -5701,8 +5703,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -5746,6 +5750,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -5782,6 +5800,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -5863,19 +5918,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  


### PR DESCRIPTION
**This PR is a proposal** — the canonical HTML has been updated with the new cells, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Reported symptom

> editable-md has a flaw that if a code snippet contains `[]` like `${ aside('editable-md', ['@tomlarkworthy/editable-md']) }` then it is escaped in such a way to break the template literal causing a compilation failure.

Reproduced exactly.

## Root cause

An **escaping asymmetry** between the two halves of the edit round trip:

- `mdCellSourceToMarkdown` wrote the JS expression source into the markdown **raw**.
- prosemirror's `defaultMarkdownSerializer` writes text back **escaped** — and a `${...}` placeholder is just plain text in the ProseMirror document, so its JS gets escaped too.

`tokenizeMarkdownTemplate` then copied that escaped text verbatim into the tagged template:

```
${aside('editable-md', \['@tomlarkworthy/editable-md'\])}
```

`\[` is not valid JS. Notably `compile()` does **not** throw on this — it swallows the syntax error and returns a cell with `_inputs: []` whose definition throws a `SyntaxError` when run. So the md cell silently turns into a broken cell on save, which is the reported "compilation failure".

Verified against the real serializer which characters actually leak (`[ ] * ~ \` \\`); `_` and backticks are *not* escaped in this position.

## Fix

Make the two directions exact inverses, via two new cells:

- `escapeMarkdownInline` — escapes exactly the set prosemirror's serializer escapes. Applied to the expression source in `mdCellSourceToMarkdown`.
- `unescapeMarkdownInline` — reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule; a superset, so serializer-added escapes are removed too). Applied to the expression source in `tokenizeMarkdownTemplate`.

Because the escape is now applied on the way *out*, prosemirror's parser strips it and the editor shows the author's **real JS** (`['@tomlarkworthy/editable-md']`, not `\[...\]`) — a UX improvement over the previous behaviour.

### Why not just unescape on the way back in?

That was the obvious one-line fix and it is **wrong**: it regresses expressions that legitimately contain backslashes. `${x.replace(/\[/g, '')}` round-trips correctly today (parse strips `\[` → serialize re-adds it), and blind unescaping would turn it into `/[/g`. The symmetric fix handles both — this case is pinned by a test.

## Targeted QA (live runtime, regenerated bundle)

- ✅ `test_placeholder_brackets_survive_editing` — the reported case; asserts `_inputs` contains `aside` (discriminating: broken → `_inputs: []`)
- ✅ `test_placeholder_round_trip_preserves_js` — 6 expressions incl. the regex/backslash cases round-trip byte-exact
- ✅ `test_escapeMarkdownInline_inverse`
- ✅ All 4 pre-existing tests still pass
- ✅ **Negative control**: the new tests were confirmed to *fail* against the old behaviour, so they genuinely guard the bug
- ✅ **End-to-end**: clicked a live md cell containing the reported placeholder, edited it, Shift+Enter → cell survives (`_inputs: ["md","aside","control"]`, no SyntaxError, brackets intact, edit applied, `aside()` renders)
- Console: clean (only pre-existing `@import` / `.mov` boot noise)

## Note

`run_tests` times out on this notebook — pre-existing, reproduced before this change. Tests above were driven directly against the shipped cells.