### PR TITLE
markdown-wiki: tidy cell layout (intro / selector / rendered-md); drop wiki_content

### DIFF
--- a/notebooks/@tomlarkworthy_blank-notebook.html
+++ b/notebooks/@tomlarkworthy_blank-notebook.html
@@ -23948,6 +23948,21 @@ md`# 📚 Knowledge Wiki
 
 A browsable markdown knowledge base. Every document below is a content block — readable by AI agents directly at \`/content/@tomlarkworthy/markdown-wiki/<file>\`, and mirrored from the repo \`knowledge/\` folder.`
 )};
+const _xnpk0l = function _wiki_selection(Inputs,wiki_files){return(
+Inputs.select(wiki_files, {
+  label: 'document',
+  value: wiki_files[0]
+})
+)};
+const _1ie98l = (G, _) => G.input(_);
+const _1k8md73 = function _wiki_view(wiki_register,wiki_selection,wikiRead,html,md) {
+    wiki_register;
+    // side-effect: register docs as FileAttachments for export durability
+    const content = !wiki_selection
+      ? '_(no documents — inject them with tools/sync-wiki.ts)_'
+      : (wikiRead(wiki_selection) ?? '_(document not found)_');
+    return html`<div style="max-height:70vh;overflow:auto;padding:0 1rem;line-height:1.5">${ md([content]) }</div>`;
+};
 const _1trbfb3 = function _wikiRead(){return(
 name => {
   const lc = typeof window !== 'undefined' ? window.lopecode : null;
@@ -23990,25 +24005,7 @@ const _1172yeo = function _wiki_index(wiki_register,wiki_summaries) {
     // side-effect: register docs as FileAttachments for export durability
     const base = '/content/@tomlarkworthy/markdown-wiki/';
     const lines = wiki_summaries.map(({name, summary}) => `- ${ base }${ name } — ${ summary }`);
-    return 'KNOWLEDGE WIKI \u2014 a curated, authoritative set of docs about THIS project (lopecode / lopebooks / ' + 'robocoop / the notebook runtime and its tooling). When a task or question touches any of these topics, ' + 'read the relevant doc with read_file FIRST \u2014 before investigating the live notebook, fetching anything, ' + 'or answering from memory. These docs are current and take precedence over your priors; do not fabricate ' + 'an answer a doc already gives. Available docs:\n' + lines.join('\n');
-};
-const _xnpk0l = function _wiki_selection(Inputs,wiki_files){return(
-Inputs.select(wiki_files, {
-  label: 'document',
-  value: wiki_files[0]
-})
-)};
-const _1ie98l = (G, _) => G.input(_);
-const _p38mdz = function _wiki_content(wiki_selection,wikiRead)
-{
-  if (!wiki_selection)
-    return '_(no documents \u2014 inject them with tools/sync-wiki.ts)_';
-  return wikiRead(wiki_selection) ?? '_(document not found)_';
-};
-const _1k8md73 = function _wiki_view(wiki_register,html,md,wiki_content) {
-    wiki_register;
-    // side-effect: register docs as FileAttachments for export durability
-    return html`<div style="max-height:70vh;overflow:auto;padding:0 1rem;line-height:1.5">${ md([wiki_content]) }</div>`;
+    return 'KNOWLEDGE WIKI — a curated, authoritative set of docs about THIS project (lopecode / lopebooks / ' + 'robocoop / the notebook runtime and its tooling). When a task or question touches any of these topics, ' + 'read the relevant doc with read_file FIRST — before investigating the live notebook, fetching anything, ' + 'or answering from memory. These docs are current and take precedence over your priors; do not fabricate ' + 'an answer a doc already gives. Available docs:\n' + lines.join('\n');
 };
 const _ln9t7s = function _wikiModule(thisModule) {return (thisModule());};
 const _1q7cpig = (G, _) => G.input(_);
@@ -24054,20 +24051,19 @@ export default function define(runtime, observer) {
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
-  $def("_okuukn", "intro", ["md"], _okuukn);  
-  $def("_1trbfb3", "wikiRead", [], _1trbfb3);  
-  $def("_103elop", "wiki_files", [], _103elop);  
-  $def("_1q8134j", "wiki_summaries", ["wiki_files","wikiRead"], _1q8134j);  
-  $def("_1172yeo", "wiki_index", ["wiki_register","wiki_summaries"], _1172yeo);  
-  $def("_xnpk0l", "viewof wiki_selection", ["Inputs","wiki_files"], _xnpk0l);  
-  $def("_1ie98l", "wiki_selection", ["Generators","viewof wiki_selection"], _1ie98l);  
-  $def("_p38mdz", "wiki_content", ["wiki_selection","wikiRead"], _p38mdz);  
-  $def("_1k8md73", "wiki_view", ["wiki_register","html","md","wiki_content"], _1k8md73);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  $def("_ln9t7s", "viewof wikiModule", ["thisModule"], _ln9t7s);  
-  $def("_1q7cpig", "wikiModule", ["Generators","viewof wikiModule"], _1q7cpig);  
+  $def("_okuukn", "intro", ["md"], _okuukn);
+  $def("_xnpk0l", "viewof wiki_selection", ["Inputs","wiki_files"], _xnpk0l);
+  $def("_1ie98l", "wiki_selection", ["Generators","viewof wiki_selection"], _1ie98l);
+  $def("_1k8md73", "wiki_view", ["wiki_register","wiki_selection","wikiRead","html","md"], _1k8md73);
+  $def("_1trbfb3", "wikiRead", [], _1trbfb3);
+  $def("_103elop", "wiki_files", [], _103elop);
+  $def("_1q8134j", "wiki_summaries", ["wiki_files","wikiRead"], _1q8134j);
+  $def("_1172yeo", "wiki_index", ["wiki_register","wiki_summaries"], _1172yeo);
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
+  $def("_ln9t7s", "viewof wikiModule", ["thisModule"], _ln9t7s);
+  $def("_1q7cpig", "wikiModule", ["Generators","viewof wikiModule"], _1q7cpig);
   $def("_icrlsb", "wiki_register", ["wikiModule","wiki_files","runtime"], _icrlsb);
   return main;
 }</script>

--- a/notebooks/@tomlarkworthy_lopecode-live-2026.html
+++ b/notebooks/@tomlarkworthy_lopecode-live-2026.html
@@ -27605,6 +27605,21 @@ md`# 📚 Knowledge Wiki
 
 A browsable markdown knowledge base. Every document below is a content block — readable by AI agents directly at \`/content/@tomlarkworthy/markdown-wiki/<file>\`, and mirrored from the repo \`knowledge/\` folder.`
 )};
+const _xnpk0l = function _wiki_selection(Inputs,wiki_files){return(
+Inputs.select(wiki_files, {
+  label: 'document',
+  value: wiki_files[0]
+})
+)};
+const _1ie98l = (G, _) => G.input(_);
+const _1k8md73 = function _wiki_view(wiki_register,wiki_selection,wikiRead,html,md) {
+    wiki_register;
+    // side-effect: register docs as FileAttachments for export durability
+    const content = !wiki_selection
+      ? '_(no documents — inject them with tools/sync-wiki.ts)_'
+      : (wikiRead(wiki_selection) ?? '_(document not found)_');
+    return html`<div style="max-height:70vh;overflow:auto;padding:0 1rem;line-height:1.5">${ md([content]) }</div>`;
+};
 const _1trbfb3 = function _wikiRead(){return(
 name => {
   const lc = typeof window !== 'undefined' ? window.lopecode : null;
@@ -27647,25 +27662,7 @@ const _1172yeo = function _wiki_index(wiki_register,wiki_summaries) {
     // side-effect: register docs as FileAttachments for export durability
     const base = '/content/@tomlarkworthy/markdown-wiki/';
     const lines = wiki_summaries.map(({name, summary}) => `- ${ base }${ name } — ${ summary }`);
-    return 'KNOWLEDGE WIKI \u2014 a curated, authoritative set of docs about THIS project (lopecode / lopebooks / ' + 'robocoop / the notebook runtime and its tooling). When a task or question touches any of these topics, ' + 'read the relevant doc with read_file FIRST \u2014 before investigating the live notebook, fetching anything, ' + 'or answering from memory. These docs are current and take precedence over your priors; do not fabricate ' + 'an answer a doc already gives. Available docs:\n' + lines.join('\n');
-};
-const _xnpk0l = function _wiki_selection(Inputs,wiki_files){return(
-Inputs.select(wiki_files, {
-  label: 'document',
-  value: wiki_files[0]
-})
-)};
-const _1ie98l = (G, _) => G.input(_);
-const _p38mdz = function _wiki_content(wiki_selection,wikiRead)
-{
-  if (!wiki_selection)
-    return '_(no documents \u2014 inject them with tools/sync-wiki.ts)_';
-  return wikiRead(wiki_selection) ?? '_(document not found)_';
-};
-const _1k8md73 = function _wiki_view(wiki_register,html,md,wiki_content) {
-    wiki_register;
-    // side-effect: register docs as FileAttachments for export durability
-    return html`<div style="max-height:70vh;overflow:auto;padding:0 1rem;line-height:1.5">${ md([wiki_content]) }</div>`;
+    return 'KNOWLEDGE WIKI — a curated, authoritative set of docs about THIS project (lopecode / lopebooks / ' + 'robocoop / the notebook runtime and its tooling). When a task or question touches any of these topics, ' + 'read the relevant doc with read_file FIRST — before investigating the live notebook, fetching anything, ' + 'or answering from memory. These docs are current and take precedence over your priors; do not fabricate ' + 'an answer a doc already gives. Available docs:\n' + lines.join('\n');
 };
 const _ln9t7s = function _wikiModule(thisModule) {return (thisModule());};
 const _1q7cpig = (G, _) => G.input(_);
@@ -27711,20 +27708,19 @@ export default function define(runtime, observer) {
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
-  $def("_okuukn", "intro", ["md"], _okuukn);  
-  $def("_1trbfb3", "wikiRead", [], _1trbfb3);  
-  $def("_103elop", "wiki_files", [], _103elop);  
-  $def("_1q8134j", "wiki_summaries", ["wiki_files","wikiRead"], _1q8134j);  
-  $def("_1172yeo", "wiki_index", ["wiki_register","wiki_summaries"], _1172yeo);  
-  $def("_xnpk0l", "viewof wiki_selection", ["Inputs","wiki_files"], _xnpk0l);  
-  $def("_1ie98l", "wiki_selection", ["Generators","viewof wiki_selection"], _1ie98l);  
-  $def("_p38mdz", "wiki_content", ["wiki_selection","wikiRead"], _p38mdz);  
-  $def("_1k8md73", "wiki_view", ["wiki_register","html","md","wiki_content"], _1k8md73);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  $def("_ln9t7s", "viewof wikiModule", ["thisModule"], _ln9t7s);  
-  $def("_1q7cpig", "wikiModule", ["Generators","viewof wikiModule"], _1q7cpig);  
+  $def("_okuukn", "intro", ["md"], _okuukn);
+  $def("_xnpk0l", "viewof wiki_selection", ["Inputs","wiki_files"], _xnpk0l);
+  $def("_1ie98l", "wiki_selection", ["Generators","viewof wiki_selection"], _1ie98l);
+  $def("_1k8md73", "wiki_view", ["wiki_register","wiki_selection","wikiRead","html","md"], _1k8md73);
+  $def("_1trbfb3", "wikiRead", [], _1trbfb3);
+  $def("_103elop", "wiki_files", [], _103elop);
+  $def("_1q8134j", "wiki_summaries", ["wiki_files","wikiRead"], _1q8134j);
+  $def("_1172yeo", "wiki_index", ["wiki_register","wiki_summaries"], _1172yeo);
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
+  $def("_ln9t7s", "viewof wikiModule", ["thisModule"], _ln9t7s);
+  $def("_1q7cpig", "wikiModule", ["Generators","viewof wikiModule"], _1q7cpig);
   $def("_icrlsb", "wiki_register", ["wikiModule","wiki_files","runtime"], _icrlsb);
   return main;
 }</script>

--- a/notebooks/@tomlarkworthy_robocoop-5.html
+++ b/notebooks/@tomlarkworthy_robocoop-5.html
@@ -20609,6 +20609,21 @@ md`# 📚 Knowledge Wiki
 
 A browsable markdown knowledge base. Every document below is a content block — readable by AI agents directly at \`/content/@tomlarkworthy/markdown-wiki/<file>\`, and mirrored from the repo \`knowledge/\` folder.`
 )};
+const _xnpk0l = function _wiki_selection(Inputs,wiki_files){return(
+Inputs.select(wiki_files, {
+  label: 'document',
+  value: wiki_files[0]
+})
+)};
+const _1ie98l = (G, _) => G.input(_);
+const _1k8md73 = function _wiki_view(wiki_register,wiki_selection,wikiRead,html,md) {
+    wiki_register;
+    // side-effect: register docs as FileAttachments for export durability
+    const content = !wiki_selection
+      ? '_(no documents — inject them with tools/sync-wiki.ts)_'
+      : (wikiRead(wiki_selection) ?? '_(document not found)_');
+    return html`<div style="max-height:70vh;overflow:auto;padding:0 1rem;line-height:1.5">${ md([content]) }</div>`;
+};
 const _1trbfb3 = function _wikiRead(){return(
 name => {
   const lc = typeof window !== 'undefined' ? window.lopecode : null;
@@ -20651,25 +20666,7 @@ const _1172yeo = function _wiki_index(wiki_register,wiki_summaries) {
     // side-effect: register docs as FileAttachments for export durability
     const base = '/content/@tomlarkworthy/markdown-wiki/';
     const lines = wiki_summaries.map(({name, summary}) => `- ${ base }${ name } — ${ summary }`);
-    return 'KNOWLEDGE WIKI \u2014 a curated, authoritative set of docs about THIS project (lopecode / lopebooks / ' + 'robocoop / the notebook runtime and its tooling). When a task or question touches any of these topics, ' + 'read the relevant doc with read_file FIRST \u2014 before investigating the live notebook, fetching anything, ' + 'or answering from memory. These docs are current and take precedence over your priors; do not fabricate ' + 'an answer a doc already gives. Available docs:\n' + lines.join('\n');
-};
-const _xnpk0l = function _wiki_selection(Inputs,wiki_files){return(
-Inputs.select(wiki_files, {
-  label: 'document',
-  value: wiki_files[0]
-})
-)};
-const _1ie98l = (G, _) => G.input(_);
-const _p38mdz = function _wiki_content(wiki_selection,wikiRead)
-{
-  if (!wiki_selection)
-    return '_(no documents \u2014 inject them with tools/sync-wiki.ts)_';
-  return wikiRead(wiki_selection) ?? '_(document not found)_';
-};
-const _1k8md73 = function _wiki_view(wiki_register,html,md,wiki_content) {
-    wiki_register;
-    // side-effect: register docs as FileAttachments for export durability
-    return html`<div style="max-height:70vh;overflow:auto;padding:0 1rem;line-height:1.5">${ md([wiki_content]) }</div>`;
+    return 'KNOWLEDGE WIKI — a curated, authoritative set of docs about THIS project (lopecode / lopebooks / ' + 'robocoop / the notebook runtime and its tooling). When a task or question touches any of these topics, ' + 'read the relevant doc with read_file FIRST — before investigating the live notebook, fetching anything, ' + 'or answering from memory. These docs are current and take precedence over your priors; do not fabricate ' + 'an answer a doc already gives. Available docs:\n' + lines.join('\n');
 };
 const _ln9t7s = function _wikiModule(thisModule) {return (thisModule());};
 const _1q7cpig = (G, _) => G.input(_);
@@ -20715,20 +20712,19 @@ export default function define(runtime, observer) {
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
-  $def("_okuukn", "intro", ["md"], _okuukn);  
-  $def("_1trbfb3", "wikiRead", [], _1trbfb3);  
-  $def("_103elop", "wiki_files", [], _103elop);  
-  $def("_1q8134j", "wiki_summaries", ["wiki_files","wikiRead"], _1q8134j);  
-  $def("_1172yeo", "wiki_index", ["wiki_register","wiki_summaries"], _1172yeo);  
-  $def("_xnpk0l", "viewof wiki_selection", ["Inputs","wiki_files"], _xnpk0l);  
-  $def("_1ie98l", "wiki_selection", ["Generators","viewof wiki_selection"], _1ie98l);  
-  $def("_p38mdz", "wiki_content", ["wiki_selection","wikiRead"], _p38mdz);  
-  $def("_1k8md73", "wiki_view", ["wiki_register","html","md","wiki_content"], _1k8md73);  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  $def("_ln9t7s", "viewof wikiModule", ["thisModule"], _ln9t7s);  
-  $def("_1q7cpig", "wikiModule", ["Generators","viewof wikiModule"], _1q7cpig);  
+  $def("_okuukn", "intro", ["md"], _okuukn);
+  $def("_xnpk0l", "viewof wiki_selection", ["Inputs","wiki_files"], _xnpk0l);
+  $def("_1ie98l", "wiki_selection", ["Generators","viewof wiki_selection"], _1ie98l);
+  $def("_1k8md73", "wiki_view", ["wiki_register","wiki_selection","wikiRead","html","md"], _1k8md73);
+  $def("_1trbfb3", "wikiRead", [], _1trbfb3);
+  $def("_103elop", "wiki_files", [], _103elop);
+  $def("_1q8134j", "wiki_summaries", ["wiki_files","wikiRead"], _1q8134j);
+  $def("_1172yeo", "wiki_index", ["wiki_register","wiki_summaries"], _1172yeo);
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
+  $def("_ln9t7s", "viewof wikiModule", ["thisModule"], _ln9t7s);
+  $def("_1q7cpig", "wikiModule", ["Generators","viewof wikiModule"], _1q7cpig);
   $def("_icrlsb", "wiki_register", ["wikiModule","wiki_files","runtime"], _icrlsb);
   return main;
 }</script>


### PR DESCRIPTION
Follow-up to the wiki export-durability fix. Cleaner pane layout:

1. **intro** — title
2. **viewof wiki_selection** — the file picker
3. **wiki_view** — the selected doc rendered as **markdown** (previously a separate `wiki_content` raw-string cell sat between them)

Folded the redundant `wiki_content` string cell into `wiki_view`. Plumbing cells (`wikiRead`, `wiki_files`, `wiki_summaries`, `wiki_index`, `wiki_register`, `wikiModule`) trail after — kept functional (`wiki_index` feeds the rc5 prompt; `wiki_register` is the export-durability fix).

Verified live: pane renders intro → selector → rendered markdown; `wiki_view` is a DOM node; FileAttachment builtin still auto-registers **13** docs; `wiki_index` intact for rc5; clean boot (`errors: []`). ObservableHQ `d/68d8…` v32→**v53**. All 4 consumer blocks byte-identical (md5 `0266f15`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)