### PR TITLE
Sync editable-md placeholder-escaping fix into 11 consumers

### DIFF
--- a/notebooks/@tomlarkworthy_belief-state-geometry.html
+++ b/notebooks/@tomlarkworthy_belief-state-geometry.html
@@ -4137,7 +4137,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -4171,10 +4171,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -4202,7 +4204,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -4229,8 +4231,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -4274,6 +4278,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -4310,6 +4328,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -4391,19 +4446,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_coding_harness_tuning_blog.html
+++ b/notebooks/@tomlarkworthy_coding_harness_tuning_blog.html
@@ -4137,7 +4137,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -4171,10 +4171,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -4202,7 +4204,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -4229,8 +4231,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -4274,6 +4278,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -4310,6 +4328,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -4391,19 +4446,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_computational-blogs-with-claude-code-connectivity.html
+++ b/notebooks/@tomlarkworthy_computational-blogs-with-claude-code-connectivity.html
@@ -5426,7 +5426,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -5460,10 +5460,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -5491,7 +5493,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -5518,8 +5520,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -5563,6 +5567,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -5599,6 +5617,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -5680,19 +5735,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_lopecode-live-2026.html
+++ b/notebooks/@tomlarkworthy_lopecode-live-2026.html
@@ -4137,7 +4137,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -4171,10 +4171,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -4202,7 +4204,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -4229,8 +4231,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -4274,6 +4278,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -4310,6 +4328,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -4391,19 +4446,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_lopecode-newsletter-001.html
+++ b/notebooks/@tomlarkworthy_lopecode-newsletter-001.html
@@ -9263,7 +9263,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -9297,10 +9297,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -9328,7 +9330,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -9355,8 +9357,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -9400,6 +9404,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -9436,6 +9454,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -9517,19 +9572,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_lopecode-substrate-2026.html
+++ b/notebooks/@tomlarkworthy_lopecode-substrate-2026.html
@@ -6032,7 +6032,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -6066,10 +6066,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -6097,7 +6099,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -6124,8 +6126,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -6169,6 +6173,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -6205,6 +6223,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -6286,19 +6341,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -9314,7 +9314,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -9348,10 +9348,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -9379,7 +9381,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -9406,8 +9408,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -9451,6 +9455,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -9487,6 +9505,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -9568,19 +9623,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -6032,7 +6032,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -6066,10 +6066,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -6097,7 +6099,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -6124,8 +6126,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -6169,6 +6173,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -6205,6 +6223,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -6286,19 +6341,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_parametric-svg.html
+++ b/notebooks/@tomlarkworthy_parametric-svg.html
@@ -5426,7 +5426,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5445,6 +5445,43 @@ const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,origi
       prosemirror.undoItem,
       prosemirror.redoItem
     ]]).concat(menuItems.blockMenu);
