### PR TITLE
Fix: editable-md helpers break on ObservableHQ push (ASI after return)

### DIFF
--- a/notebooks/@tomlarkworthy_belief-state-geometry.html
+++ b/notebooks/@tomlarkworthy_belief-state-geometry.html
@@ -4301,9 +4301,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -4319,16 +4319,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_coding_harness_tuning_blog.html
+++ b/notebooks/@tomlarkworthy_coding_harness_tuning_blog.html
@@ -4301,9 +4301,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -4319,16 +4319,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_computational-blogs-with-claude-code-connectivity.html
+++ b/notebooks/@tomlarkworthy_computational-blogs-with-claude-code-connectivity.html
@@ -5590,9 +5590,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -5608,16 +5608,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5773,9 +5773,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -5791,16 +5791,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_lopecode-live-2026.html
+++ b/notebooks/@tomlarkworthy_lopecode-live-2026.html
@@ -5248,9 +5248,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -5266,16 +5266,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_lopecode-newsletter-001.html
+++ b/notebooks/@tomlarkworthy_lopecode-newsletter-001.html
@@ -9427,9 +9427,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -9445,16 +9445,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_lopecode-substrate-2026.html
+++ b/notebooks/@tomlarkworthy_lopecode-substrate-2026.html
@@ -6196,9 +6196,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -6214,16 +6214,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -9478,9 +9478,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -9496,16 +9496,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -6196,9 +6196,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -6214,16 +6214,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_parametric-svg.html
+++ b/notebooks/@tomlarkworthy_parametric-svg.html
@@ -5773,9 +5773,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -5791,16 +5791,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_unaggregating-cloudwatch-metrics.html
+++ b/notebooks/@tomlarkworthy_unaggregating-cloudwatch-metrics.html
@@ -5775,9 +5775,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -5793,16 +5793,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};

--- a/notebooks/@tomlarkworthy_virtual-monorepo.html
+++ b/notebooks/@tomlarkworthy_virtual-monorepo.html
@@ -3550,9 +3550,9 @@ function isPasteableUrl(text) {
 }
 )};
 const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
-// Pasting a URL over a selection links the selection instead of replacing it.
-// Returns true when handled, so prosemirror skips its default paste.
 function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
   const linkType = prosemirror.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
@@ -3568,16 +3568,16 @@ function linkifyPastedUrl(view, event) {
 }
 )};
 const _3kmqp1 = function _escapeMarkdownInline(){return(
-// Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-// so escape/unescape are exact inverses across a parse+serialize round trip.
 function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
   return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
-// Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-// a superset of escapeMarkdownInline so serializer-added escapes are also removed.
 function unescapeMarkdownInline(text) {
+  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
   return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
 }
 )};


### PR DESCRIPTION
User report: on ObservableHQ, `test_placeholder_brackets_survive_editing = TypeError: escapeMarkdownInline is not a function`.

## Root cause (verified against the live Observable document)

`escapeMarkdownInline`, `unescapeMarkdownInline`, and `linkifyPastedUrl` each began their returned expression with a line comment before `function`. In the notebook the cell is `return( //comment \n function… )` — the `(` immediately after `return` blocks automatic-semicolon-insertion, so it works (and the in-browser tests are green).

But `lope-push-ws` decompiles the cell to a block body **without** the wrapping parens:

```
escapeMarkdownInline = {
  return // Mirrors the character set...
  function escapeMarkdownInline(text) { ... };
}
```

`return` followed by a line comment then a newline triggers ASI → `return;`. The cell evaluates to `undefined`, and `mdCellSourceToMarkdown` (which calls it) throws. Fetched node 847/848/854 from Observable's API to confirm this exact form.

## Fix

Move each leading comment inside its function body, so the cell body starts with `function`. `--dry-run` decompile now emits `return function <name>(...)` on one line — no ASI. Behaviorally identical; the in-notebook runtime was never affected.

## Verification

- ✅ `--dry-run` decompile of all 3 cells: `return function …` on one line, no `return //`
- ✅ Pushed to Observable (v859), re-fetched, and **evaluated the exact pushed cell bodies**: `escapeMarkdownInline`/`unescapeMarkdownInline` now `typeof === "function"` and behave (`escapeMarkdownInline("a[0]*b") === "a\[0\]\*b"`)
- ✅ Canonical + 11 consumers synced; 0 ASI-hazard cells remain

Includes the 11 consumer syncs (behaviorally a no-op there — they run in-browser where the original form worked — but kept in sync to preserve canonical==consumers).