+  // Copied and adjusted from exampleSetup.
+  const blockQuoteRule = type => prosemirror.wrappingInputRule(/^\s*>\s$/, type);
+  const orderedListRule = type => prosemirror.wrappingInputRule(/^(\d+)\.\s$/, type, m => ({ order: +m[1] }), (m, n) => n.childCount + n.attrs.order == +m[1]);
+  const bulletListRule = type => prosemirror.wrappingInputRule(/^\s*([-+*])\s$/, type);
+  const codeBlockRule = type => prosemirror.textblockTypeInputRule(/^```$/, type);
+  const headingRule = (type, maxLevel) => prosemirror.textblockTypeInputRule(new RegExp('^(#{1,' + maxLevel + '})\\s$'), type, m => ({ level: m[1].length }));
+  const buildEditorInputRules = schema => {
+    const rules = [
+      prosemirror.ellipsis,
+      prosemirror.emDash
+    ];
+    let type;
+    if (type = schema.nodes.blockquote)
+      rules.push(blockQuoteRule(type));
+    if (type = schema.nodes.ordered_list)
+      rules.push(orderedListRule(type));
+    if (type = schema.nodes.bullet_list)
+      rules.push(bulletListRule(type));
+    if (type = schema.nodes.code_block)
+      rules.push(codeBlockRule(type));
+    if (type = schema.nodes.heading)
+      rules.push(headingRule(type, 6));
+    return prosemirror.inputRules({ rules });
+  };
+  const editorPlugins = [
+    buildEditorInputRules(prosemirror.schema),
+    prosemirror.keymap(prosemirror.buildKeymap(prosemirror.schema)),
+    prosemirror.keymap(prosemirror.baseKeymap),
+    prosemirror.dropCursor(),
+    prosemirror.gapCursor(),
+    prosemirror.menuBar({
+      floating: true,
+      content: menuContent
+    }),
+    prosemirror.history(),
+    new prosemirror.Plugin({ props: { attributes: { class: 'ProseMirror-example-setup-style' } } })
+  ];
   const isInteractiveTarget = (event, root) => {
     if (!event || !root)
       return false;
@@ -5500,6 +5537,10 @@ const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,origi
         const listener = async event => {
           if (isInteractiveTarget(event, dom))
             return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
+            return;
           dom.removeEventListener('click', listener);
           dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
@@ -5508,10 +5549,7 @@ const _1a2tzk1 = function _md(editor_theme_css,prosemirror,Element,randstr,origi
           const state = prosemirror.EditorState.create({
             doc,
             schema: prosemirror.schema,
-            plugins: prosemirror.exampleSetup({
-              schema: prosemirror.schema,
-              menuContent
-            })
+            plugins: editorPlugins
           });
           dom.innerHTML = '';
           view = new prosemirror.EditorView(dom, {
@@ -5571,7 +5609,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -5605,10 +5643,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -5636,7 +5676,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -5663,8 +5703,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -5708,6 +5750,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -5744,6 +5800,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -5819,25 +5912,30 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1a2tzk1", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1a2tzk1);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","invalidation"], _1z4iyw);  
   $def("_etlb83", "irToEditableText", [], _etlb83);  
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_unaggregating-cloudwatch-metrics.html
+++ b/notebooks/@tomlarkworthy_unaggregating-cloudwatch-metrics.html
@@ -5611,7 +5611,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -5645,10 +5645,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -5676,7 +5678,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -5703,8 +5705,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -5748,6 +5752,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -5784,6 +5802,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -5865,19 +5920,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  

--- a/notebooks/@tomlarkworthy_virtual-monorepo.html
+++ b/notebooks/@tomlarkworthy_virtual-monorepo.html
@@ -3386,7 +3386,7 @@ mdCellSourceToMarkdown(
   "title = md`foo ${'cool'}`"
 )
 )};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk){return(
+const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
 function mdCellSourceToMarkdown(source) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
@@ -3420,10 +3420,12 @@ function mdCellSourceToMarkdown(source) {
     out += text.replaceAll("${", "\\${");
 
     // 2. interleaved JS expression as `${ ... }`
+    // Markdown-escape the JS so a round trip through prosemirror's parser
+    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
     if (i < expressions.length) {
       const expr = expressions[i];
       const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + exprSource + "}";
+      out += "${" + escapeMarkdownInline(exprSource) + "}";
     }
   }
 
@@ -3451,7 +3453,7 @@ function markdownToMdTagged(editableMarkdown) {
   return out;
 }
 )};
-const _1060b9b = function _tokenizeMarkdownTemplate(){return(
+const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
 function tokenizeMarkdownTemplate(input) {
   const parts = [];
   let i = 0;
@@ -3478,8 +3480,10 @@ function tokenizeMarkdownTemplate(input) {
       if (depth !== 0) {
         throw new Error("Unbalanced ${...} in markdown template");
       }
+      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+      // placeholder too, which would otherwise emit invalid JS into the tagged template.
       const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: exprSource.trim() });
+      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
     } else {
       buf += input[i++];
     }
@@ -3523,6 +3527,20 @@ function escapeTemplateChunk(text) {
   return out;
 }
 )};
+const _3kmqp1 = function _escapeMarkdownInline(){return(
+// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+// so escape/unescape are exact inverses across a parse+serialize round trip.
+function escapeMarkdownInline(text) {
+  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+}
+)};
+const _9wq3vz = function _unescapeMarkdownInline(){return(
+// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+function unescapeMarkdownInline(text) {
+  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
+}
+)};
 const _150iump = function _randstr(){return(
 function randstr(prefix)
 {
@@ -3559,6 +3577,43 @@ const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMark
   const template = markdownToMdTagged(markdown);
   expect(template).toBe("md`\\${...}`"); // same as original tag
 };
+const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain("aside");
+};
+const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
+{
+  const EXPRS = [
+    "arr[0]",
+    "a * b",
+    "obj['key']",
+    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
+    "d3.range(10).map(i => i ** 2)",
+    "f(a, [b, c], {d})"
+  ];
+  for (const expr of EXPRS) {
+    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + " expressions round trip";
+};
+const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
+)};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -3640,19 +3695,24 @@ export default function define(runtime, observer) {
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
   $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk"], _196gc4w);  
+  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
   $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
   $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", [], _1060b9b);  
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
-  $def("_150iump", "randstr", [], _150iump);  
+  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
+  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
+  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
+  $def("_150iump", "randstr", [], _150iump);
   $def("_2gy6uf", null, ["md"], _2gy6uf);  
   $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
   $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
   $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
   $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
   $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
+  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
+  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
   main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  


### PR DESCRIPTION
Follow-up to #112 (merged), which fixed the `${...}` placeholder escaping in `@tomlarkworthy/editable-md`.

This propagates the regenerated module into the 11 lopebooks notebooks that bundle it, so they pick up the fix.

## What changed

Mechanical `tools/channel/sync-module.ts` `<script id="@tomlarkworthy/editable-md">` block swap in each consumer — no rebuild, no other regions touched. Each file verified to contain the new `escapeMarkdownInline` / `unescapeMarkdownInline` cells and zero remaining pre-fix code.

ObservableHQ has been pushed (`@tomlarkworthy/editable-md` now at version 851: `mdCellSourceToMarkdown` + `tokenizeMarkdownTemplate` modified, 4 new cells inserted).

## Consumers synced (11)

belief-state-geometry, coding_harness_tuning_blog, computational-blogs-with-claude-code-connectivity, lopecode-live-2026, lopecode-newsletter-001, lopecode-substrate-2026, lopecode-tour, lopecode-vision, parametric-svg, unaggregating-cloudwatch-metrics, virtual-monorepo

Five further grep matches (bulk-jumpgate, daw, grid-container, my-lopebooks, robocoop-5) reference the module by name but don't bundle its `<script>` block, so `sync-module` skipped them.

## Verification

Per the bug-fix skill, consumer changes that are pure `sync-module` block swaps rely on the canonical-bundle verification already done in #112 (unit tests + negative control + end-to-end click→edit→Shift+Enter). The module's API surface, imports, and dependency graph are unchanged by the fix — only two cell bodies changed and four cells were added — so no per-consumer browser QA.