### PR TITLE
Fix: editable-md destroys GFM tables on edit

### DIFF
--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -4,12 +4,59 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>@tomlarkworthy/editable-md</title>
+  <meta property="og:title" content="@tomlarkworthy/editable-md">
+  <meta property="og:type" content="website">
   <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgd2lkdGg9IjUwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDY0IDY0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjQiIHg9IjIwIiB5PSI1MCI+PC9yZWN0PjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjE2IiB4PSIyOCIgeT0iNTAiPjwvcmVjdD48cGF0aCBkPSJNMzIsMzhhOCw4LDAsMSwwLTgtOEE4LjAwOSw4LjAwOSwwLDAsMCwzMiwzOFptMC0xMmE0LDQsMCwxLDEtNCw0QTQsNCwwLDAsMSwzMiwyNloiPjwvcGF0aD48cGF0aCBkPSJNNiw2Mkg1OGEyLDIsMCwwLDAsMi0yVjE1YTIsMiwwLDAsMC0uNTg2LTEuNDE0bC0xMS0xMUEyLDIsMCwwLDAsNDcsMkg2QTIsMiwwLDAsMCw0LDRWNjBBMiwyLDAsMCwwLDYsNjJabTQyLTRIMTZWNDZINDhaTTE2LDZIMzF2NGg0VjZoNHY4SDE2Wk04LDZoNFYxNmEyLDIsMCwwLDAsMiwySDQxYTIsMiwwLDAsMCwyLTJWNmgzLjE3Mkw1NiwxNS44MjlWNThINTJWNDRhMiwyLDAsMCwwLTItMkgxNGEyLDIsMCwwLDAtMiwyVjU4SDhaIj48L3BhdGg+PC9zdmc+">
 </head>
 <body>
+
 <script id="networking_script">
   const normalize = url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
   const isNotebook = id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
+
+  // --- streaming gate ---
+  // main runs from the TOP of the document, before the whole file has finished downloading, so a
+  // block a boot import needs may not have streamed in yet. __waitForId blocks until the block's
+  // <script> is fully parsed (el.nextSibling is non-null only after its </scr\ipt> is seen),
+  // bounded by window.__lopeStreaming, which flips to false once the document is fully parsed (so a
+  // genuinely-absent id resolves to a 404 rather than hanging).
+  //
+  // The wait is event-driven (MutationObserver + DOMContentLoaded/load), NOT a setTimeout poll:
+  // Safari throttles timers in background/unfocused tabs, and a fork opens via window.open into a
+  // tab that is often not foregrounded, so a poll loop stalls there (works in a foreground file://
+  // download but hangs in a backgrounded blob: fork). MutationObserver fires on the parser's node
+  // insertions regardless of timer throttling. The end-of-document sentinel stays as a redundant
+  // fast-path; DOMContentLoaded/load clear the flag even if that inline script never runs.
+  window.__lopeStreaming = true;
+  function __endStreaming() { window.__lopeStreaming = false; }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", __endStreaming, { once: true });
+    window.addEventListener("load", __endStreaming, { once: true });
+  } else {
+    __endStreaming();
+  }
+  function __isComplete(el) { return !!el && (el.nextSibling != null || !window.__lopeStreaming); }
+  function __waitForId(id) {
+    if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) return Promise.resolve();
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        mo.disconnect();
+        document.removeEventListener("DOMContentLoaded", onEnd);
+        window.removeEventListener("load", onEnd);
+        resolve();
+      };
+      const check = () => { if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) finish(); };
+      const onEnd = () => { __endStreaming(); finish(); };
+      const mo = new MutationObserver(check);
+      mo.observe(document.documentElement, { childList: true, subtree: true });
+      document.addEventListener("DOMContentLoaded", onEnd);
+      window.addEventListener("load", onEnd);
+      check();
+    });
+  }
 
   const b64ToBytes = (b64) => {
     const bin = atob(b64);
@@ -59,6 +106,7 @@
 
   // Async bytes for global fetch/XHR/blob URLs
   async function dvfBytes(id) {
+    await __waitForId(id);
     const el = document.getElementById(id);
     if (!el) return { status: 404 };
 
@@ -90,7 +138,11 @@
     return { status: 422 };
   }
 
-  // --- es-module-shims hooks (sync) ---
+  // --- es-module-shims hooks ---
+  // fetch and source are async and wait for not-yet-streamed blocks (es-module-shims awaits both:
+  // `c = await fetchHook(...)` and `await (sourceHook||default)(...)`). resolve is NOT awaited, so it
+  // stays synchronous — it just routes a not-yet-present notebook id to file:// (where fetch/source
+  // then wait) instead of rewriting it to the remote observablehq API.
   window.esmsInitOptions = {
     shimMode: true,
     resolve(id, parentUrl, defaultResolve) {
@@ -101,12 +153,14 @@
         if (el.href) return el.href;
         return `file://${id}`;
       }
+      if (window.__lopeStreaming && isNotebook(id)) return `file://${id}`;
       if (isNotebook(id)) id = `https://api.observablehq.com/${id}.js?v=4`;
       return defaultResolve(id, parentUrl);
     },
-    source(url, fetchOpts, parent, defaultSourceHook) {
+    async source(url, fetchOpts, parent, defaultSourceHook) {
       if (url.startsWith("file://")) {
         const id = url.slice(7);
+        await __waitForId(id);
         const el = document.getElementById(id);
         if (!el) return { type: "js", source: "throw new Error('DVF 404')" };
         const enc = (el.getAttribute("data-encoding") || "text").toLowerCase();
@@ -119,12 +173,13 @@
       }
       return defaultSourceHook(url, fetchOpts, parent);
     },
-    fetch(url, options, parent) {
+    async fetch(url, options, parent) {
       if (typeof url !== "string" || !url.startsWith("file://")) {
         return fetch(url, options);
       }
       const id = url.slice(7);
-      return dvfResponseSync(id); // must be synchronous
+      await __waitForId(id);
+      return dvfResponseSync(id);
     }
   };
 
@@ -234,6 +289,35 @@
       }
     }
   })();
+</script>
+
+<script id="main">
+(async () => {
+  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").then(r => r.text()).then(src => {
+    const script = document.createElement('script');
+    script.textContent = src;
+    document.head.appendChild(script);
+  });
+
+  const style0 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css", { with: { type: 'css' } });
+  const style1 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/inspector.css", { with: { type: 'css' } });
+  const style2 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/highlight.css", { with: { type: 'css' } });
+  const style3 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/plot.css", { with: { type: 'css' } });
+  const style4 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/index.css", { with: { type: 'css' } });
+  const style5 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/theme-parchment.css", { with: { type: 'css' } });
+  const style6 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-light.css", { with: { type: 'css' } });
+  const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-light.css", { with: { type: 'css' } });
+  const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
+  document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
+
+  const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
+  const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
+  const notebook = document.querySelector("notebook");
+  const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
+  const observer = Inspector.into(document.body);
+  const {default: define} = await importShim("@tomlarkworthy/bootloader");
+  runtime.bootloader = runtime.module(define, () => ({}));
+})().catch((e) => console.error("boot error", e));
 </script>
 
 <!-- CSS -->
@@ -821,6 +905,2421 @@ H4sIAK6D82gAA7Uca2/cNvK7fwVjHAqpUTep+83bNC3uckCAJimatMDBMFx5V7bV7kp7ktaOz93/fiTn
 H4sIAGWI82gAA+08/XfbOI6/969QdXlbuXHs2O112qRpm0ncndzko69J566X5BLFomNNZckryfnY1P/7AQRJkfqwZW96s7Pv+l5jiQRBEAABECTVblth5LGLUeRNApa0P0RXCYtv3KuADf/W9sNkzPppFLeTuN/2/GTspv1h6/fkyWAS9lM/Ci1Z6CCappXej+Gvx1LXDxrWwxNLPFtb8uH7d+thugkVN25seVF/MmJh2oV6RNCKbkMW74rSpsVu4AfbSriWxwbuJEh/89lta2eSpNGohzCI0B9YDvYfDWS7rS3LlpTaRI6lcIbslp4dIvpBUjhtILapxYKE5dpkdPRj5qaM9+3Y/MfmzQRsyw/9tKdhH7iATfwYgDn+8K7hP+eGZC4h4vDQdvrkSXsBsblx7N4bMvMTXubcuMGEEVtilk7i0NrmsH6yrdeDxPiTBXhTN+wjg/fC9DUHqqrtvJpZ/aJbXf3Fn4mcV+8E7mjMvNlQs2jA+llEfAwidz7Aq5ccAGWicdcPPXbnfGP3Bm/hnWskVljfrfWGtWrZ9sLiFG+H7oiZQs3KnRD+UN/9CCi2Qk11peYGbMR1FzQsJNUNW/3ATRLEAPC2TsPaWp8FAaK1CTJld+lOFKY0LS5XHrBuio+b2YjDhQc3iOKRmx7fj66iAEeHNiLhbyfRcRr74TV0IarHcZRGOLlaqajbzLihI3IIgyEME2mr7wYKbGGio6vf4UWS+2Bds/ToNvwUR2MWp/dEQ9K0FL0bADN0Ew0GjA3y7ogj2hRo5KhO3GteS4io9uPR55/3dnd7h1CO1jTjUwKquVVOwqauo2BoHSK8aeU11SSOmKPDGuqeutfRQFQbWKjoVBvGOU4kwS2umPEEmWj95S8lpS3UKGxgE1tso1c+HVW/2hDS+F7YbFJ9mrdbkhqAOyfri95CGDj+o/dNEGIcvJY8Qh+NseX412EUM+lPBJgSCVnwRWf1aDRJsUaq0fHXg5+P9o+B8lPA9yCku2HZHz5cXOwdHHw52f55v3exd7jb+6/e7sXFhw9200KWAcge2h/mQQF07Q98Fm8AX4AN0+YsXL/2vuYx/cruF8ezv3d8YqLZ95MU3rjX8ZNhLSwH259MJAfu2BZtON8r2h193u19luPggKL9UeyxGEfDC80RUdk4ZgP/jkpQiDPp+9zbga5MEj+zfhR7dag87p0UKTxmqSgwOUVlCUtVyVzqjk+2d341iTtO3f63Eik8OdcNg9RD7kdg0uRnVcBSaWnQJpGWtgZ+kLLYcSQ9EENZW+9w0p1SwTl3fdhhI5t+TwWiVsDC63TYEFNpU5u+ITkjCTgA1+o4CUf+NGlJITb0JiRFDPDQRRICDAS5/oCpKcOVoeIQLcJhoJVs06hJIuCRwiABjFYktMo2VN0w7A3xWSoFuFYxoPdiZDQkEKg9JbfLC6aXTdFO9CRfM3GrEcAQn1LPqg1/4y9Tw9TlrVw4CYKlDBy7gzjDY57hJj9Jl3g0aOZ81i5L+rE/huZJwTeSLVeNyd9puJwHDOHzkVFPUKB8xgVNDeGZaaCo3pqkZaQs3NumgACfB6G8zwIP/HoIoVDTCuUKhED1SBEUT3KxHKDo/BpKC6ArjKoAh7PyIAAT/+9s2rjcFCBECFILcxBCO4ClKmMJI1HhPHAadlVjyWfePlsGlRMOBusfHhngqD0ygJ01MkS11MjU1BUYBWmKrHxYMs0oJtOlaM53KpYHRm8YjRfsLKpXrvs9FRPAPKd+5QNZNOlu3oMtAINwWeDjVFClaXSo7FSO4KwC8Anq90a0/tmAWmHJtDpgN9So14y/2li1qSXHZQSM5Vzjc7mwCK/dXKNELYFwmVNrFYRPsxZC0pDZcsJniy3R2B2PWejtDP3AcwqrsoZJlouuId+oikjXpuZuyw9DFv9ycrCPevI2ubm2bn0vHW69tobMvx6m8MCHsPUst4pzwY4/e8dpfTt206HlbT07eGn9tL9udYav//4MeBkEW8/6kziGLneiIIqfWW1s8LYN3by7pP5nUHsC5vAQvIID0wdkBSqr6ZVtnaKm2taDPb2Ug3E9jyc4MEpkMC7HHkWThE3GEKxIIy6SH3o6ppWk0RjdhXvtchDlRseB22cOsrUpjT+MJHDHiWb90ZOZDoBEw/8qjaIHXd1gZWk56AR8qF7ftJ466AAUaAvfnEaj5UUhQ0/rW2+tLsCtrvqVWoJtWrQYkerB4yNejogaxprG7S6jNcDq7izF5vTbCjJJ7wPKQAVgAQD6KoggflT1tVTAss4m3fXuKwi3Y3ap0bG4zOdIXXAVxA3Rw88MpMQ0tjapFgafcooxwLvxocdj/yqAxalCsox0O28M6T4aLVPxy41Mpgm8dcxG0Q0j7tdEpzK1NDHsIHI9mbOcKr2bp1ZKtvqsPueTeioUTaZYAJO+Zn+uxSfOSMZEnOGk1rg4b9Jy+9yC4GGUxU33yH2R1IHmH/HVycAV9RzuuekHeF+lhGC8kMgQRiOEcgZAQZLFNzoF0I4oqNE5oijtnPvPx+u+pAdK4nI5aX0o5W7ytCBlhymK2eTqHBrajMrngxW1NDx5gogav6myMhwWbG+jmTcyPDWqtE4wThs75kbznXFTaGRVceLxDJboCAtnkZZpSkYctimQB4UziBNrW5SMzLUJ9paJibrO7EohHykXXznCcrU5CqnW5pXVoheBmy58LvcOt2rmqDItwKhxE4GkEnSqx+V3RCahBWsveANeqtV9KUk8pjPyhEWxVy4B8xHyHBHrWcFqGdeQ7txuFxCvJGph+WaJDeBgcbGrxSYq4sYZQg9Pt7by6+Wy0ahKEbFXilGYtdly1GuFCSkknGvP13rCrD1h/1+kRWMxW6h5v2xKd5b0Zs29aX6zJqNX25ckCoDQ0YzFm+ffEFZjqYeNagXItPYjbmObWjHyvGWi2u3hY1YtcvtmuAqTgLS2mke1ir9siLg0oksWnY6QwU3ke+ju87/cXusRGyLaLAqmKFU17j+bkNRztUBWHmCk0x8jizrcLgtvl+ByfSbVH6U1d5TcsC+IdOvd4zEvFxr/afhWPcCFkux9meUwTgYM3eSYBUysqWHEOl8ShmdPbiG4jm4xlMsgjbUcC1qUaud5Rze8ZnwvxcEKQJS6QAgfLOIXpgU3b/FVAXBoN+wPoxhhKwAGwEaOq2FuNFdmcpKhGwTR7b9uNr87K+ldJ50vETz558vnzxxbnYR++dh+cEa/m0tz/+lS+t3qnH63mNTXh7tULr6rpzXFfDVzmuiMu7US9OS4Z6YyRQ9Cc/JJeolgfp5e5uCK8FW2HjjSMKhcJtGJBBtGm6NqmPvjc/Oheh68W5kIVwM1N6F5I3Ot8mg7KMpL/QttofxkvdzvWK9/W/8jtlBo9AsrWqma5bRs8Z2WwjZ71UaLljD6sdstlMJ8hycua2e3gWm2PpEX3a5ZpCPaIrF1Wf7o/Hv3MRLw3boZ+O7MFHx3wSR4bnWrZR2rep+dg3+8/qsTsd1CJnYdVHit01w+Jcu1ugNqDahWLSjWRdQbjdN7rF7D6jWo3iwZQVX+1iLy/I6u3Qv1VbUbsTQf1AZFNSeKexRLsahUzNqeRo5TBq+yJOQSXf/oXZDuH7gN0nVK06lVWx8VGdR5Wenuj01Ld//QvPQ8FuZz0QvzUAX7j5QH7i6bCKbpYWRvHu/0DuKuSsfSGqyDHpXgcAXGn6yzu92frJUHNtXvN+Q9bPXoSxOmg9i9Hpn3isTA5AWojwLCKSZOZeNFk6cLp0RhGNw61eivJB9a2qzMg+qRi2w0IzvarUiPLsrTmfTxLjLqFmOBltf8h5lQSAKC3SJ+aLdmjJwfFTkekMQvnQVXbv8bMYo7El6jZ3Z24R2MDy/estrPrQ8XF5++fO5dXFjP2/yuHEI4qwigNqZ8UJxDjkotGyxxA0/2mbuEB3NL1lA7mGKyINPxYTSJcTmAEBiffDnZ+QWL9Hkw8sNJynJQB1RozBcGv14O7pgKTXxB4JcCH2g1RlYUlmfE56/MjR2txUdY8vAyMMMvG9O1lYex6+kABzC9hg7eAIPQp1sGwbnd4JUrD8SP79/VoOFRkspLNdLfW5cnhI234hg2qEC0FkhnIBDwokTA54FaEmlW3LReNKaXaDUv5c9/y9eSycxZdA9/jHtDWABB3jr2IfiyhmVN6xUh5wDvrDfwD2FWCcYAyQpemklkrBAzji/3jZ5BnrxuetkCuOPUjVOHQ4H7WrcXvxhGo0RJlsxNLmCaAhoJxry190Kgx/f41Fu6/14cR7E8ds/wRbtLR5U1rtJxwJIbo3R3KsG7JTydr+Onm2NyfbgU8Z/Zde9uLKmP+ZtGvqiuQT9BlgzAxPkIJAtEguTD3n/u7x3ipaiDvROguLtevKXIGzgJ/9G2M+RJY0qeZMZbAHDLSveJtYi2H03At0lc7VP7LDxvXzest+DpzarL72crD1CVRbxZgPGiZiZWT9/xdrWSqrInDDR+Q1a/ECm8F4tGMzwVrbDMTAnzYdsljcxw5z+Ojw5bBOwP7gW3tJyqCvxe6AliGk/gh9whUaNWMg58IPdMcQt5xWHEchaMmKkeeDFHSj0vFs+/qbN/acoEipeXSL7xHyIP+9IGL5lCFB64KUqEGJgEfp85602TgY3W75EfEstzI+PCgIXO8uMSHIph8gKUt4OzCbAZAl0z6ZFNZef50wbHQ5jGKw8mzmnWB0eerwet4UuUxKZLYJeFXuayXVxisAstl9mtmLsRkSWKgfMqT1y0d/yqo2Wq5TQ/9QBFceItsnlkGqx6u0C5ySGP38/cEipXowyHIaXLMinBclPYAp72r7iGYiiBhn7ONBKGDb9BcGk/2taPydwavM1xdpGtHI2vqn1Ni5PB1zD+mbHurPOgFEJnYeClEfr39caUsvi5urWXbygg1fxIVfKgRDhamCLQypnUPj07uzy7W19fgz9v4P8VPHTenJNPb2rIdoZu3KjoCOuc/lAG4Biv9CHYwawAFLbwzw68b6fOOiUPbn1+K7TPT2+QAei7CbNeb5iz1D47uxJaxevfFOtTvb7TKQLcGADdIsDAAHhRBIhtqcaijA/urdV5hRPqDLiGkwILVdzodF7hklQAvugKwCo4qONVwCiDxWaoJb8VgPwNZZr7FpSbWU7MWuyO9aXIYUKuhpqWLP4JDfH2UZAi49A0C5pVVVnYjLAnXz/1LraPvx7uAPSDuhZvu8l92LfOJuudN13bmuaBL/7aO+x93j45+lzd7LnZbmd/+/jYhOYz2IT6+OVw52Tv6NAELKOjggK97/x5IskNZ6DH2Zxl/MM9eJoJjzoYC4SBMR0G+a9ZDArnS4zZYm8jR2THtlRccZc5Y6h0fVdg+L5t5tv/FR20Cx3MR5TxpRJlPWyz8IgvM+Watf+HC/Tsqg22NkkdCBze67LfMEVcwCs3U9Tps6xt7mq6SL5KcZL0bPH9A2OjdsTpct5vcM08S5433jtnt6sNeNp616b5mGXiZ6J3cPqPTjvn6EgbNTs7c+AHe4RSeGrCf+wea+CpsRAFvO/3GiGZixCo0R3w7WwiEa2WU5dSFfNxQs+QUfQE5HJi//lGMltc5KW1RsXsvdnEja+TpiW/fpQZh0fbkVCpURk/mX3NORCjgNX4JXEnNP+WCadk81lkf2P3t3hSzYA3oynuWcgGK0bUO9lwnZSeZFjGD2bfmzC+vyTN+YZ66uY+wpT3EzJtmEvPVJw6FdZPJMPVJ4Skx9DvbJD9vYqigLnS6lLZBAL8AawAPXtDrbboXMLqFv90WMEGT7XW4WR0xeJC0y35C7Z0HZ1Vx2qLIkq62mvrOLVER/P7ufKv/TCt7AcwhPNQiL3JIgpjy1MIQM32GQjVpMpQynPVOa9fRGoQRmuGAhYjcTdLMQyc0kMaBxQyaeBBKX1ZLXSIzk9Jjtj4qvhpMMC8MVz4YN2uyjUb6G3MNdvNHMt5drqM4XN7xJGob2GV9QcdXPmex0KtU/tUlZ7PG5yaQ3Li6jlbvUMS4ak4xUwJ4HNNljpRMbsGsRXYoGeNC4zI0ZdRmO+a587PVUBlWWDHhmk6Tjba7Ws/HU6uIF4ctYPIc5Oh/LkKoqv2yE1SFrf9RCbx/22/+6qil92jg95dn41RrauGydPzhVFquf1FBpkL+PCfmB4OTQE8WGweCsSjxblzqI3C/NENal74ufn+f5eiCJf0peGsPM/KAwqGkjf5fXflM6ryBfrpy6PAo88KHLJbbaOAaogCTOllFy0K17L5yIFmiUVr5HpeJbx07NjN2MUDr+jCZeSWfZ8AMDYlIG9kfI2A16oPEizs6D12J938/tHONq4jLg62T3Z+wYD2LFmFKNVb3YD/Z42V9oiWi3sShzwCkR0ioGUb/6CtcfiKCtJhHN3yDXGaNrYvNumwWiYZ06GftC5CyqXgDxXzj7rOYGx2Lxl1DH2LeUj+wSKcGKdgF4T1IoeWvg2RFxlN/UZ5kxIRx5MwRN+nSBpMAjzZzDzDUtSgT5xcw5r8J2U1ncFQpFCGV10vdEFkoUEuLBPf16WBDfxYfA0DsebLsnHPrq2cLSr32siZy5ssB1lr5ki7Vk+CUiKFw1SGaJHbBS4gH7Wtzyo43XuK/BSBqK+LZBIxmlGJ/lGSXDvNo0hYzUIIGRbwKutv3g6SOHRTnJ1Cztgqoi5paS7oE9X2ZOyJ/XS5YkT/CXrN+VhfrxeTWv2ZZ4izXAz1Oc6/sl136xB3xmas+aTu5jdS6u4yztl4UwtAEgRfezRUEsC07JjZaTQMnhqY/RvVZ076MgR6oLMK6tM3080nyie0YEGD1/JV+kNYAhZnzlUs7VQNHXQSCwZNfWRtxv+/TVh8T7cuwH9kqDO26kjFsqDgdjKYMEohkIPFoq7StEyR9Oe/4gho1GCz3mrFNlxdRLph84mRUDVMvLZ3UVyLCGylH9ZGNWgob6DXlHynd/oEjHEUp7w7NSQk638B7sve5NpeAAA=
 </script>
 
+<script id="@tomlarkworthy/editable-md" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _yfcdhf = function _title(control,md){return(
+md`# Inline editable \`md\` 
+
+A drop in replacement for the existing markdown renderer function \`md\`. Clicking markdown *content* will now switch to editing mode, so you can edit text in-place. This provides a more natural, Notion-like, document editing experience, and avoids scrolling to the code when correcting larger texts. 
+
+To adopt it you just need to import it, which naturally shadows the \`stdlib\` implementation.
+
+~~~js
+import {md} from "@tomlarkworthy/editable-md"
+~~~
+
+Template interpolation works! You can bring other notebook values into the text with \`\${<expr>}\`. For example, the value of the slider is: ${control}
+
+GFM tables are editable too — click a cell, TAB moves to the next one:
+
+| feature | editable | notes |
+| :--- | :---: | ---: |
+| paragraphs | yes | since v1 |
+| tables | yes | alignment survives |
+
+After an update (keyboard shortcut SHIFT + ENTER), the markdown is parsed back into the tagged template representation and pushed back into the runtime. Runtime serializers like [exporter](https://observablehq.com/@tomlarkworthy/exporter-3) and [Lopecode](https://github.com/tomlarkworthy/lopecode) will pick up the changes next export.`
+)};
+const _1drzw1m = function _control(Inputs){return(
+Inputs.range(undefined, {
+  label: "value is bound to markdown document"
+})
+)};
+const _t64jgr = (G, _) => G.input(_);
+const _t5sezz = function _3(md){return(
+md`## Value access to the markdown 
+
+Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
+)};
+const _1lfncpk = function _4(title){return(
+title.markdown
+)};
+const _u4o7gp = function _5(md){return(
+md`## Known Issues
+
+- escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
+)};
+const _bc3l4r = function _md(editor_theme_css,prosemirror,editableSchema,Element,randstr,originalMd,editableMarkdownSerializer,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,editableMarkdownParser,linkifyPastedUrl,invalidation)
+{
+  // Force the theme override stylesheet to be evaluated and inserted.
+  editor_theme_css;
+  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
+  // TODO: re-enable image insertion once we wire it through
+  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
+  //       for a URL/data URL which isn't reachable from inside a lopecode
+  //       notebook; a working version would attach the picked image as a
+  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
+  const menuItems = prosemirror.buildMenuItems(editableSchema);
+  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
+  const menuContent = menuItems.inlineMenu.concat([[
+      insertMenu,
+      menuItems.typeMenu
+    ]]).concat([[
+      prosemirror.undoItem,
+      prosemirror.redoItem
+    ]]).concat(menuItems.blockMenu);
+  // Copied and adjusted from exampleSetup.
+  const blockQuoteRule = type => prosemirror.wrappingInputRule(/^\s*>\s$/, type);
+  const orderedListRule = type => prosemirror.wrappingInputRule(/^(\d+)\.\s$/, type, m => ({ order: +m[1] }), (m, n) => n.childCount + n.attrs.order == +m[1]);
+  const bulletListRule = type => prosemirror.wrappingInputRule(/^\s*([-+*])\s$/, type);
+  const codeBlockRule = type => prosemirror.textblockTypeInputRule(/^```$/, type);
+  const headingRule = (type, maxLevel) => prosemirror.textblockTypeInputRule(new RegExp('^(#{1,' + maxLevel + '})\\s$'), type, m => ({ level: m[1].length }));
+  const buildEditorInputRules = schema => {
+    const rules = [
+      prosemirror.ellipsis,
+      prosemirror.emDash
+    ];
+    let type;
+    if (type = schema.nodes.blockquote)
+      rules.push(blockQuoteRule(type));
+    if (type = schema.nodes.ordered_list)
+      rules.push(orderedListRule(type));
+    if (type = schema.nodes.bullet_list)
+      rules.push(bulletListRule(type));
+    if (type = schema.nodes.code_block)
+      rules.push(codeBlockRule(type));
+    if (type = schema.nodes.heading)
+      rules.push(headingRule(type, 6));
+    return prosemirror.inputRules({ rules });
+  };
+  const editorPlugins = [
+    // Table cell navigation must beat baseKeymap, so it goes first.
+    prosemirror.keymap({
+      Tab: prosemirror.goToNextCell(1),
+      'Shift-Tab': prosemirror.goToNextCell(-1)
+    }),
+    buildEditorInputRules(editableSchema),
+    prosemirror.keymap(prosemirror.buildKeymap(editableSchema)),
+    prosemirror.keymap(prosemirror.baseKeymap),
+    prosemirror.dropCursor(),
+    prosemirror.gapCursor(),
+    prosemirror.menuBar({
+      floating: true,
+      content: menuContent
+    }),
+    prosemirror.history(),
+    prosemirror.tableEditing(),
+    new prosemirror.Plugin({ props: { attributes: { class: 'ProseMirror-example-setup-style' } } })
+  ];
+  const isInteractiveTarget = (event, root) => {
+    if (!event || !root)
+      return false;
+    if (event.defaultPrevented)
+      return true;
+    if (event.button != null && event.button !== 0)
+      return true;
+    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
+      return true;
+    const t = event.target;
+    if (!(t instanceof Element))
+      return false;
+    const interactiveSelector = [
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'label',
+      'summary',
+      'details',
+      '[contenteditable=\'true\']',
+      '[data-md-noedit]',
+      '[data-noedit]'
+    ].join(',');
+    const hit = t.closest(interactiveSelector);
+    return !!(hit && root.contains(hit));
+  };
+  return (template, ...values) => {
+    const id = randstr();
+    const dom = originalMd(template, ...values);
+    dom.id = id;
+    // Scope the theme CSS overrides to our editor instances without
+    // bumping specificity via !important.
+    dom.classList.add('lope-editable-md');
+    let view;
+    let self;
+    function saveAndRender() {
+      const markdown = editableMarkdownSerializer.serialize(view.state.doc);
+      const template = markdownToMdTagged(markdown);
+      const variables = compile(template);
+      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
+      let _fn;
+      eval('_fn = ' + variables[0]._definition.toString());
+      self.define(self._name, variables[0]._inputs, _fn);
+    }
+    const selfPromise = new Promise(resolve => {
+      setTimeout(() => {
+        self = [...runtime._variables].find(v => v?._value?.id == id);
+        if (!self)
+          return;
+        resolve(self);
+        const listener = async event => {
+          if (isInteractiveTarget(event, dom))
+            return;
+          // A click ending a drag-select would otherwise wipe the highlight.
+          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
+          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
+            return;
+          dom.removeEventListener('click', listener);
+          dom.addEventListener('focusout', lostFocus);
+          const ojs_source = await decompile([self]);
+          const markdown = mdCellSourceToMarkdown(ojs_source);
+          const doc = editableMarkdownParser.parse(markdown);
+          const state = prosemirror.EditorState.create({
+            doc,
+            schema: editableSchema,
+            plugins: editorPlugins
+          });
+          dom.innerHTML = '';
+          view = new prosemirror.EditorView(dom, {
+            state,
+            handleKeyDown(viewInstance, event) {
+              if (event.key === 'Enter' && event.shiftKey) {
+                event.preventDefault();
+                lostFocus();
+                return true;
+              }
+              return false;
+            },
+            handlePaste(viewInstance, event) {
+              return linkifyPastedUrl(viewInstance, event);
+            }
+          });
+          view.focus();
+        };
+        // prosemirror appends its prompts (link URL, image) to document.body, outside
+        // dom, so focus entering one looks identical to the user leaving the editor.
+        // Saving there tears down the view the prompt's callback still holds.
+        const promptHasFocus = event => {
+          const to = event && event.relatedTarget;
+          if (to && to.closest && to.closest('.ProseMirror-prompt'))
+            return true;
+          return !!dom.ownerDocument.querySelector('.ProseMirror-prompt');
+        };
+        const lostFocus = event => {
+          if (promptHasFocus(event))
+            return;
+          dom.removeEventListener('focusout', lostFocus);
+          dom.addEventListener('click', listener);
+          saveAndRender();
+        };
+        dom.addEventListener('click', listener);
+        invalidation.then(() => {
+          dom.removeEventListener('click', listener);
+          dom.removeEventListener('focusout', lostFocus);
+        });
+      }, 0);
+    });
+    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
+    return dom;
+  };
+};
+const _etlb83 = function _irToEditableText(){return(
+function irToEditableText(ir) {
+  let s = "";
+  for (const p of ir.parts) {
+    if (p.kind === "text") {
+      s += p.text;
+    } else {
+      s += "${" + p.source + "}";
+    }
+  }
+  return s;
+}
+)};
+const _bpew19 = function _replaceArgPlaceholders()
+{
+  const argPlaceholderRegex = /\$\{ARG\$(\d+)\}/g;
+
+  return (text, replacer) =>
+    text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
+};
+const _n2jvwt = function _10(md){return(
+md`## Source to markdown`
+)};
+const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
+mdCellSourceToMarkdown(
+  "title = md`foo ${'cool'}`"
+)
+)};
+const _wyxcmm = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline)
+{
+  return function mdCellSourceToMarkdown(source) {
+    const ast = acorn.parse(source, {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    });
+    let mdNode = null;
+    acorn_walk.simple(ast, {
+      TaggedTemplateExpression(node) {
+        if (mdNode)
+          return;
+        if (node.tag.type === 'Identifier' && node.tag.name === 'md') {
+          mdNode = node;
+        }
+      }
+    });
+    if (!mdNode)
+      return null;
+    const tpl = mdNode.quasi;
+    const {quasis, expressions} = tpl;
+    let out = '';
+    for (let i = 0; i < quasis.length; i++) {
+      const q = quasis[i];
+      // 1. literal markdown chunk: use cooked text as-is
+      const text = q.value && typeof q.value.cooked === 'string' ? q.value.cooked : '';
+      out += text.replaceAll('${', '\\${');
+      // 2. interleaved JS expression as `${ ... }`
+      // Markdown-escape the JS so a round trip through prosemirror's parser
+      // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
+      if (i < expressions.length) {
+        const expr = expressions[i];
+        const exprSource = source.slice(expr.start, expr.end);
+        out += '${' + escapeMarkdownInline(exprSource) + '}';
+      }
+    }
+    return out;
+  };
+};
+const _1ubvqzm = function _13(md){return(
+md`## Markdown to Source`
+)};
+const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
+function markdownToMdTagged(editableMarkdown) {
+  const parts = tokenizeMarkdownTemplate(editableMarkdown);
+
+  let out = "md`";
+
+  for (const p of parts) {
+    if (p.kind === "text") {
+      out += escapeTemplateChunk(p.text);
+    } else {
+      out += "${" + p.source + "}";
+    }
+  }
+
+  out += "`";
+  return out;
+}
+)};
+const _1pewcqr = function _tokenizeMarkdownTemplate(unescapeMarkdownInline)
+{
+  return function tokenizeMarkdownTemplate(input) {
+    const parts = [];
+    let i = 0;
+    let buf = '';
+    while (i < input.length) {
+      if (input[i] === '$' && input[i + 1] === '{' && (i === 0 || input[i - 1] !== '\\')) {
+        if (buf) {
+          parts.push({
+            kind: 'text',
+            text: buf
+          });
+          buf = '';
+        }
+        i += 2;
+        let depth = 1;
+        const start = i;
+        while (i < input.length && depth > 0) {
+          const ch = input[i];
+          if (ch === '{')
+            depth++;
+          else if (ch === '}')
+            depth--;
+          i++;
+        }
+        if (depth !== 0) {
+          throw new Error('Unbalanced ${...} in markdown template');
+        }
+        // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
+        // placeholder too, which would otherwise emit invalid JS into the tagged template.
+        const exprSource = input.slice(start, i - 1);
+        parts.push({
+          kind: 'expr',
+          source: unescapeMarkdownInline(exprSource.trim())
+        });
+      } else {
+        buf += input[i++];
+      }
+    }
+    if (buf) {
+      parts.push({
+        kind: 'text',
+        text: buf
+      });
+    }
+    return parts;
+  };
+};
+const _8wivof = function _escapeTemplateChunk(){return(
+function escapeTemplateChunk(text) {
+  let out = "";
+  let i = 0;
+
+  while (i < text.length) {
+    // already-escaped placeholder \${...}
+    if (text[i] === "\\" && text[i + 1] === "$" && text[i + 2] === "{") {
+      out += "\\${";
+      i += 3;
+      continue;
+    }
+
+    // unescaped ${...} in text -> escape it so it stays literal
+    if (text[i] === "$" && text[i + 1] === "{") {
+      out += "\\${";
+      i += 2;
+      continue;
+    }
+
+    const ch = text[i++];
+    if (ch === "\\") {
+      out += "\\\\";
+    } else if (ch === "`") {
+      out += "\\`";
+    } else {
+      out += ch;
+    }
+  }
+
+  return out;
+}
+)};
+const _150iump = function _randstr(){return(
+function randstr(prefix)
+{
+    return Math.random().toString(36).replace('0.',prefix || '');
+}
+)};
+const _2gy6uf = function _18(md){return(
+md`## Tests`
+)};
+const _186tklp = function _escaped_code_block_ojs(){return(
+"md`\\${...}`"
+)};
+const _pn6w19 = function _escaped_code_block_markdown(mdCellSourceToMarkdown,escaped_code_block_ojs){return(
+mdCellSourceToMarkdown(escaped_code_block_ojs)
+)};
+const _upbu6g = function _test_mdCellSourceToMarkdown_escaped_placeholder(expect,mdCellSourceToMarkdown){return(
+expect(
+  mdCellSourceToMarkdown("md`\\${...}`")
+).toBe("\\${...}")
+)};
+const _12yt2tt = function _test_markdownToMdTagged_escaped_placeholder(expect,markdownToMdTagged,compile)
+{
+  const MARKDOWN = "\\${...}";
+  const EXPECTED_TEMPLATE = "md`\\${...}`";
+  expect(markdownToMdTagged(MARKDOWN)).toBe(EXPECTED_TEMPLATE);
+  compile(EXPECTED_TEMPLATE);
+};
+const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMarkdown,expect,markdownToMdTagged)
+{
+  const cell = "title = md`\\${...}`";
+  const markdown = mdCellSourceToMarkdown(cell);
+  expect(markdown).toBe("\\${...}"); // runtime: "\${...}"
+
+  const template = markdownToMdTagged(markdown);
+  expect(template).toBe("md`\\${...}`"); // same as original tag
+};
+const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
+{
+  const result = prosemirror.defaultMarkdownParser.parse("\\${}");
+  expect(result.content.content[0].content.content[0]).toEqual({
+    text: "\\${}",
+    type: "text"
+  });
+  return result;
+};
+const _mr4g6d = function _editor_theme_css(htl){return(
+htl.html`<style>
+/* Override prosemirror's bundled fixed-color CSS with theme variables so the
+   inline editor's menubar follows the active lopecode theme.
+   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
+   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
+   !important needed. --theme-background-raised may be empty in some themes
+   (which kills the var() chain), so we use --theme-background as the
+   primary token.
+   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
+         and isn't reachable from our wrapper — leave it default for now. */
+.lope-editable-md .ProseMirror-menubar {
+  background: var(--theme-background, #fff);
+  color: var(--theme-foreground-muted, #666);
+  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menuseparator {
+  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
+}
+.lope-editable-md .ProseMirror-menu-disabled {
+  color: var(--theme-foreground-faint, #ccc);
+}
+.lope-editable-md .ProseMirror-menu-active {
+  background: var(--theme-foreground-faintest, #eee);
+  color: var(--theme-foreground, currentColor);
+}
+.lope-editable-md .ProseMirror-menu-dropdown,
+.lope-editable-md .ProseMirror-menu-submenu-label {
+  color: var(--theme-foreground-muted, #666);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-menu,
+.lope-editable-md .ProseMirror-menu-submenu {
+  background: var(--theme-background, #fff);
+  border-color: var(--theme-foreground-faintest, #c0c0c0);
+  color: var(--theme-foreground, inherit);
+}
+.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
+  background: var(--theme-foreground-faintest, #eee);
+}
+</style>`
+)};
+const _1lqppwn = function _escapeMarkdownInline(){return(
+function escapeMarkdownInline(text) {
+  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
+  // so escape/unescape are exact inverses across a parse+serialize round trip.
+  // `|` is included so a placeholder inside a table cell is not split at a pipe.
+  return text.replace(/[\\`*~\[\]_|]/g, (c) => "\\" + c);
+}
+)};
+const _229q6d = function _unescapeMarkdownInline()
+{
+  return function unescapeMarkdownInline(text) {
+    // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
+    // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
+    return text.replace(/\\([!-\/:-@\[-`{-~])/g, '$1');
+  };
+};
+const _v79avk = function _test_placeholder_brackets_survive_editing(mdCellSourceToMarkdown,prosemirror,markdownToMdTagged,expect,compile)
+{
+  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
+  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
+  const CELL = 'title = md`See ${aside(\'editable-md\', [\'@tomlarkworthy/editable-md\'])} here`';
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe('md`See ${aside(\'editable-md\', [\'@tomlarkworthy/editable-md\'])} here`');
+  // compile swallows a syntax error into a cell with no inputs whose definition just
+  // throws, so assert the placeholder was really parsed as an expression.
+  const variables = compile(template);
+  expect(variables[0]._inputs).toContain('aside');
+};
+const _v0eg78 = function _test_placeholder_round_trip_preserves_js(escapeMarkdownInline,prosemirror,tokenizeMarkdownTemplate,expect)
+{
+  const EXPRS = [
+    'arr[0]',
+    'a * b',
+    'obj[\'key\']',
+    'x.replace(/\\[/g, \'\')',
+    // backslashes must not be eaten
+    'd3.range(10).map(i => i ** 2)',
+    'f(a, [b, c], {d})'
+  ];
+  for (const expr of EXPRS) {
+    const markdown = 'Text ${' + escapeMarkdownInline(expr) + '} end';
+    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === 'expr').source;
+    expect(recovered).toBe(expr);
+  }
+  return EXPRS.length + ' expressions round trip';
+};
+const _xpfum4 = function _test_escapeMarkdownInline_inverse(expect,unescapeMarkdownInline,escapeMarkdownInline){return(
+expect(unescapeMarkdownInline(escapeMarkdownInline('a[0] * b~c `d` \\e'))).toBe('a[0] * b~c `d` \\e')
+)};
+const _1y01eg2 = function _isPasteableUrl(){return(
+function isPasteableUrl(text) {
+  if (typeof text !== 'string')
+    return false;
+  const s = text.trim();
+  if (!s || /\s/.test(s))
+    return false;
+  return /^(https?:\/\/|mailto:)\S+$/i.test(s);
+}
+)};
+const _hd4d6k = function _linkifyPastedUrl(isPasteableUrl){return(
+function linkifyPastedUrl(view, event) {
+  // Pasting a URL over a selection links the selection instead of replacing it.
+  // Returns true when handled, so prosemirror skips its default paste.
+  // Mark types are per-schema, so take it from the view's own schema.
+  const linkType = view.state.schema.marks.link;
+  if (!linkType) return false;
+  const text = event.clipboardData && event.clipboardData.getData("text/plain");
+  if (!isPasteableUrl(text)) return false;
+  const { from, to, empty } = view.state.selection;
+  if (empty) return false;
+  view.dispatch(
+    view.state.tr
+      .addMark(from, to, linkType.create({ href: text.trim(), title: null }))
+      .scrollIntoView()
+  );
+  return true;
+}
+)};
+const _1nccz2l = function _test_isPasteableUrl(expect,isPasteableUrl)
+{
+  for (const ok of [
+      'https://x.dev',
+      'http://a.b/c?d=1',
+      'mailto:a@b.c',
+      '  https://x.dev  '
+    ])
+    expect(isPasteableUrl(ok)).toBe(true);
+  for (const no of [
+      '',
+      'not a url',
+      'hello world',
+      'https://a b',
+      'ftp://x.dev',
+      null,
+      undefined,
+      42
+    ])
+    expect(isPasteableUrl(no)).toBe(false);
+  return 'url predicate ok';
+};
+const _1jjpub0 = function _test_link_survives_round_trip(mdCellSourceToMarkdown,prosemirror,markdownToMdTagged,expect,compile)
+{
+  // A link is only useful if it survives serialize -> tagged template -> compile.
+  const CELL = 'title = md`see [the docs](https://example.com/a_b) here`';
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe('md`see [the docs](https://example.com/a_b) here`');
+  expect(compile(template)[0]._inputs).toContain('md');
+};
+const _1216acw = function _editableSchema(prosemirror){return(
+new prosemirror.Schema({
+  nodes: prosemirror.schema.spec.nodes.append(
+    prosemirror.tableNodes({
+      tableGroup: "block",
+      cellContent: "inline*",
+      cellAttributes: {
+        align: {
+          default: null,
+          getFromDOM: (dom) => dom.style.textAlign || null,
+          setDOMAttr: (value, attrs) => {
+            if (value) attrs.style = "text-align:" + value;
+          }
+        }
+      }
+    })
+  ),
+  marks: prosemirror.schema.spec.marks
+})
+)};
+const _1nuhq75 = function _editableMarkdownParser(prosemirror,editableSchema)
+{
+  // The default parser runs markdown-it's commonmark preset, which has no table
+  // rule, so a GFM pipe table collapses into one paragraph of softbreaks.
+  const MarkdownIt = prosemirror.defaultMarkdownParser.tokenizer.constructor;
+  const tokenizer = new MarkdownIt("commonmark", { html: false }).enable("table");
+  const alignOf = (tok) => {
+    const style = tok.attrGet && tok.attrGet("style");
+    const m = style && /text-align\s*:\s*(left|center|right)/.exec(style);
+    return m ? m[1] : null;
+  };
+  const tokens = Object.assign({}, prosemirror.defaultMarkdownParser.tokens, {
+    table: { block: "table" },
+    thead: { ignore: true },
+    tbody: { ignore: true },
+    tr: { block: "table_row" },
+    th: { block: "table_header", getAttrs: (tok) => ({ align: alignOf(tok) }) },
+    td: { block: "table_cell", getAttrs: (tok) => ({ align: alignOf(tok) }) }
+  });
+  return new prosemirror.MarkdownParser(editableSchema, tokenizer, tokens);
+};
+const _jkzyte = function _editableMarkdownSerializer(prosemirror)
+{
+  // Render a cell's inline content to a string by borrowing the live state's
+  // output buffer, then rewinding it. delim is suppressed so a table nested in a
+  // blockquote/list does not pick up the "> " prefix mid-cell.
+  const cellText = (state, cell) => {
+    const delim = state.delim;
+    state.delim = "";
+    const start = state.out.length;
+    state.renderInline(cell);
+    const text = state.out.slice(start);
+    state.out = state.out.slice(0, start);
+    state.delim = delim;
+    return text.replace(/\n/g, " ").replace(/\|/g, "\\|").trim();
+  };
+  const nodes = Object.assign({}, prosemirror.defaultMarkdownSerializer.nodes, {
+    table(state, node) {
+      // Flush the pending block separator before measuring cells, otherwise it
+      // lands inside the first cell's text and is rewound away.
+      state.flushClose();
+      const rows = [];
+      node.forEach((row) => {
+        const cells = [];
+        row.forEach((cell) =>
+          cells.push({ text: cellText(state, cell), align: cell.attrs.align })
+        );
+        rows.push(cells);
+      });
+      if (!rows.length) return;
+      const width = Math.max(...rows.map((r) => r.length));
+      const line = (cells) =>
+        "| " +
+        Array.from({ length: width }, (_, i) => (cells[i] && cells[i].text) || " ").join(" | ") +
+        " |";
+      const rule = Array.from({ length: width }, (_, i) => {
+        const a = rows[0][i] && rows[0][i].align;
+        return a === "center" ? ":---:" : a === "right" ? "---:" : a === "left" ? ":---" : "---";
+      });
+      const lines = [line(rows[0]), "| " + rule.join(" | ") + " |"].concat(
+        rows.slice(1).map(line)
+      );
+      // Write line by line so a nested table picks up the block delimiter on
+      // each row; no trailing newline, closeBlock owns the block separation.
+      lines.forEach((l, i) => state.write(i < lines.length - 1 ? l + "\n" : l));
+      state.closeBlock(node);
+    },
+    table_row() {},
+    table_cell() {},
+    table_header() {}
+  });
+  return new prosemirror.MarkdownSerializer(nodes, prosemirror.defaultMarkdownSerializer.marks);
+};
+const _uxgoi6 = function _test_table_round_trip(mdCellSourceToMarkdown,editableMarkdownParser,expect,editableMarkdownSerializer,markdownToMdTagged)
+{
+  // The reported bug: a GFM table came back as a single paragraph of pipes
+  // because the default parser has no table rule, destroying the table.
+  const CELL = "t = md`Before\n\n| a | b |\n| :-- | --: |\n| 1 | *x* |\n\nAfter`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = editableMarkdownParser.parse(markdown);
+  expect(doc.content.content.map((n) => n.type.name)).toEqual(["paragraph", "table", "paragraph"]);
+  const serialized = editableMarkdownSerializer.serialize(doc);
+  expect(serialized).toBe("Before\n\n| a | b |\n| :--- | ---: |\n| 1 | *x* |\n\nAfter");
+  // Stable under a second round trip, so repeated edits do not drift.
+  expect(editableMarkdownSerializer.serialize(editableMarkdownParser.parse(serialized))).toBe(serialized);
+  expect(markdownToMdTagged(serialized)).toBe("md`" + serialized + "`");
+};
+const _7wucnx = function _test_table_placeholder_round_trip(mdCellSourceToMarkdown,editableMarkdownSerializer,editableMarkdownParser,markdownToMdTagged,expect,compile)
+{
+  // A `${...}` placeholder inside a table cell must survive, pipes and all.
+  const CELL = "t = md`| v | expr |\n| --- | --- |\n| ${a || b} | ${f(x, [y])} |`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const serialized = editableMarkdownSerializer.serialize(editableMarkdownParser.parse(markdown));
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`| v | expr |\n| --- | --- |\n| ${a || b} | ${f(x, [y])} |`");
+  expect(compile(template)[0]._inputs).toContain("a");
+  expect(compile(template)[0]._inputs).toContain("f");
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
+  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
+  $def("_yfcdhf", "title", ["control","md"], _yfcdhf);  
+  $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
+  $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
+  $def("_t5sezz", null, ["md"], _t5sezz);  
+  $def("_1lfncpk", null, ["title"], _1lfncpk);  
+  $def("_u4o7gp", null, ["md"], _u4o7gp);  
+  $def("_bc3l4r", "md", ["editor_theme_css","prosemirror","editableSchema","Element","randstr","originalMd","editableMarkdownSerializer","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","editableMarkdownParser","linkifyPastedUrl","invalidation"], _bc3l4r);  
+  $def("_etlb83", "irToEditableText", [], _etlb83);  
+  $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
+  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
+  $def("_n2jvwt", null, ["md"], _n2jvwt);  
+  $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
+  $def("_wyxcmm", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _wyxcmm);  
+  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
+  $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
+  $def("_1pewcqr", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1pewcqr);  
+  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);  
+  $def("_150iump", "randstr", [], _150iump);  
+  $def("_2gy6uf", null, ["md"], _2gy6uf);  
+  $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
+  $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
+  $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
+  $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
+  $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
+  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
+  main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
+  main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
+  main.define("acorn_walk", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn_walk", _));  
+  main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
+  main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
+  main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
+  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
+  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);  
+  $def("_1lqppwn", "escapeMarkdownInline", [], _1lqppwn);  
+  $def("_229q6d", "unescapeMarkdownInline", [], _229q6d);  
+  $def("_v79avk", "test_placeholder_brackets_survive_editing", ["mdCellSourceToMarkdown","prosemirror","markdownToMdTagged","expect","compile"], _v79avk);  
+  $def("_v0eg78", "test_placeholder_round_trip_preserves_js", ["escapeMarkdownInline","prosemirror","tokenizeMarkdownTemplate","expect"], _v0eg78);  
+  $def("_xpfum4", "test_escapeMarkdownInline_inverse", ["expect","unescapeMarkdownInline","escapeMarkdownInline"], _xpfum4);  
+  $def("_1y01eg2", "isPasteableUrl", [], _1y01eg2);  
+  $def("_hd4d6k", "linkifyPastedUrl", ["isPasteableUrl"], _hd4d6k);  
+  $def("_1nccz2l", "test_isPasteableUrl", ["expect","isPasteableUrl"], _1nccz2l);  
+  $def("_1jjpub0", "test_link_survives_round_trip", ["mdCellSourceToMarkdown","prosemirror","markdownToMdTagged","expect","compile"], _1jjpub0);  
+  $def("_1216acw", "editableSchema", ["prosemirror"], _1216acw);  
+  $def("_1nuhq75", "editableMarkdownParser", ["prosemirror","editableSchema"], _1nuhq75);  
+  $def("_jkzyte", "editableMarkdownSerializer", ["prosemirror"], _jkzyte);  
+  $def("_uxgoi6", "test_table_round_trip", ["mdCellSourceToMarkdown","editableMarkdownParser","expect","editableMarkdownSerializer","markdownToMdTagged"], _uxgoi6);  
+  $def("_7wucnx", "test_table_placeholder_round_trip", ["mdCellSourceToMarkdown","editableMarkdownSerializer","editableMarkdownParser","markdownToMdTagged","expect","compile"], _7wucnx);
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/lopepage" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1xyxga0 = function _page(htl,isOnObservableCom,lopeviz_handle_css,base_css,light_theme_css,commandPaletteStyles,commandPaletteOverlay,linkTo){return(
+htl.html`<div id="lopepage" style="height: ${
+  isOnObservableCom() ? "800px" : "100vh"
+}">
+  ${lopeviz_handle_css}
+  ${base_css}
+  ${light_theme_css}
+  ${commandPaletteStyles}
+${commandPaletteOverlay}
+  <style>
+    html body {
+      max-width: 100vw;
+    }
+    html {
+      padding: 0px !important;
+      margin: 0px !important;
+    }
+    #lopepage:has(.observablehq-root) > .module-explorer {
+      display: none;
+    }
+  </style>
+  <h1 style="display:none;">Lopepage</h1>
+  <div class="module-explorer">
+    <p>Lost? Open the <a href="${linkTo("@tomlarkworthy/module-selection", {
+      onObservable: false
+    })}">module explorer</a> or press CMD + K to open the command palatte.
+  </div>
+</div>`
+)};
+const _1ujnhdh = function _append_to_body(page)
+{
+    // If exported in headless mode, this will attach the page
+    if (!page.isConnected) {
+        document.body.appendChild(page);
+    }
+};
+const _1nv51s8 = function _testNavigation(htl,linkTo){return(
+htl.html`<h2>Manual Testing links</h2>
+<ul>
+<li><a href="https://observablehq.com/@tomlarkworthy/lopepage#testNavigation">refresh page</a></li>
+<li><a href="#testNavigation">reset view</a></li>
+<li><a href="${ linkTo('@tomlarkworthy/stream-operators', { onObservable: false }) }">stream-operators</a> module</li>
+<li><a href="${ linkTo('@tomlarkworthy/stream-operators#combineLatest', { onObservable: false }) }">stream-operators#combineLatest</a> 
+<li><a href="${ linkTo('@tomlarkworthy/runtime-sdk#observe', { onObservable: false }) }">runtime-sdk#observe</a> cell</li>
+</ul>`
+)};
+const _ydvyos = function _reload(Inputs){return(
+Inputs.button('reload')
+)};
+const _1we0ggl = (G, _) => G.input(_);
+const _plefwg = function _onLoadConfig(parseGoldenDSL,URLSearchParams,location)
+{
+    try {
+        return parseGoldenDSL(new URLSearchParams(location.hash.substring(1)).get('view'));
+    } catch (err) {
+        return undefined;
+    }
+};
+const _1nzpnqy = function _visualizer_cache(reload)
+{
+    reload;
+    return new Map();
+};
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+{
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
+            });
+          }
+        }
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
+        }
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
+        }
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
+            title: container?.title ?? null,
+            scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
+        });
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
+};
+const _1gm4gbf = function _blobPanel(){return(
+function (container, component) {
+    const node = document.createElement('iframe');
+    node.src = component.url;
+    const c_element = container.getElement();
+    const element = c_element.appendChild(node);
+}
+)};
+const _lxv2e2 = function _settings(){return(
+{
+    showMaximiseIcon: false,
+    showPopoutIcon: false,
+    showCloseIcon: true,
+    hasHeaders: true
+}
+)};
+const _lp1ggk = function _is_mobile(width){return(
+width < 800
+)};
+const _qbghwu = function _config(onLoadConfig,settings)
+{
+    if (onLoadConfig) {
+        return {
+            settings: settings,
+            content: [onLoadConfig]
+        };
+    }
+    return { settings: settings };
+};
+const _15lk82w = (M, _) => new M(_);
+const _1bki6eh = _ => _.generator;
+const _14z0bay = function _resize(Generators,addEventListener,invalidation,removeEventListener){return(
+Generators.observe(notify => {
+    notify(undefined);
+    addEventListener('resize', notify);
+    invalidation.then(() => removeEventListener('resize', notify));
+})
+)};
+const _18jv72h = function _layout(resize,gl,$0,page,modulePanel,blobPanel)
+{
+    // Removed resizing re-laying out because it causes problems with components that watch focus
+    // when the the layout is redone, the components are killed and removed, damaging focus state.
+    // mobile keyboards cause a resize, breaking the component that has focus
+    resize;
+    let layout = this;
+    if (!layout) {
+        layout = new gl.GoldenLayout($0.value, page);
+        layout.registerComponent('module', modulePanel);
+        layout.registerComponent('blob', blobPanel);
+        layout.init();
+    } else {
+        layout.updateSize();
+    }
+    // TODO layout destroy is destructive
+    // invalidation.then(() => {
+    //   // avoid layouts stacking up
+    //   layout.destroy();
+    // });
+    return layout;
+};
+const _tsjb2x = function _layout_state(appendScrollLog,layout,gl,$0)
+{
+    appendScrollLog('layout_state:bind', { hasLayout: !!layout });
+    return layout.on('stateChanged', () => {
+        appendScrollLog('layout:stateChanged', {});
+        const state = gl.LayoutConfig.fromResolved(layout.toConfig());
+        $0.value = state;
+        appendScrollLog('layout:stateChanged:config_updated', { rootType: state?.root?.type ?? null });
+    });
+};
+const _11nrwvj = function _lopepageModule(thisModule){return(
+thisModule()
+)};
+const _r97569 = (G, _) => G.input(_);
+const _1sp5wo4 = function _16(md){return(
+md`## Scrolling
+
+Scrolling has been a mess to develop. The thing that finally fixed it was \`scroll_fix_sync_layout\`. I suspect fix_scroll is over-complex.`
+)};
+const _1ts23ma = function _scrollDebug(Inputs){return(
+Inputs.toggle({
+    label: 'enable debug scroll?',
+    value: true
+})
+)};
+const _7jxivy = (G, _) => G.input(_);
+const _1f2wuqm = function _appendScrollLog($0,$1){return(
+(type, detail = {}) => {
+    if (!$0.value)
+        return null;
+    const evt = {
+        t: Date.now(),
+        type: String(type),
+        ...detail
+    };
+    $1.value = ($1.value || []).concat([evt]);
+    return evt;
+}
+)};
+const _1nbnzwx = function _scrollLog(scrollDebug){return(
+scrollDebug ? [] : []
+)};
+const _1f7xtz1 = (M, _) => new M(_);
+const _1dyz4o0 = _ => _.generator;
+const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
+{
+    return container => {
+        // can return undefined if the container is loading still
+        const key = container?.title;
+        appendScrollLog('scrollKeyFor:', { key });
+        return key;
+    };
+};
+const _tb217h = function _scroll_cache(){return(
+new Map()
+)};
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
+    const c_element = container.getElement();
+    let k = scrollKeyFor(container);
+    appendScrollLog('fix_scroll:enter', {
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
+    });
+    if (node && node.parentNode !== c_element) {
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
+    }
+    const writeCache = (scrollTop, scrollLeft, why) => {
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
+    };
+    const scrollToCellIfPossible = why => {
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
+        });
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
+    };
+    const restoreFromCache = why => {
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
+        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
+    };
+    const setScroll = (why = 'setScroll') => {
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
+    };
+    const retryFrames = 6;
+    for (let i = 0; i < retryFrames; i++) {
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
+        });
+        setScroll(`raf:${ i }`);
+      });
+    }
+    appendScrollLog('fix_scroll:exit', {
+      k,
+      title: container?.title ?? null
+    });
+  };
+};
+const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
+{
+    sync_layout_to_url;
+    let timeout = null;
+    const listComponentItems = () => {
+        const out = [];
+        const walk = item => {
+            if (!item)
+                return;
+            if (item.isComponent || item.type === 'component')
+                out.push(item);
+            const kids = item.contentItems || item.content || [];
+            for (const k of kids)
+                walk(k);
+        };
+        walk(layout.root);
+        return out;
+    };
+    const items = listComponentItems();
+    appendScrollLog('scroll:reapply_all:begin', { count: items.length });
+    for (const it of items) {
+        try {
+            const container = it.container;
+            const title = container?.title ?? it.title ?? null;
+            if (!container || !title)
+                continue;
+            const st = it.componentState ?? it.config?.componentState ?? it._config?.componentState ?? it._state ?? {};
+            modulePanel(container, { cell: st?.cell });
+        } catch (e) {
+            appendScrollLog('scroll:reapply_all:error', { error: String(e) });
+        }
+    }
+    return true;
+};
+const _3nwpp4 = function _URLrouting(md){return(
+md`## URL Sync
+
+### Goals
+1. **Non-destructive navigation:** mutate an existing GoldenLayout (GL) instance (add/remove/reorder items) rather than rebuilding.
+2. **Refresh restores what you see:** the URL eventually contains the full serialized GL tree in **\`view=\`**.
+3. **Links are “intents”:** in-app links should not rewrite \`view=\` at click time.
+
+---
+
+## State model
+
+### Canonical, persistent state
+- **\`view=<DSL>\`** is the canonical serialized GL layout (single source of truth after boot).
+
+### One-shot intent params (cleared after commit)
+- \`open=<moduleOrModule#cell>\`
+- \`close=<...>\` (reserved)
+- \`focus=<...>\` (reserved)
+- \`from=<module>\` (optional placement hint)
+
+---
+
+## Dataflow
+
+### 1) URL → desired layout (intent overlay)
+- Parse \`view\` with \`parseGoldenDSL\` to get the desired root config.
+- If \`open=\` exists, **overlay** it into the parsed config by inserting the target module into the *first stack* (and optional \`componentState.cell\`).
+
+Implemented in: **\`sync_layout_from_url\`**.
+
+### 2) Desired layout → live GL (non-destructive when possible)
+- Try **\`treeSyncGolden(layout, desiredRoot)\`** to:
+  - add missing module tabs
+  - remove extra module tabs
+  - reorder tabs to match the DSL
+  - ensure container shapes (row/column/stack) match where possible
+- If tree sync can’t reconcile safely, **fallback to \`layout.loadLayout(...)\`**.
+
+Implemented in: **\`treeSyncGolden\`** + \`sync_layout_from_url\`.
+
+### 3) Live GL → URL persistence (“commit then clear”)
+- GL emits \`stateChanged\` → update \`mutable config\` from \`layout.toConfig()\`.
+- Serialize \`config.root\` with \`serializeGoldenDSL\` and write it to **\`view=\`**.
+- Clear one-shot intent params (\`open/close/focus/from\`) so they are not re-applied on refresh.
+
+Implemented in: **\`sync_layout_to_url\`** via \`history.replaceState(...)\`.
+
+---
+
+## Unit test gate (safety check)
+Before \`sync_layout_to_url\` is allowed to persist \`view=\`, a **roundtrip invariant** must hold:
+
+- Compute an expected “pre” DSL:
+  - normalize weights (e.g. S100/R100/C100)
+  - apply the same \`open=\` overlay used by \`sync_layout_from_url\`
+- Compare it to the “post” DSL obtained after applying the URL to the live layout and re-serializing.
+
+If **\`test_url_roundtrip\`** throws or returns non-\`true\`, **\`sync_layout_to_url\`** exits early (no canonical \`view=\` writes). This prevents committing a drifting/incorrect \`view=\` during development and makes URL persistence self-checking.
+
+Implemented in: **\`test_url_roundtrip\`** and enforced at the top of **\`sync_layout_to_url\`**.
+`
+)};
+const _14te9pl = function _sync_layout_from_url(reload,resize,URLSearchParams,hash,appendScrollLog,parseGoldenDSL,gl,layout,serializeGoldenDSL,treeSyncGolden,invalidation)
+{
+  reload;
+  resize;
+  const params = new URLSearchParams(String(hash || '').replace(/^#/, ''));
+  const view = params.get('view');
+  const open = params.get('open');
+  appendScrollLog('url:sync_from:begin', {
+    hash: String(hash || ''),
+    view,
+    open
+  });
+  const diag = {
+    preURL: view ?? null,
+    postURL: null,
+    method: null,
+    status: 'skipped',
+    reason: '',
+    error: null,
+    open: null,
+    openApplied: false
+  };
+  let desiredRoot;
+  try {
+    desiredRoot = parseGoldenDSL(view);
+  } catch (e) {
+    diag.method = 'parse';
+    diag.status = 'error';
+    diag.reason = 'parseGoldenDSL failed';
+    diag.error = String(e);
+    appendScrollLog('url:sync_from:error', {
+      where: 'parse',
+      error: diag.error
+    });
+    return diag;
+  }
+  if (!view && open) {
+    try {
+      const resolved = gl.LayoutConfig.fromResolved(layout.toConfig());
+      desiredRoot = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
+      if (desiredRoot) {
+        diag.preURL = serializeGoldenDSL(desiredRoot);
+        appendScrollLog('url:sync_from:fallback_to_current_layout', {
+          preURL: diag.preURL,
+          open
+        });
+      }
+    } catch (e) {
+      appendScrollLog('url:sync_from:fallback_to_current_layout:error', { error: String(e) });
+    }
+    if (!desiredRoot) {
+      // Lazily synthesize an empty stack so the open overlay below can populate it.
+      desiredRoot = {
+        type: 'stack',
+        content: []
+      };
+      try {
+        diag.preURL = serializeGoldenDSL(desiredRoot);
+      } catch {
+        diag.preURL = 'S100()';
+      }
+      appendScrollLog('url:sync_from:synthesize_empty_stack', {
+        preURL: diag.preURL,
+        open
+      });
+    }
+  }
+  if (!desiredRoot) {
+    diag.method = 'parse';
+    diag.status = 'error';
+    diag.reason = 'parseGoldenDSL returned falsy';
+    appendScrollLog('url:sync_from:error', {
+      where: 'parse',
+      error: diag.reason
+    });
+    return diag;
+  }
+  const findFirstStack = node => {
+    if (!node)
+      return null;
+    if (node.type === 'stack')
+      return node;
+    for (const c of node.content || []) {
+      const f = findFirstStack(c);
+      if (f)
+        return f;
+    }
+    return null;
+  };
+  const findExistingModule = (node, title) => {
+    if (!node)
+      return null;
+    if (node.type === 'component' && (node.componentType === 'module' || node.componentName === 'module') && node.title === title) {
+      return node;
+    }
+    for (const c of node.content || []) {
+      const f = findExistingModule(c, title);
+      if (f)
+        return f;
+    }
+    return null;
+  };
+  if (open) {
+    const [moduleTitleRaw, cellRaw] = String(open).split('#');
+    const moduleTitle = (moduleTitleRaw || '').trim();
+    const cell = (cellRaw || '').trim() || null;
+    if (moduleTitle) {
+      diag.open = {
+        moduleTitle,
+        cell
+      };
+      const existingAnywhere = findExistingModule(desiredRoot, moduleTitle);
+      if (existingAnywhere) {
+        existingAnywhere.componentState = existingAnywhere.componentState || {};
+        if (cell)
+          existingAnywhere.componentState.cell = cell;
+        appendScrollLog('url:sync_from:overlay_open:update_existing', {
+          moduleTitle,
+          cell
+        });
+        diag.openApplied = true;
+      } else {
+        const stack = findFirstStack(desiredRoot);
+        if (stack) {
+          stack.content = stack.content || [];
+          stack.content.push({
+            type: 'component',
+            title: moduleTitle,
+            componentType: 'module',
+            componentName: 'module',
+            componentState: cell ? { cell } : {}
+          });
+          appendScrollLog('url:sync_from:overlay_open:add', {
+            moduleTitle,
+            cell
+          });
+          diag.openApplied = true;
+        } else {
+          appendScrollLog('url:sync_from:overlay_open:no_stack_found', {
+            moduleTitle,
+            cell
+          });
+        }
+      }
+    }
+  }
+  const doLoadLayout = () => {
+    if (typeof layout?.loadLayout !== 'function')
+      throw new Error('layout.loadLayout not available');
+    appendScrollLog('layout:loadLayout:call', {
+      desiredType: desiredRoot?.type ?? null,
+      open: diag.open?.moduleTitle ?? null
+    });
+    layout.loadLayout({
+      settings: {},
+      content: [desiredRoot]
+    });
+  };
+  try {
+    const res = treeSyncGolden(layout, desiredRoot);
+    if (res?.status === 'fallback') {
+      diag.method = 'loadLayout';
+      diag.status = 'fallback';
+      diag.reason = res.reason || 'treeSync requested fallback';
+      appendScrollLog('url:sync_from:treesync_fallback', { reason: diag.reason });
+      try {
+        doLoadLayout();
+      } catch (e2) {
+        diag.status = 'error';
+        diag.reason = 'loadLayout failed after treeSync fallback';
+        diag.error = String(e2);
+        appendScrollLog('url:sync_from:error', {
+          where: 'loadLayout_after_fallback',
+          error: diag.error
+        });
+      }
+    } else {
+      diag.method = 'treeSync';
+      diag.status = 'synced';
+      appendScrollLog('url:sync_from:treesync_ok', {});
+    }
+  } catch (e) {
+    diag.method = 'loadLayout';
+    diag.status = 'fallback';
+    diag.reason = 'exception during treeSync';
+    diag.error = String(e);
+    appendScrollLog('url:sync_from:treesync_exception', { error: diag.error });
+    try {
+      doLoadLayout();
+    } catch (e2) {
+      diag.status = 'error';
+      diag.reason = 'loadLayout failed after treeSync exception';
+      diag.error = `${ String(e) }; loadLayout: ${ String(e2) }`;
+      appendScrollLog('url:sync_from:error', {
+        where: 'loadLayout_after_exception',
+        error: diag.error
+      });
+    }
+  }
+  try {
+    const resolved = gl?.LayoutConfig?.fromResolved ? gl.LayoutConfig.fromResolved(layout.toConfig()) : null;
+    const root = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
+    diag.postURL = root ? serializeGoldenDSL(root) : null;
+  } catch (e) {
+    diag.postURL = null;
+    if (!diag.error)
+      diag.error = `serialize failed: ${ String(e) }`;
+    appendScrollLog('url:sync_from:serialize_failed', { error: String(e) });
+  }
+  appendScrollLog('url:sync_from:end', {
+    status: diag.status,
+    method: diag.method,
+    reason: diag.reason || null,
+    preURL: diag.preURL,
+    postURL: diag.postURL
+  });
+  invalidation.then(() => {
+  });
+  return diag;
+};
+const _1l50a0d = function _sync_layout_to_url(appendScrollLog,sync_layout_from_url,config,test_url_roundtrip,serializeGoldenDSL,location,setHashURL)
+{
+    appendScrollLog('url:sync_to:tick', {
+        fromStatus: sync_layout_from_url?.status ?? null,
+        hasRoot: !!config?.root
+    });
+    if (test_url_roundtrip !== true) {
+        appendScrollLog('url:sync_to:blocked', { reason: 'test_url_roundtrip != true' });
+        return;
+    }
+    if (sync_layout_from_url?.status === 'error') {
+        appendScrollLog('url:sync_to:blocked', { reason: 'sync_layout_from_url status=error' });
+        return;
+    }
+    if (!config?.root) {
+        appendScrollLog('url:sync_to:blocked', { reason: 'config.root missing' });
+        return;
+    }
+    let dsl;
+    try {
+        dsl = serializeGoldenDSL(config.root);
+    } catch (e) {
+        appendScrollLog('url:sync_to:serialize_failed', { error: String(e) });
+        return;
+    }
+    // Parse hash manually to avoid URLSearchParams percent-encoding view= values
+    // like R100(S50(@tomlarkworthy/lopepage)) → R100%28S50%28%40tomlarkworthy%2Flopepage%29%29
+    const rawHash = String(location.hash || '').replace(/^#/, '');
+    const knownIntents = new Set([
+        'open',
+        'close',
+        'focus',
+        'from'
+    ]);
+    // Split into key=value pairs, preserving original encoding
+    const parts = rawHash.split('&').filter(Boolean);
+    const extra = [];
+    // unknown params to preserve (e.g. cc=TOKEN)
+    let currentView = null;
+    let hasIntent = false;
+    for (const part of parts) {
+        const eq = part.indexOf('=');
+        const key = eq >= 0 ? part.slice(0, eq) : part;
+        const val = eq >= 0 ? part.slice(eq + 1) : '';
+        if (key === 'view') {
+            currentView = decodeURIComponent(val);
+        } else if (knownIntents.has(key)) {
+            hasIntent = true;
+        } else {
+            extra.push(part);    // preserve verbatim
+        }
+    }
+    if (currentView === dsl) {
+        appendScrollLog('url:sync_to:no_change', { hasIntent });
+        if (hasIntent) {
+            // Rebuild without intents, keep view + extras
+            const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
+            const res = setHashURL(newHash);
+            appendScrollLog('url:sync_to:clear_intents', { result: res });
+        }
+        return;
+    }
+    const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
+    appendScrollLog('url:sync_to:write_view', {
+        oldHash: String(location.hash || ''),
+        newHash,
+        dsl
+    });
+    if (newHash !== location.hash) {
+        const res = setHashURL(newHash);
+        appendScrollLog('url:sync_to:setHashURL_result', { result: res });
+    }
+};
+const _jcy1xg = function _test_url_roundtrip(sync_layout_from_url)
+{
+    const d = sync_layout_from_url;
+    if (!d || d.status === 'skipped')
+        return true;
+    if (d.status === 'error')
+        throw new Error(d.error || d.reason || 'sync error');
+    if (d.postURL == null)
+        throw new Error(d.error || 'postURL missing');
+    const normalize = dsl => {
+        if (dsl == null)
+            return dsl;
+        let s = String(dsl);
+        s = s.replace(/S\d+(?=\()/g, 'S100').replace(/R\d+(?=\()/g, 'R100').replace(/C\d+(?=\()/g, 'C100');
+        s = s.replace(/S(?=\()/g, 'S100').replace(/R(?=\()/g, 'R100').replace(/C(?=\()/g, 'C100');
+        return s;
+    };
+    const overlayOpen = (dsl, openTarget) => {
+        if (!openTarget?.moduleTitle)
+            return dsl;
+        const title = String(openTarget.moduleTitle);
+        if (dsl && dsl.includes(title))
+            return dsl;
+        const s = String(dsl ?? '');
+        if (!/S100\(/.test(s)) {
+            return `S100(${ title })`;
+        }
+        return s.replace(/S100\(([^)]*)\)/, (m, inner) => {
+            const trimmed = String(inner || '').trim();
+            const next = trimmed ? `${ trimmed },${ title }` : title;
+            return `S100(${ next })`;
+        });
+    };
+    const preRaw = d.preURL ?? 'S()';
+    const preWithIntent = overlayOpen(normalize(preRaw), d.open);
+    const post = normalize(d.postURL);
+    if (preWithIntent !== post) {
+        throw new Error(`view URL drift: preURL != postURL\n` + `preURL=${ String(preRaw) }\n` + `open=${ d.open?.moduleTitle || '' }\n` + `postURL=${ String(d.postURL) }\n` + `normalizedPreWithIntent=${ String(preWithIntent) }\n` + `normalizedPost=${ String(post) }\n` + `method=${ d.method } status=${ d.status } reason=${ d.reason || '' }`);
+    }
+    return true;
+};
+const _1yxu9kf = function _setHashURL(location,appendScrollLog,history){return(
+function setHashURL(newHash) {
+    const h = String(newHash ?? '');
+    const hash = h.startsWith('#') ? h : `#${ h }`;
+    const url = new URL(location.href);
+    url.hash = hash;
+    const href = url.toString();
+    appendScrollLog('url:setHashURL:attempt', {
+        hash,
+        href
+    });
+    try {
+        history.replaceState(null, '', href);
+        const res = {
+            ok: true,
+            method: 'replaceState',
+            href,
+            hash
+        };
+        appendScrollLog('url:setHashURL:success', res);
+        return res;
+    } catch (e) {
+        const a = document.createElement('a');
+        a.href = href;
+        a.rel = 'noreferrer';
+        a.style.display = 'none';
+        (document.body || document.documentElement).appendChild(a);
+        a.click();
+        a.remove();
+        const res = {
+            ok: false,
+            method: 'synthetic-click',
+            href,
+            hash,
+            error: String(e)
+        };
+        appendScrollLog('url:setHashURL:fallback', res);
+        return res;
+    }
+}
+)};
+const _1zkl8r = function _treeSyncGolden(appendScrollLog,gl){return(
+function treeSyncGoldenFactory(gl) {
+    const isCompCfg = n => n && n.type === 'component';
+    const isContCfg = n => n && (n.type === 'row' || n.type === 'column' || n.type === 'stack');
+    const desiredModuleKey = cfg => isCompCfg(cfg) && (cfg.componentType === 'module' || cfg.componentName === 'module') && cfg.title ? `module:${ cfg.title }` : null;
+    const liveModuleKey = item => {
+        if (!item)
+            return null;
+        if (!(item.isComponent || item.type === 'component'))
+            return null;
+        const t = item.componentType || item.componentName;
+        return t === 'module' && item.title ? `module:${ item.title }` : null;
+    };
+    const cloneCfg = cfg => {
+        const c = JSON.parse(JSON.stringify(cfg));
+        if (c.type === 'component' && (c.componentType === 'module' || c.componentName === 'module')) {
+            c.componentType = 'module';
+            c.componentName = 'module';
+            c.componentState = c.componentState || {};
+        }
+        return c;
+    };
+    function indexLiveModules(stackLive) {
+        const map = new Map();
+        for (const child of stackLive?.contentItems || []) {
+            const k = liveModuleKey(child);
+            if (k)
+                map.set(k, child);
+        }
+        return map;
+    }
+    function setLiveComponentStateCell(liveItem, cell) {
+        if (!liveItem || !cell)
+            return false;
+        let changed = false;
+        liveItem.componentState = liveItem.componentState || {};
+        if (liveItem.componentState.cell !== cell) {
+            liveItem.componentState.cell = cell;
+            changed = true;
+        }
+        const configs = [
+            liveItem.config,
+            liveItem._config,
+            liveItem._state
+        ].filter(Boolean);
+        for (const cfg of configs) {
+            cfg.componentState = cfg.componentState || {};
+            if (cfg.componentState.cell !== cell) {
+                cfg.componentState.cell = cell;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+    function syncStack(stackLive, desiredStackCfg) {
+        appendScrollLog('treeSync:syncStack:enter', {
+            title: stackLive?.parent?.title ?? stackLive?.title ?? null,
+            desiredCount: (desiredStackCfg?.content || []).length,
+            liveCount: (stackLive?.contentItems || []).length
+        });
+        const desiredComps = (desiredStackCfg.content || []).filter(isCompCfg);
+        let liveByKey = indexLiveModules(stackLive);
+        for (let i = 0; i < desiredComps.length; i++) {
+            const d = desiredComps[i];
+            const k = desiredModuleKey(d);
+            if (!k)
+                continue;
+            if (!liveByKey.has(k)) {
+                let before = null;
+                for (let j = i + 1; j < desiredComps.length; j++) {
+                    const k2 = desiredModuleKey(desiredComps[j]);
+                    if (k2 && liveByKey.has(k2)) {
+                        before = liveByKey.get(k2);
+                        break;
+                    }
+                }
+                const idx = before ? (stackLive.contentItems || []).indexOf(before) : (stackLive.contentItems || []).length;
+                appendScrollLog('treeSync:stack:addItem', {
+                    key: k,
+                    title: d?.title ?? null,
+                    idx,
+                    beforeKey: before ? liveModuleKey(before) : null
+                });
+                if (typeof stackLive.addItem !== 'function')
+                    return {
+                        status: 'fallback',
+                        reason: 'stack missing addItem'
+                    };
+                stackLive.addItem(cloneCfg(d), idx);
+                liveByKey = indexLiveModules(stackLive);
+            }
+        }
+        const desiredKeys = new Set(desiredComps.map(desiredModuleKey).filter(Boolean));
+        for (const child of Array.from(stackLive?.contentItems || [])) {
+            const k = liveModuleKey(child);
+            if (k && !desiredKeys.has(k) && typeof child.remove === 'function') {
+                appendScrollLog('treeSync:stack:remove', {
+                    key: k,
+                    title: child?.title ?? null
+                });
+                child.remove();
+            }
+        }
+        const order = desiredComps.map(desiredModuleKey).filter(Boolean);
+        const byKey = indexLiveModules(stackLive);
+        for (let i = 0; i < order.length; i++) {
+            const item = byKey.get(order[i]);
+            if (!item)
+                continue;
+            const curIdx = (stackLive.contentItems || []).indexOf(item);
+            if (curIdx !== i && typeof stackLive.removeChild === 'function' && typeof stackLive.addChild === 'function') {
+                appendScrollLog('treeSync:stack:reorder', {
+                    key: order[i],
+                    from: curIdx,
+                    to: i
+                });
+                stackLive.removeChild(item, true);
+                stackLive.addChild(item, i, false);
+            }
+        }
+        {
+            const byKey2 = indexLiveModules(stackLive);
+            for (const d of desiredComps) {
+                const k = desiredModuleKey(d);
+                const desiredCell = d?.componentState?.cell ?? null;
+                if (!k || !desiredCell)
+                    continue;
+                const liveItem = byKey2.get(k);
+                if (!liveItem)
+                    continue;
+                const changed = setLiveComponentStateCell(liveItem, desiredCell);
+                if (changed) {
+                    appendScrollLog('treeSync:stack:sync_componentState_cell', {
+                        key: k,
+                        title: liveItem?.title ?? null,
+                        cell: desiredCell
+                    });
+                }
+            }
+        }
+        appendScrollLog('treeSync:syncStack:exit', { liveCount: (stackLive?.contentItems || []).length });
+        return { status: 'synced' };
+    }
+    function ensureContainerChild(parentLive, idx, desiredChildCfg) {
+        const liveChild = parentLive?.contentItems?.[idx];
+        if (liveChild && liveChild.type === desiredChildCfg.type)
+            return liveChild;
+        if (liveChild && typeof liveChild.remove === 'function') {
+            appendScrollLog('treeSync:container:remove_child_for_type_mismatch', {
+                idx,
+                liveType: liveChild?.type ?? null,
+                desiredType: desiredChildCfg?.type ?? null
+            });
+            liveChild.remove();
+        }
+        if (typeof parentLive?.addItem !== 'function')
+            return null;
+        appendScrollLog('treeSync:container:addItem', {
+            idx,
+            type: desiredChildCfg?.type ?? null
+        });
+        parentLive.addItem({
+            type: desiredChildCfg.type,
+            content: []
+        }, idx);
+        return parentLive?.contentItems?.[idx] || null;
+    }
+    function isContainerItem(item) {
+        if (!item)
+            return false;
+        if (item.isComponent)
+            return false;
+        return item.type === 'row' || item.type === 'column' || item.type === 'stack';
+    }
+    function syncContainer(containerLive, desiredCfg) {
+        if (!containerLive || !desiredCfg || !Array.isArray(desiredCfg.content))
+            return { status: 'synced' };
+        const desiredChildren = desiredCfg.content.filter(isContCfg);
+        for (let i = 0; i < desiredChildren.length; i++)
+            ensureContainerChild(containerLive, i, desiredChildren[i]);
+        const liveContainers = (containerLive.contentItems || []).filter(isContainerItem);
+        while (liveContainers.length > desiredChildren.length) {
+            const last = (containerLive.contentItems || []).slice().reverse().find(isContainerItem);
+            if (!last)
+                break;
+            appendScrollLog('treeSync:container:remove_extra_container', { type: last?.type ?? null });
+            if (typeof last.remove === 'function')
+                last.remove();
+            liveContainers.pop();
+        }
+        for (let i = 0; i < desiredChildren.length; i++) {
+            const d = desiredChildren[i];
+            const l = containerLive.contentItems?.[i];
+            if (!l)
+                continue;
+            if (l.type !== d.type)
+                return {
+                    status: 'fallback',
+                    reason: `child type mismatch @${ i } live=${ l.type } desired=${ d.type }`
+                };
+            if (d.type === 'stack') {
+                const r = syncStack(l, d);
+                if (r?.status === 'fallback')
+                    return r;
+            } else {
+                const r = syncContainer(l, d);
+                if (r?.status === 'fallback')
+                    return r;
+            }
+        }
+        return { status: 'synced' };
+    }
+    return function treeSync(layout, desiredRootCfg) {
+        appendScrollLog('treeSync:enter', {
+            desiredType: desiredRootCfg?.type ?? null,
+            hasRoot: !!layout?.root
+        });
+        if (!layout?.root || !desiredRootCfg)
+            return { status: 'noop' };
+        const liveTop = layout.root.contentItems?.[0];
+        if (!liveTop)
+            return {
+                status: 'fallback',
+                reason: 'no live top'
+            };
+        if (liveTop.type !== desiredRootCfg.type) {
+            const out = {
+                status: 'fallback',
+                reason: `top type mismatch live=${ liveTop.type } desired=${ desiredRootCfg.type }`
+            };
+            appendScrollLog('treeSync:fallback', out);
+            return out;
+        }
+        const out = desiredRootCfg.type === 'stack' ? syncStack(liveTop, desiredRootCfg) : syncContainer(liveTop, desiredRootCfg);
+        if (out?.status === 'fallback')
+            appendScrollLog('treeSync:fallback', out);
+        else
+            appendScrollLog('treeSync:synced', { status: out?.status ?? 'synced' });
+        return out;
+    };
+}(gl)
+)};
+const _133ahw5 = function _background_jobs(onLoadConfig,layout_state,sync_layout_from_url,test_url_roundtrip,sync_layout_to_url,runtime,navigator_jobs,commandPaletteKeybinding,auto_attach,scroll_fix_sync_layout,commit_history,replay_git,change_listener,cc_chat)
+{
+  onLoadConfig;
+  layout_state;
+  sync_layout_from_url;
+  test_url_roundtrip;
+  sync_layout_to_url;
+  runtime;
+  navigator_jobs;
+  commandPaletteKeybinding;
+  auto_attach;
+  scroll_fix_sync_layout;
+  // history
+  commit_history;
+  replay_git;
+  change_listener;
+  cc_chat;
+};
+const _1n78po6 = function _imports(md){return(
+md`## Imports`
+)};
+const _b2c0kp = function _32(exporter){return(
+exporter()
+)};
+const _1ey5aow = function _dragOutGrips(layout,invalidation)
+{
+    function readModuleSource(name) {
+        const r = window.lopecode?.contentSync?.(name);
+        if (!r || r.status !== 200 || !r.bytes)
+            return null;
+        return new TextDecoder().decode(r.bytes);
+    }
+    function filenameFor(name) {
+        let m = name.match(/^@([A-Za-z0-9-]+)\/([A-Za-z0-9-]+)$/);
+        if (m)
+            return `at_${ m[1] }_${ m[2] }.js`;
+        m = name.match(/^d\/([A-Za-z0-9]+)(@\d+)?$/);
+        if (m)
+            return `d_${ m[1] }${ m[2] ?? '' }.js`;
+        return name.replace(/[/]/g, '_') + '.js';
+    }
+    function flashGrip(grip) {
+        const prev = grip.style.opacity;
+        grip.style.opacity = '1';
+        setTimeout(() => {
+            grip.style.opacity = prev;
+        }, 350);
+    }
+    function hookTab(tabEl) {
+        if (tabEl.__lopepageGripHooked)
+            return;
+        tabEl.__lopepageGripHooked = true;
+        const grip = document.createElement('span');
+        grip.className = 'lm_drag_out_grip';
+        grip.title = 'Click to copy source \xB7 Drag out as .js';
+        grip.setAttribute('draggable', 'true');
+        grip.innerHTML = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="display:block"><rect x="5.5" y="5.5" width="9" height="9" rx="1.5"/><path d="M2.5 10.5V3a.5.5 0 01.5-.5h7.5"/></svg>`;
+        Object.assign(grip.style, {
+            display: 'inline-block',
+            width: '12px',
+            height: '12px',
+            verticalAlign: '3.5px',
+            marginLeft: '-7px',
+            marginRight: '2px',
+            cursor: 'pointer',
+            opacity: '0.55',
+            userSelect: 'none',
+            lineHeight: '0',
+            color: 'currentColor'
+        });
+        [
+            'pointerdown',
+            'mousedown',
+            'touchstart'
+        ].forEach(ev => {
+            grip.addEventListener(ev, e => e.stopPropagation(), { capture: true });
+        });
+        grip.addEventListener('click', e => {
+            e.stopPropagation();
+            const t = tabEl.querySelector('.lm_title')?.textContent || '';
+            if (!t)
+                return;
+            const source = readModuleSource(t);
+            if (!source) {
+                console.warn('[grip click] no source for:', t);
+                return;
+            }
+            navigator.clipboard?.writeText?.(source).then(() => {
+                console.log('[grip click] copied source for:', t, `(${ source.length } chars)`);
+                flashGrip(grip);
+            }).catch(err => console.warn('[grip click] clipboard failed:', err));
+        });
+        grip.addEventListener('dragstart', e => {
+            e.stopPropagation();
+            const title = tabEl.querySelector('.lm_title')?.textContent || '';
+            const source = readModuleSource(title);
+            if (!source) {
+                e.dataTransfer.setData('text/plain', `// no source for ${ title }`);
+                return;
+            }
+            const filename = filenameFor(title);
+            const dataUrl = 'data:text/javascript;base64,' + btoa(unescape(encodeURIComponent(source)));
+            e.dataTransfer.setData('DownloadURL', `text/javascript:${ filename }:${ dataUrl }`);
+            e.dataTransfer.setData('text/plain', source);
+            e.dataTransfer.effectAllowed = 'copyMove';
+        });
+        const titleEl = tabEl.querySelector('.lm_title');
+        if (titleEl?.parentNode === tabEl)
+            tabEl.insertBefore(grip, titleEl);
+        else
+            tabEl.prepend(grip);
+    }
+    document.querySelectorAll('.lm_drag_out_grip').forEach(g => g.remove());
+    document.querySelectorAll('.lm_tab').forEach(t => {
+        t.__lopepageGripHooked = false;
+    });
+    document.querySelectorAll('.lm_tab').forEach(hookTab);
+    const handler = tab => hookTab(tab.element);
+    layout.on('tabCreated', handler);
+    invalidation.then(() => {
+        try {
+            layout.off?.('tabCreated', handler);
+        } catch (e) {
+        }
+    });
+    return 'drag-out grips installed';
+};
+const _1gkn0mq = function _dropInHandler(location, setHashURL, runtime, page, invalidation) {
+    const STYLE_ID = 'lopepage-dropzone-style';
+    const oldStyle = document.getElementById(STYLE_ID);
+    if (oldStyle)
+        oldStyle.remove();
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = `.lm_header.lopepage-drop-target { outline: 2px dashed currentColor; outline-offset: -2px; background: color-mix(in srgb, currentColor 14%, transparent); }`;
+    document.head.appendChild(s);
+    function parseModuleName(filename) {
+        let m = filename.match(/^at_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.js$/);
+        if (m)
+            return `@${ m[1] }/${ m[2] }`;
+        m = filename.match(/^d_([A-Za-z0-9]+)(@\d+)?\.js$/);
+        if (m)
+            return `d/${ m[1] }${ m[2] ?? '' }`;
+        return null;
+    }
+    function ensureDomScriptTag(name, source) {
+        let el = document.getElementById(name);
+        if (el?.tagName === 'SCRIPT' && el.getAttribute('type') === 'text/plain') {
+            el.textContent = source;
+            return el;
+        }
+        el = document.createElement('script');
+        el.type = 'text/plain';
+        el.id = name;
+        el.setAttribute('data-mime', 'application/javascript');
+        el.textContent = source;
+        document.body.appendChild(el);
+        return el;
+    }
+    function openModuleInHash(name) {
+        let h = location.hash.replace(/^#/, '');
+        if (/(^|&)open=[^&]*/.test(h)) {
+            h = h.replace(/(^|&)open=[^&]*/, `$1open=${ name }`);
+        } else {
+            h = h + (h ? '&' : '') + `open=${ name }`;
+        }
+        setHashURL(h);
+    }
+    function tearDownExistingModule(name) {
+        const existing = runtime.mains.get(name);
+        if (!existing)
+            return false;
+        try {
+            for (const v of Array.from(existing._scope.values())) {
+                try {
+                    v.delete();
+                } catch (e) {
+                }
+            }
+        } catch (e) {
+            console.warn('[lopepage drop-in] teardown scope:', e);
+        }
+        runtime.mains.delete(name);
+        return true;
+    }
+    async function installFromFile(file) {
+        const name = parseModuleName(file.name);
+        if (!name) {
+            console.warn('[lopepage drop-in] bad filename:', file.name);
+            return;
+        }
+        const src = await file.text();
+        const blob = new Blob([src], { type: 'text/javascript' });
+        const url = URL.createObjectURL(blob);
+        let imported;
+        try {
+            imported = await window.importShim(url, `file://${ name }`);
+        } catch (e) {
+            console.error('[lopepage drop-in] import failed:', e);
+            return;
+        }
+        if (typeof imported.default !== 'function') {
+            console.warn('[lopepage drop-in] default export not a function');
+            return;
+        }
+        const replaced = tearDownExistingModule(name);
+        const mod = runtime.module(imported.default);
+        runtime.mains.set(name, mod);
+        ensureDomScriptTag(name, src);
+        openModuleInHash(name);
+        console.log(`[lopepage drop-in] ${ replaced ? 'replaced' : 'installed' } + opened:`, name);
+    }
+    let activeHeader = null;
+    const clearHighlight = () => {
+        if (activeHeader) {
+            activeHeader.classList.remove('lopepage-drop-target');
+            activeHeader = null;
+        }
+    };
+    const isFilesDrag = e => [...e.dataTransfer?.types || []].includes('Files');
+    const onDragOver = e => {
+        if (!isFilesDrag(e))
+            return;
+        const header = e.target?.closest?.('.lm_header');
+        if (!header) {
+            clearHighlight();
+            return;
+        }
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+        if (activeHeader !== header) {
+            activeHeader?.classList.remove('lopepage-drop-target');
+            header.classList.add('lopepage-drop-target');
+            activeHeader = header;
+        }
+    };
+    const onDragLeave = e => {
+        if (!page.contains(e.relatedTarget))
+            clearHighlight();
+    };
+    const onDrop = e => {
+        if (!isFilesDrag(e))
+            return;
+        const header = e.target?.closest?.('.lm_header');
+        if (!header)
+            return;
+        e.preventDefault();
+        clearHighlight();
+        const f = e.dataTransfer.files[0];
+        if (f)
+            installFromFile(f).catch(err => console.error('[lopepage drop-in] failed:', err));
+    };
+    page.addEventListener('dragover', onDragOver);
+    page.addEventListener('dragleave', onDragLeave);
+    page.addEventListener('drop', onDrop);
+    invalidation.then(() => {
+        page.removeEventListener('dragover', onDragOver);
+        page.removeEventListener('dragleave', onDragLeave);
+        page.removeEventListener('drop', onDrop);
+        clearHighlight();
+        document.getElementById(STYLE_ID)?.remove();
+    });
+    return 'drop-in handler installed';
+};
+const _1v605qi = function _file_attachment_cache(reload)
+{
+    reload;
+    return new Map();
+};
+const _1fgpmzl = function _renderFileAttachment()
+{
+    return function renderFileAttachment(mime, bytes) {
+        const m = String(mime || '').toLowerCase();
+        // HTML: srcdoc keeps the runtime same-origin-ish (opaque) but renders rich content
+        if (m === 'text/html' || m === 'application/xhtml+xml') {
+            const iframe = document.createElement('iframe');
+            iframe.setAttribute('srcdoc', new TextDecoder().decode(bytes));
+            Object.assign(iframe.style, {
+                width: '100%',
+                height: '100%',
+                border: '0',
+                display: 'block'
+            });
+            return iframe;
+        }
+        if (m.startsWith('image/')) {
+            const img = document.createElement('img');
+            img.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(img.style, {
+                maxWidth: '100%',
+                maxHeight: '100%',
+                display: 'block',
+                margin: 'auto'
+            });
+            return img;
+        }
+        if (m.startsWith('audio/')) {
+            const audio = document.createElement('audio');
+            audio.controls = true;
+            audio.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(audio.style, { width: '100%' });
+            return audio;
+        }
+        if (m.startsWith('video/')) {
+            const video = document.createElement('video');
+            video.controls = true;
+            video.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(video.style, {
+                width: '100%',
+                height: '100%'
+            });
+            return video;
+        }
+        if (m === 'text/plain' || m === 'text/markdown' || m === 'application/json' || m.startsWith('text/')) {
+            const pre = document.createElement('pre');
+            pre.textContent = new TextDecoder().decode(bytes);
+            Object.assign(pre.style, {
+                margin: '0',
+                padding: '8px',
+                whiteSpace: 'pre-wrap',
+                overflow: 'auto',
+                width: '100%',
+                height: '100%',
+                boxSizing: 'border-box'
+            });
+            return pre;
+        }
+        // application/pdf and unknown: blob: iframe — browser picks the viewer
+        const iframe = document.createElement('iframe');
+        iframe.src = URL.createObjectURL(new Blob([bytes], { type: mime || 'application/octet-stream' }));
+        Object.assign(iframe.style, {
+            width: '100%',
+            height: '100%',
+            border: '0',
+            display: 'block'
+        });
+        return iframe;
+    };
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/golden-layout-2-6-0", async () => runtime.module((await import("/@tomlarkworthy/golden-layout-2-6-0.js?v=4")).default));  
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-selection", async () => runtime.module((await import("/@tomlarkworthy/module-selection.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
+  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
+  main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
+  $def("_1xyxga0", "page", ["htl","isOnObservableCom","lopeviz_handle_css","base_css","light_theme_css","commandPaletteStyles","commandPaletteOverlay","linkTo"], _1xyxga0);  
+  $def("_1ujnhdh", "append_to_body", ["page"], _1ujnhdh);  
+  $def("_1nv51s8", "testNavigation", ["htl","linkTo"], _1nv51s8);  
+  $def("_ydvyos", "viewof reload", ["Inputs"], _ydvyos);  
+  $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
+  $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
+  $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
+  $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
+  $def("_lxv2e2", "settings", [], _lxv2e2);  
+  $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
+  $def("_qbghwu", "initial config", ["onLoadConfig","settings"], _qbghwu);  
+  $def("_15lk82w", "mutable config", ["Mutable","initial config"], _15lk82w);  
+  $def("_1bki6eh", "config", ["mutable config"], _1bki6eh);  
+  $def("_14z0bay", "resize", ["Generators","addEventListener","invalidation","removeEventListener"], _14z0bay);  
+  $def("_18jv72h", "layout", ["resize","gl","mutable config","page","modulePanel","blobPanel"], _18jv72h);  
+  $def("_tsjb2x", "layout_state", ["appendScrollLog","layout","gl","mutable config"], _tsjb2x);  
+  $def("_11nrwvj", "viewof lopepageModule", ["thisModule"], _11nrwvj);  
+  $def("_r97569", "lopepageModule", ["Generators","viewof lopepageModule"], _r97569);  
+  $def("_1sp5wo4", null, ["md"], _1sp5wo4);  
+  $def("_1ts23ma", "viewof scrollDebug", ["Inputs"], _1ts23ma);  
+  $def("_7jxivy", "scrollDebug", ["Generators","viewof scrollDebug"], _7jxivy);  
+  $def("_1f2wuqm", "appendScrollLog", ["viewof scrollDebug","mutable scrollLog"], _1f2wuqm);  
+  $def("_1nbnzwx", "initial scrollLog", ["scrollDebug"], _1nbnzwx);  
+  $def("_1f7xtz1", "mutable scrollLog", ["Mutable","initial scrollLog"], _1f7xtz1);  
+  $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
+  $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
+  $def("_tb217h", "scroll_cache", [], _tb217h);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
+  $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
+  $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
+  $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  
+  $def("_1l50a0d", "sync_layout_to_url", ["appendScrollLog","sync_layout_from_url","config","test_url_roundtrip","serializeGoldenDSL","location","setHashURL"], _1l50a0d);  
+  $def("_jcy1xg", "test_url_roundtrip", ["sync_layout_from_url"], _jcy1xg);  
+  $def("_1yxu9kf", "setHashURL", ["location","appendScrollLog","history"], _1yxu9kf);  
+  $def("_1zkl8r", "treeSyncGolden", ["appendScrollLog","gl"], _1zkl8r);  
+  $def("_133ahw5", "background_jobs", ["onLoadConfig","layout_state","sync_layout_from_url","test_url_roundtrip","sync_layout_to_url","runtime","navigator_jobs","commandPaletteKeybinding","auto_attach","scroll_fix_sync_layout","commit_history","replay_git","change_listener","cc_chat"], _133ahw5);  
+  $def("_1n78po6", "imports", ["md"], _1n78po6);  
+  $def("_b2c0kp", null, ["exporter"], _b2c0kp);  
+  $def("_1ey5aow", "dragOutGrips", ["layout","invalidation"], _1ey5aow);  
+  $def("_1gkn0mq", "dropInHandler", ["location","setHashURL","runtime","page","invalidation"], _1gkn0mq);  
+  main.define("gl", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("gl", _));  
+  main.define("base_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("base_css", _));  
+  main.define("light_theme_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("light_theme_css", _));  
+  main.define("unorderedSync", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("unorderedSync", _));  
+  main.define("runtime", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
+  main.define("Inspector", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("Inspector", _));  
+  main.define("lopeviz_handle_css", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("lopeviz_handle_css", _));  
+  main.define("viewof notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof notebookModule", _));  
+  main.define("notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("notebookModule", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("viewof selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof selected_modules", _));  
+  main.define("selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("selected_modules", _));  
+  main.define("navigator_jobs", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("navigator_jobs", _));  
+  main.define("serializeGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("serializeGoldenDSL", _));  
+  main.define("parseGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("parseGoldenDSL", _));  
+  main.define("linkTo", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("linkTo", _));  
+  main.define("persistedAttachments", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("persistedAttachments", _));  
+  main.define("getHashModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("getHashModules", _));  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("getPromiseState", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getPromiseState", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
+  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
+  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
+  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
+  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
+  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
+  main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
+  main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
+  main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
+  main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
+  main.define("commandPaletteStyles", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteStyles", _));  
+  main.define("commandPaletteKeybinding", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteKeybinding", _));  
+  main.define("commandPaletteOverlay", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteOverlay", _));  
+  $def("_1v605qi", "file_attachment_cache", ["reload"], _1v605qi);  
+  $def("_1fgpmzl", "renderFileAttachment", [], _1fgpmzl);
+  return main;
+}</script>
+
 <script id="@mbostock/safe-local-storage" 
   type="text/plain"
   data-mime="application/javascript"
@@ -1174,12 +3673,19 @@ export default function define(runtime, observer) {
 >
 H4sICP8iLWcCA2Fjb3JuQDguMTEuMy5qcwDMvflzHMeRKPz7+ysas37gjNgDzuAiMdBoHg8dXJEiTVCS1xSMbcw0MC0OukfdPSRhAl/w0i1Ksr2SRUkUKd4Eb4KHSPGI2P3Rn/0iNt6u16F96x7o/TQRG/gXvsysqu7qCwBp74svSEx3111ZWVmZWVlZa5555r8pzygbWmatodeU8WnlTWeT3jD22ErLMcxJZYfVaLSayp7enrVDPUVFM2vKTt12dFvZM9BTHOrp7cH822xj0jC1hjJhNPSSssZsTq3RqpZt/o91PcViT9+amuG4LKRn6k0HsmCuTZbyyradUJGujOzYrOw13LpSmza1KaOqNRrTyqRu6rbmQruwWKdL2WrZumKYE5Y9pbmGZZaUuus2ndKaNXv37u1506lRy3uq1tQaan3esY08FpvnxeapIKh7zX/bo9mKW941UBhSC2pv71r4LQ4U1H61d6hfHVKLfYPr1F74V1QH1T61vwivA5hmcBCCBtb2Q+AQ/OtbC2HqOoxeW1SLBRXK6FOLvX2Yvl8tQrpeDIYwtVjEkgbxcx0UBW9D6lpI17cWqoPnkIpl91M1+N2PzcA6sBlQSR/+YkP7qLHr8JOV0acOYNZeamuRZShgoiJ9DUK3oC1DELcWI4aoK+sgEa+hF9qJWaHL61RW0yD+H6JEvdTTddSbAUzd34evCIoh7PUAgamPqi3QOxVa7C1QoVg7BGMZ/djgXgJdARsC//uhRQNqf2GQQLEWWwjNg3fsTpGBcoCVwHuIlVBhQzhaFNjPxqKP4FygoALG845j9EDfQBEC11LL+9b1YUfWYV19WMwgNrUX+1MsFFllMHrrECRYVJE6NTRI0OlfC42FUYLuYqo+qmOAjwN0GEFRhMohT39xHTZjAPoxgGn6h1jPEfy9faz52JxBBpciA5foEzSFMA4jadT6BnD0Bwku/UNs7NZhjmIR24/N7187gHWsXbd2LQxub9/QqKqXdxEmADbTSK3jFSBuYhEAiiL0BBB5AJIMEg5Al9bhf+hMEacE9mstFYLoCDkGaLggGRQBrSoOsUD2gy0YICwoFlhFvX63oiGDWAlhQm+R4XfvAGEUTbl11CxC+F6sC3P00wzopTnRyyYX9H5QdAxD2e8AISe2FKphk5dwlP6to+Kwp/DTx7APqAB8DPQFZUCZOEDYdWhaL04zmOA4D+gXutvXT2iNdawdoulTJPyE/P003wDBYSJARC+NG8AYZy6bwwA/KATa0Y91Y2kFPr0Bnv3UUxxqmiLU5QJhNjS3SO3tx6Khc/18WvSyqd9PxGQdUpg+hpZEE4rSMPDCh3gNUMEQNq04JBL2FanlRT6ZiusGsLh+rKFvLY8q4LzppwoLCB2YQH3rEB3XDVLnoZGDfUgA11Kf+gjIhIhEYFhnhgYoGjIW1/Kg3iFGu/qGiFD28ikIc663wFpNleEE7SVgYKoBylcsBjMI2slANshJFPWKJl8fDtQ60YgiYkQf0hqii9Am7Hehj+YVJoM29g5CcUNEFYuFtYQZSLawbCAR6wZhuAYAl9fhEELcWiofGzRE40dd7FWJJELE4LohBE0REqzFwYPgtdgMQNOiAMFgkYgUEMC1CE0oe6iPIbDoYO9QgXWhjw19geEJ0jRocF8BqRmSBYQd5sdpOTRURFJO872X42GfT76LvHaqYrCfSmXDNsjnByXrZwSWEfM+wpl+jo+sLSt4g/6u6yeMX4vDA1RtEInNWpwStLAROvT19gooApoCEkIb1gLBGRS4LvAdqDNR8bWEMrD2DLC5LmBV4ERkiGdkmIZVDAiso7/eSPron4gT49AnlTfEaDiBihF3mAf9SAl6kRr3IR8xQODsRYAPrB0kdFzbv5blw4nXDz0Y6MfwAoBiiOZTf3GoOKoa5cw/zv3j7X+8/08H8v/0+T99kf+nO//0Xf53B3/3Tv53v/rdyfzvzvzu8u+u/v56/ve3fn/n93d/fz//+4e/f/yHd/7wXv4PH/zhoz98nP/Dt384nf+ft//n3fw/H/znD/L/69r/upH/l8//5di/nMz/63t//DT/x7k/Xsv/8ea/ncz/6YM/Xf3TtT/dyP/wmx8+++HsD+d+uPrDtR/u53948MPjf//033+d//dr//to/j/O/seNP3+Q//Pcn2/9+faf73snD+S9k595J7/0Tp7xTl7wvoXvb7/wvj0Jjznv2+t579S73qn34fGxdwoCT7/vnTmS987c88489M5+6p39Iu+d/dY7eyPvnTvgnXsbHh955z7xzn3qnfsNfFzwzs3B47p37qZ37g683fPOPfTOf+yd/9o7f9w7fyLvnf/WO3/dO3/DO//AuwAFXPjAu/CJd+FT7wIUcOGCdwEKuHDdu3DTuzDvXbjtXbjjXfjOu3DPu3gs71382rv4jXfxJrzd8uYg99xRb+4TePzKm4Pscxe8Ocg+d92bu+nNzXtzt+Hjnjf30Lv0qXfppHfpW+/SPe8y5Lv8kXf5E+/yp95lyHb5gncZsl2+7l2+6V2e9y5DtsuQ7qF35WvvynHvCjT7yrfelRve1cPeVch99QPv6sfw+NS7+mt4fOZdPeZd/dK7+rV39Rvv6gnv6mnv6hnv6gWIm/OuXoXHPe/ap951yHr9I+86ZL0OX5D1+gXvOtR8/Z53/aF3A4B740vvxnHvxknvxrfezQPeTchx8yPvJuS4+al3E3LcvODdhBw3572b0Mqb97ybD7354978N978SW/+W2/+hjd/07sFg3brI+8W5Lv1qXcL8t2679166N3+2Lv9D3nv9ufebejT7W+92/fh8di7A/Xc+dy78yU8bnh35uHxvXfnoXcX8OPuO953B/Ped9e9725638179yDs3jve/YPe/UPe/SPe/Xfy3v0PvPsfweO0d/+sd/88vF337t/07s979x9630OG749437/jff81vJ3wHhzwHkLYw3e9h4BqDy97j97Le48+ah84kG8fmGsfeNw++Gm+ffCz9sEv4XG8ffDb9sGz7YPn2gevwvf19sHb+fahg+1DH7cPncy3D7/dPvxu+/DR9mHIdPh++/CDfPv999rvfwCPo+33IfD9z9vvf9F+Hwp7/3j7fcjywXvtDyD6g6PtDyD6g+vtD27C43b7g+/g8aj94YH2h4fy7Q/fbn/4Hjw+b3/4Rb790aftj34Nj8/aH8HX0S/bH0NrP/6k/TGU98nt9ieQ9ZOH7U8P5tvHLrePXYPH4/aX8PXll+0vIclXc+2voPVffdf+GvJ9/av21yfgcaN9HL6O/6p9HJIcv9w+DkmOX29/A4HfzLdP/LZ94uv2SYj69rv2KQg7daF9aq596nq+ffp2+wwEnPmmfRZ6cPZK+ywEnr3VPgeB5y61z8HX+ffbF+DrwuftC1DCxX9oz51vA+q3L8+3r8Djykftq4fz7asn21evtq9ea1+9n29fO9u+Dlmun27fOJpv3/ikfQNgduNh+yYE3nyvfROqunm/ffMhPB635y/m2/OX2/PQ5Pn59vzt9vyd9vz99i1Ie+dx+zt4PPis/QBg9eB4+wG04OHb7YcAzodH2w+hnIe/bT881n74Vfvh8fZDAMXDh+1HkOXRrfajO/B40H70qP0YBuHxkfbjd+DxUfsx5Hr8m/bjz+HxVfsxlPj4cvsxDNzjW+3HkOfxg4WDNxYOPl449Gl+4dDXC0cOLRx5d+HIB/mFI79ZOPLZwpEv4O34wpEzC0fOLRy5sHBkDr7vLRx5AI/HC2+/nV94+/2Ftz9eePtkfuGd9xYAEAvzZxbmL8Hj6sL8zYX5+QXo28Ktswu3zi/curJw63p+4fb5hdvXFu5A8J3PF+5AxjvnFu5cgMfVhTsQfefOwp3v4PFoASbSwt13Fu6+B4+PF+5CC+9+vnAXWnT3mx8PvJ3/8cC7Px74Fh4XfzxwAx63fzzwHTwe/HjwYP7HQ5//eOgreJz48RAkOXz/R8DwHw8//vEI5Dty7ccjkOGdj3985yQ8Hv/47vX8j+8+/vHTA/n/c+fx/4FR6Pz6o85vPs13fvOw8w/w9cVHnS/g64sTnS/mOl9c6hyDsGNXO8ce5ztfHu8Apna+utb5+rf5ztcnOl+fyne+ea/zzYf5zokPOic+7Zz4VefEbzonPoPvY50TN/Odkwc7Jw/D4+3OyXfh8UHn5EfwONWBdaXz7Xzn1KF859R85zSkPH23c/r7zumHndOPOmc+yHfOnO2cuZ7vnH2ncxbqPPugc+5IvnPuZuf8J53zEHD+TOf8OXhc65y/D49HHUDlzoULnYvwuHiocxESX/ywcxFSXrzTuXi/c/FRvjN3rTN3ozN3uzN3pzN3D74fdi4d6Fw61Ln0Vb5z6XjnEqS+NNe5BK25dKtz+WC+c/mdzuX34fFx5/Kv4PF55zIkuXyuc/kCPK52LkMDr3zZufI1PC52rsDXtVMdwIv//Ob0f35zPf+fJ975zxMfwuP7RZiLixevLF68nl+8dGzxMnxdfmcRlpbFy79dvHx88fIJeLuwCIvM4uU7i5e/g8eDxcuPFq8cWLxycPHK4cUrRxavvJNfvHpj8RpkuvVw8fan+cU7nyze+XV+8e67i3eh3LvfL96Dx71bi/fu5Be/f7D44Nv84oP7iw8P5hcffrn48Fx+8dGjRZgyi4/fXXz8ATw+WXwM2R//dvHxl/D4OqM65f19pYw27ri2VnWVcctq6JqpjE+7ulKta7ZSbWiOo9Ss1nhDV3SzNaXo+5qW7cLD1c2ao0wwHVLD0lxl0nItxZhqNvQp3XQdfMWkhkl/uj2hVXWlYZmTiqm5xh5daWrV3dokPG1jj+bi03L1KmqPmlChUVWcOhbguJAcPlpN3VacabNaty3T+CUkc+Ftr6NA603HgDqVPVYD0jb0jDpQyrDG81az5rIyqpbpuKInrJUZdbCUwaQAFNc2qm4pI/ckaL7urqDZrMHTht6oifI2GGYNatgD0NLsyRaVm5lV7XJm3Na13UpVcwDmmlutY/Ncw2zpSk0fb01OQoNr+oTWargwEIregHQE9ca0MmHZykTLrKJmTTEmFFt3W7apOHsNLIegA8CZVlBztrcOcGEaO7PVaEA41DChYXEGgEMzq7o1objTTXzssYwa1Aq91RVT3wspoDTDyahaef9AyVYzA1NWrQVwLtmrM3FIYiADMh8DDv5QQjYYAAOzvOYXhpkVbchVfrJGtcpY7Q598vl9zWxmV2a1sTozmsmp9YTwhQMfLRw4+o93/98D+d9f+8O7/3w4/8/v/uuv8v/68F8f//HgHw/98cgf3/7ju//2af7fvvzTh/k/XfzT9R8+z//w9Q8n8j+c+eH8Dxd+mMv/cOWH6/kf7v37r/79ev5/f/Af5/L/cf3PB/J/fv/Pl/J/nv/zQ+/k58AlH/NOfgWP097Js/A47528CI8r3rfAhX77lXcKeLVTJ7zTHwCP/K13+jTwyIe9M8BMnXngnXkETPIn3tlfweO33tlT3tnT3tlz8HHNOweM1LnD3rkH3jlIdP6Id/5d7/x73vkP4eOod/633vlT3vnTHpA+7/w17/wj7wJkuHDYuwC8MmS4eMi7+K538T3vImS4eNS7+CvvIiS9eMO7eNubg6Rzh725B94cJL30tnfpXXi8712CtJeOepdOeZdOe5cg+aVr3iVo6aXHHtBA7/Jh7/ID7zJkuXLEu/Kud+U97wrkuHLUu/IZPH7rXTnlXTntXYGMV655Vw95VyHptUPeNWD7rr3nXQMIXDvqXfutdw1SXLvmAX30rh/xrj/wrkPCG0e8G5DwxnveDUh446h34zPvxufejVPejdPeDchx45p3E1px87B384F3E3LMH/HmIcf8e9485Jg/6s1/5s1/7s2f8uZPe/OQY/6aNz/vwVLs3Trs3freu/XAuwX5bh/xbkO+2+95tyHf7aPe7d96t095t097tyHT7WveHajmzmHv7gfeXZAY7v6Dd/dzD1Zg7+4J7y6kuHvNu3vTuzvvfXfD++4W8Lv3vXsAwHsfe/c+hccx7/4N7z6E33/gfQ/s6vcfe99D+PfHvAdfeA/gF6SlBxe9B7e9B3e9B/e8B4+8B4+9hyAoPTriPXrHe/Su9+gofPzWewQY9OiB9/id9oFLwO8+ah8Evufg++2DwNgcPNY++A08TrYPnoLHmfbB8/C40j54Ax632oeAITp0tH3oE3gcbx89DnzoifZR4MOO3mh/Dczp15+1vwaG6Otb7eO/bh//Tfv4zfbx+fY3t/LtE79pnzjePgFM04mL7ZMf5tsnj7ZPQjEnj7VPXWyfgfAzl9qwILfPfN8+C/zW2U/a54HfOv9l+8JvgYf8qn3xM+Ahv2lfRFbyQfvi43x77v32HCSZO9aeg3xzD9tzEHjp4zasfu3LR9qXodYrR9pXIMmVY+0r0NUr8+2rEHf1UPvqt/C40r4K+a7eawPitK/Nt6+fAc7zbvsGJLnxfvsG5LtxrD0Pj/lft+f/AR4X2vNX2vO32vN34eNeG1iq9t3HjBosHHi8cPDAwsF/WAAhYOHw1wuHv104fBberi/MXwMG7sbC7ccLd4E/u/v4xwNzwFld+/HQsR8Pffnj4e87X8Ca/8XFzrFrnWO3gBd62Pnym86XJzpfXe98daNz8lDn5Dudkx92Tp4GxuZ85+TlzqkDnVMHO6cg7em3O6eBlzp9rHMayjh9o3MauKgz73fOAOdy5krnLLBEZ3/TAZa8c+5w59w88DEHOgDVzvljnfNnO+eBnzh/r3PhIjA2wMMc7lz8qHPxaOciJLh4rHPxe3g87Mxd78wBvzJ3qzN3tzP3XWfuUWfucefSwc6lS8DFXOtcut25dKdzDRp3ba5z7XLn2pXONeRT7i1e/mYRuL/F7z5Z/O4kPK4tfje/+B0wD0eBh/hk8QHwFw+OLT54vPjwLBDaYX9ZaWZdVc/th6Umi8uIUR4cGOgbBNahMOw8q/c0dHPSrQ87q8u9uf3GRDZrrC7ru5zR3HNuji1HXcXhIHx1EWLKflRhVqSZ9SusQoVGbj9fy9xnBwcqfYPlctktuc8OFWdmsvBYWxka4EHF3j4Ko3YNVNznysW1he5uq8fVHTc7AouvOdkzYVtTG4Gh2WjV9Kyby5W6il3lstHdzXqXywXVN7KG6vjVG8/2r2PVGyXj2YF1MzNdWQOalOvuhic1x/Cbg0lYcwzRHIM3p57eHEM0x4Eym1C7npuZwSe0E1uGUG+VRfvYaND6XIAqdcijl/fP5lRcn3sa2rjeKLvsY7c+vdeya2VdvLHgcR3GUof10y53denSJ4uGZdh2HT86+GTRhrPFspoUxV5F8HrHMSZNHsE+WFTT1ieMfRTBXnmw5bh+OHvn7TNMqEBnz5kZZFZYRKtZA3ZrI3BHwE+UMXw2QNMaAwwfNmQSWhCyP+hdqaugUpElfZYBdaIcjp5Vp8r7g/5SyD6AbVDJZKiShEHwQQ1jsG+XO1oWDdFZlXvK+4HHLLHQDLGbUznV1ieBMxKh7IsiHEIXEcG+KMLUpnS/FHinQM6Pbq6JGD+AooG1EhHwCrzUODD9u3V3iwjdlYnCKwwMP8cOkWOUl6L7ZexfURm6X8IslNDUbN30S8guWwKl90vIQQlVa2pKEwFqRp0A0OlThggZppCqBbKHCCpRUM1yRUAPFPNWC+aoESSqUCIRuilIXMHUmg3stQgpP0dpXR2EBgC5CBbfkNwwgfc3ajsjKSLBkFBvNIymYzh+y3p6qOxxgP1PW1aQ9e9pWGtWo6HZG0Kj8JPlh0F/y296LK2Yvyylxt556rHlkhtmdZNeFclXr16Tz0MONvMxNZ/riQPLEvGsXWv+n1hVQTHRvA1rEm0Qtu0o1bKZmZmMWvTD1r+yCQO7uzNqL4DRcPcajs4TZtQ+P+hnLOwXGbXfDxN5QaBEmLVgrNxpDCmX13SV15TpASAZxFncIBMHrYHxz655bs2z5TXPQdxaKm2kbky4FANRz8F/wJh10OdGy9lq+OAFcGWSqdbQEp0nYczCwv87dLyQowT4+Qz/BCmsjt9rgmhKwmt95plopbM4X7SG7lR1zFepEEDHSFYtTWaZ0ArIOoZyKwbgk9B0jIRYFgQvlIYLtBTI3zFcyLcYLt5ZOIm7LJheWck1i4IsaCxbewg6kWaPoYSM6fDJ8nFxGQP5K9YC2SjEsuXysARB7ymav9NcGzMmMMxA6jnGVgH8Zm+sLiZ7Yyh7w5QkiGMQvbB0IJZTiE1tgbUBv+DB4eW4HFiOiyEkvGMIvUTbi0I9RcITU8Oo4ic8liUDY7iysqaheI99JLGcOkDyOYWRGE8twhcWxoV6AjV7ZT1jQj4LJoUAwm1KhAklAZaASzg1FJ4sBJUSDCwttqaNkYaCBkKj8aRRIKgbZspMWTtLaYQ+gaUVX0vlYcoPqp/enoD8jCEzQEMIzyfJx5QsDNXxbeV5Z9Xp8po37DfMyswb5swbrd5C7zr2GFqjjst6kukex2rZVV3NTMqc/RhwwoKXKSIf487MFPvYc11vX6//RmEBh7wb+Rlk0X0GyEBuuOxyYQCq4MKCU9ZBSDBAOlgNqSHAhkRVzviud7NODkWDsaydywnV1bNGvtjdTc2w4UnNCmVZXcxVnNW9JXjhwkO+SLzVSHnNrjdaxcF1BQRCoZCnh0YQmcDfAfjtg4g3WhP6xMToGnVjeU22UnrDmXljzRtrep7BxzO7fjH6TOWNZ95Yk3tmzaS6t7xt/E296vagjs9CrFCfL+/tqWvOtr3mdtuCCeJOq5shyLUYb6+uF1lYopmZMOfO+/l8DxrMMcZQ3V5eb9vaNPLN+JSziAyZXRaVqlCKUVh+ypt5EVDAK6LOKpBlV8/ihJIG+jVpoF8BrhQElFcEcypUab8ASGRWuz22DnxIVc+uUaD7sD7mVmdyP8nIAtJOqTRf7EqWs0pZN8/lxaQEAwO9Q4Ors+5zz+GiNDDY11tYnS0Wevu6XSH4bKEhgnHdtI5GdNOGF14YzVa6MGQjC3kBQnIzmOoX4WQzv8hFk61Rd0QkKSY2GaYupCZgE1tTZlmfHd4RjHqPNTHh6G45PjAkauzI+sXIhayGsRnGXmwKVYpTJxC1yjwLENCyoeLIdSHKsxn7AlB7mFssNYWEonKSbLItKqcXSUYfFhMPZ60DKXDG2c8WcqHmg9CZh8m4ejXIvmV7lkC/obxfr05pr+m2QzwxymGs6p0AkVLGqdpGEyi5ZW42HZgHem0EeG7OZWNiy9xpawYAZXIj488xEFDW2rtDhwx79FooCJuzreU6Rk1/QSzAXUUWu5lWjedpPXl+j25P763rtu5Hr9+rGW40b1D2CC5kPHqr7tYtueKXgDXaoIGUBYVV63p193YmNb2A2nsH6W7DqhJj52AS6JS1W/d7iD3TTZd92lCMTqkAcSZtbUoGGo4X+64ZNszVkUgo0HkCynaUbrCQWXVruasYDPALiHQ4MDrJpGKcUTe/IafvMkbLbnf3elKeVFz4LG2AHxztDAoWwEegpNojDWkl9FUu6uuoJdFU2a6twDoz8gNl8B0CZE0sRE7+0rNXs01AVWhzQZXDspkREAl0ZT2aEivrego9BVWxmgRQuR7FcBQbOGwATq3nDXMTY/zQoNm1FCDhkGu85dI2hLLXaDQUx7WaCsjauzENbVDoykQLsEgH6QxF8VDnirlSKOS5cm+hOICCuxyah9DCUE4VcAhhKyUOhYQh9SyICDAEbAq7PSHsApKrh0PKkeYUQejYDok4guXYWMMKKkKG/bckMuT0NFtOHVcDvioqrDCOoDlqvP9ZTlyU/ECgAqqtaqqpWqwZ9fJ+HPeSUclsgOmwG+TnLUDsMioIr8CxOYw3KdkqULGSNjsMrICYNFBxHb9otdlEpIzKBVj1sAlDKei1vAtqHcWxo87UoTNZXZW7AXFEnF4t9w4MBnPjrVA/emeybqW/VIBVQa+sgydleTOZCHNULLtlnGCqRGpxbobIbUit5pRfy2q73PAgDlYGSxm+NVYOyDgSzEqwZzYwmhtmRDmTGe4qEL2PYppddpIKJ61naHoOlPpG1ZQ6sZzV5YyiIX3ESUEd4ISm9jrvhc1aY5azdgV37mBwYdnH5Qk3LofjeUYoAnKaSSWO+PudmALL88vCQJ7FMJstt8y4gqyeE8um6WrAqz/vVIH0qUYlK1SFsDT6S+wILZtBKT0gk7ibzZq+bxsQuzdALAAeMre6yMts2VtoeQ/SOw0DOJxCpMRcj9ME6T47nRN8bCmoPlJ5IVx2kbcf50h5Tw/QR/ZNs6McaDCdoOW43IvSpcgtMFFEvP8O1Wy3HINQ11f0Oi7QguelVDxoRBQTVCvHlCPZI42ocu0qhxbUqTW4xlVUDVKdvR6xFehfV0GM5lZCwHIKIooeEt6EcszMSFGbaGU09ug+4HNCWQwCJrZlPSrd1rvlfDEpYrP5gmUTM4DoQwloE367GEGaCOGvzTUoAIMKkgrdKe8a5UpnwKsJGOMaYz6cJE5bJSmFt7i7O0L6YfH8m66MSBHGwF6gy6z/u40mohKnc9leQYmqIGPAwFV3+y3S0RhhBMOzRX/+ocoYkrkytnH17yvalF/CrPpieb9h+jzSfhjvCWOyZWvjwIegwtswX2RneCw7MXY9GmAkxFQ1kwCfEBXwYGmRbNzTkrgIatFkZ73zmpZa0Cv63k2Wu1OzJ3U3sfkbUX8xQvYZtJDFE80Ovynx/U3NdvRg4WCrIUdhwcRwZs/HZJhlr6B4kxsWUhKGmzCFaPUW84iK3mk1t+h7dCbGvdgTDE3PpCxuiKUt29stKAJwiS5AgiFCrmeioU06uecKrBR/DFOKWbdcMd3dXSkpOAyJPd4MBIJVSGiRUln/X7cygWnR2gRHzEcnmDmcnOeLw+5zIBG5+bzgoyMJQSZGflmPVTszo7PGdr8a2tTs7ebhOb+rejAS8ugLcsenewL/CxxgH0chEZsq2yAYglkVBYQEBA7RnfDOQaoiS0NNVFFjE+0pR9nsIPQE+jAzYyS1KS5Q+S2SpnIKOhR7w9gnNS6ExQnTPrlEBuGE5JtNVq5cG68p5zdYJhn/FZDsHVgnQMmmSpQEpYBpqTkDaIgwerOHKV6TZ8EuPEfm25qJjXo9nx/Oubv00SAKPgJxknrLd/fdYHd/dQ5idjmjWcOnagY2IEIfo3uwWBhw8MBbUcJszs+DakzdQcRf78YYcyb5+AUA74eKC1/SkUmpEy2O1eFitPFL3V5B22ZVvqazlZ6r9QzdyUorgfoi45JfKsuBr5fXoOJsVRb1iG/0zOz6xao33hjNPVPJrZrJBIEZHpjJrRl+KcrrhKQ5ICppBALES5/24HChamdjwPui/mp1eSOghF7NBqxGbldhVAwjI3qvR5NwbgSEK6RpXXqIxGXwrC9rMfIwWX1XcRTI4a7e0Vyk+tV6pCojoTWAWQa8QobVRpBctWXmCLW9TDnMdZ/DWLM9M5OZ5S/TzJoCSwAGqiu7Zlf273t2rX4jv+aZ//7sc2W18ovu0TUsjZ2DfMR+2cCIlSN8mKhqdREogosWKkGbngi2KmtkEAdrCdD61atnZ9WXeoAyJcnsgcxQRt1N1ucTAK+7QGqFnIbDue+W1liuiD09aArAVxgmelC5XVHZijdpyZK7urhdR5AqS1qEhEYC7wmonFIc41nl2iCULyotk2XVa1kqCJZ2pkv0NYmp1F50GWQtXpgfxCwMfCyJI3pYApKkrxyDeXoTxPSMNzTrb2GE5m+CcjTCAiSkSG5hSORD2GNbnaRWCpBn91C8gLYRbXHKKGgTIGCEVLcRIiqgIFA3peehImK9DsVmY3KqmiTTwprL2+wjYIB/iViXjmvBdzwjNM1hsl1X2a24pQBD1Myrfj6FFpkM1/H/MjYCZL1e18waN43ibIoMVyEIwDJc1x20aZfThiJIoULBzBx/Oy5CIAfPworC9NaaC+NmPg+CsO0kjBi0Klz7c7jTFvR3h1619ugkB2UjKdUMPVBFa1quAsvjlOEiBAhVSPMKq6+r6MxgPpPj9F+vuEm9K7nxrg0bSzTHUPVKhuXlCmGb6FumlNkuF6Q0GQxgTIicIFgCziANMl2SpSLngaJjB8uWK8M9tFAqBogVMzMOChf4KvcCmp4ZEWXhSQHaMVSYTQ07XAAdUMgGSLHMxjRqsmsAS7tVhbKxt7xPTgYWz0jpMowcNbNDJw6GFEWKNaGMjRGnMjbmV5zJ+XD5O2RUSbjYLJTtAEttyonhsVChAPHvCmlR+MwS8c+GInMhMIQSqhmqHI8D8KFRgKAiZo3riuafdmBDzKVlUWy8VBGjZqg3KyyVLa4jdMiDjTETARKWwjCOBfjElFxIBCt8rYwXBzMpaE+ulCFtkzFh6HaQGxiUrfrUuG4nFc2Iy09lrnP4p2HdQajJjMdL3A4GntHtGbdq02gvSy8gI+SGfVLexddTvmVolAM1BamWSDFF6qWuAvLjrAymqjdys2JVEKJuLrACKACDx5u0W592somatRxIHLZkT1xkzdDKNsgdwyl0KqmgXdqoINYsRFmVWa2tzqwS9IsnBySQFy6tpjUDrhymecOabOkcUhwL+bIjqzbDuqCoyhOno1MndRA0ZzvTFIkl4+Xy/t10LKhhWc3MrPp34pubDs3CSBvOlghSLiUiDM7MJPBtmYaO2n+fyIU4W6625MJBAsdu+GlkDl91onw0N9AwSIoYKgIGA4EYQisSxzf3HqaFSJYvir19LKXzHJoDDHR3O8+SJUAoTxXIGzCbgXhrl43VxeFGNq0VNjGnw7nVq21qTu9ylTBUi/GKhmozqchkzKSWSzBdV39KJs/TZlXoH5J4xqTxWpc8XhqWtaIRgzVs5WPG5amu7JKcMe4FGDkUm3zbt65yEmSM1esgFfyGo1ldsFgAo5+GI5AT+TIxGi4fjRyCMkxwknUDQmAkIZwPm6x4ZRMoKyzWkQ7naFNtTw/a2gHysjkBo7ufTt5BOLNtFF++zaJMIqhpGzDdRh4dEEZNtcXWYG5YlOJbOMZK2cRjpAKkbFZCBisxKVoxxtK+YCWX6xs2ihy+bQkJ+DDkxgQNNojKtA9CH7mllJaDPFJmryX9tpgQMpy6iiqwXH6jmG1h0KKliiPdGRZRCPIbE3EAbJ5I7D832YwlZ8YniVm4PWcsywiFJ2Zh5p6xHDsxODmDPZ2Q3J5OTMyMQ8UXGo4KvVhZMGTE4qApAhmUspMlS0EV1YvS+DhBZczuNNa21zE4sXVkihpPD6FJyfnZgfgUQ71oFriMICnZ88cSPj/VdJPBxK1QfSRhBqhL0OLnisBa26RA4Kkj+i2Z7JpJRNcKiK4pLZT1FCJo0cLSj3uH9ZmZfjxjVM/Fe+jzhPIQJcWjUjtJEF/CgAqtUjjOSAw1551WMSisIg+Cqxg8VylT2jSTU7RmU8c10yXxD21xGsiMZnJq0v7ukxTPS6Za6LzyKsnsTGEbzKvQmiE0WhVp9lMAYEMpBCcKgyVkWNiX+xxrePGWVDmp88aUNsTTCV2BCB0iTLMszcxqOXn8hIbblpR5EYmhSksebxZT8ZAyJyd1fwtSbr0mt6SpVlU3Ao4EtKqi3PzTpZa56Dk0khP4aQC0LxuOQWcFeqiKyw+ukUF4WB5BKFRig1DKiizSqCOgRK2OpJeTzJFpVyPY5Rd80erVjm+fHMSi2AEowmzBeH0zMzY1qeyH0CdxeUxfBFwA8PBoEA3LKTH2qHumwFyOAEVMMMvc3W2wMN9qyxFa5FALw1JvoIoCtHW1KjobyKwWRjQhkQMNtrB8fwAzpUxsUDMB3xVjS1KVzvIYS9BOEntihcoVWk9WFQcLCZ0voyRGcmySpIoHRSKZrKZkxAKolBVLHBaELLFUEAn98uxUl2CCKlFUL60ILlZ4IZXAInNwcf0kA8iwtImd2KwhjjZixzwgGyFhgxmHVWIK11KeJLREsEcMUQpRsLIzfbJZFE5mAg0fWT3Q90kzWw/RVNRYqEx7IWkkGEOfG46ooRk3FN0MYPwSiCliVzEqK8AqApMEpYFSQKKH09BP8Eskj4L0EBtWR81AtIHaiU06sLY2WUECIkbbapiRnfVEtjosF+KxTeDGSbbuqQXFCzJRyS6JDPEmVNJGoeQyvVoZE0TGZDMSfycHRHjFY+hwc34hYce1E6qJJlvM7ccvBc8UXSG7qEYUTRnSqlbYxiYM3axZfioA/5dBUevuNkOUvC4o+c46upaZcPOkJkazCtTfaujgJQ8vuIwQa4TaK8rCGSMA3aoeQeVci2keSTNWRzHLEnaVqPDd8prW4HsE2XrSkNZzwuIxUXGetVDsUlc85nVJnI9xRzGxfskJ90KQ+OczWaNSKP0kh/3TgxokiW/ZdWQFpB63Sx39rRYWl7i40BlAtPRDeKLdnbQC0BFEmSOL5CsFNnrhBUHqhLQWRKTT1O4FxmNJNjuJByzSuXNW8CrFYhkQHX11UAIPvDIuT5icMEYvKwUkM8RxXi4JahH4SJCLCOlxRXmYXe2pGXioZcowNXNZ/ADBMrAS9dc9JtEm8Cp/l7RoSmY3XcWIIp7tYg/n4qscVh1b5rhME1rlwlmGhdggQU9XMwxGG/H4rt8v1mQ9tlaiZb40MUTvOfycih6dWTLQSlkjdbsxtvub2YqHP5oN3d+3gcWuBU3Dk/RodsyrYva34TFgAtEsecrSE3Z/Q53gxyZSdjpy4fVF32e4vvXXCqCZxrwGfGgYkyP4KmFyWHm0HIV7GsuH+MaalDCzudHQJ7UGGk6hFby/8YvnmYkOPuFETup9uI9ik+RngGZix2sjnijfSIhAe5UptnpMfgWByzAn17vWFNnqJW69hUc3mJp6pa+3VEhbPWHJqvSXehN53h0QGoyapMNL3MPxKc84arzKUQ0YxiBH0NBtya5bntYAj7Axq6QETyHSnDWvkHEzwFDSrkbAmxX8QNLWRbGQpBwRhQatDRE8TBAR2Liur+hDM5hiQecTZprUWGkjr4cO+JPhn7wg82P/8prMIczXYlETkIugiPDqKJbGrYZD92wwZ33ogY9746vyxiTitoQJ0rSWNa9PxhKhDOISDwRJVzS9EsUSvyVhSfSvwUI9obTOPBuskFCmys0hTXNqL9h2R5ziCeYHmetVaInBEqLOMUbPe9iJyGXYhCX6y5w1JHVO7oPUt7Cye0XaknDB4QKkkqMawwgqoj+sYOO1IDbc2CAN289q/v4i7dpru+xRoSTTw8YwAsJUIW7L63xbXmvYulabVphQS3vzokYzYGa4y6kK06uVItSQbdVUxO45P6KboE3LF4ctNNaxxEmAekjtZ5Haj2QzBg5iSdipbFormRYvmkAiwGqd9H1lM6SQlyfDfvLgpKu032+q4ZIke7PZJZHIqeSZLsAQp9/Yrh16SOCvJackApOmFteiGknoEsUKGRXj6uNkQ2vZ/EWcdF+GTiWULdVMZDtGKglXhDcK2tUso6wa8dCVxM5yM5g0Nl6ozEJcezKjLnPeSazksC7Zyzj+kmWE92DL/koo5rFogrwwxpdDgkuKJjFtaNBUzHc/ILpOMlyIwIfUd5VAR5/C5cVKYn7bImUxZukJSvO5qyVoKvrySeIjVrKkyBrXMPg2m4m7HjE1UJLSMHHVpYP4bB+H7RnoIWUe7h3i0KC9nZGuJETjkfDmPd/t1Yn4wLfE8VJwrJIatSLM+nOXf2rWqCA884aZKWWYHgqdgTBd1B7eK0Uq0ldQ1bU9ICAAZrPjo8hJkYyACi5Etx7bmKy7ZaOSIicGwVu16XFuTvd/Gx+g9zT08sYJBGybSGHjUpZMNwR0IjRsaTACzxwxxl1IB6LszbWs7XN5jKPV38pVbDaBk8Gl50oOoADzIIW+LmMag6dVQFecMGrR9hZHpZkZPUlBKlRCCbpW3omADqQIoBstNK3cp4wzsc63ihU+I0IIx/CRW3qWErZww8rzQAUgoYAdn7uITTm1K7T3OjWl8W09f62X0WJzLepvBkCVKqWmiJuQRaXJjYSjUiz1At/PpeOfl4vqT8q9gSeEv5VJFLmjJFYMzfV2GaPob5x8a4mjNez03ibfbJgRCm6VOqm7AT3p7s448vfMTNYuM2rhGlXgumCCGEAhWCxQPgOzl8n4JGM47B0P8Yh3Cp8Mwh0pvSOld6T0Io1dyWJ3eGcQHKWuLgftWjHUJvj4IHHdENnGQWu2ABHIqBsAJMzicCWOILbDybTj87PQoC0GDIvWCMeL8zZ6bjai845RBjQ688/XB6ptsUWUvO+wzFztcnKxiYckpbtb7/5JohVDz6Q4IyxLypgnt9RW5zqspocMFMsActSD/ZyCAK37uwW7H96+jyzyYqO+CzMhxfgJ75yP+cyOmiF+aImTWo0f1IxK2vFPnCmlvlxOtu30TdDNsEMAISeEXAKEFnTfkUAhbJAe+o46E5D4xrcE2GTQ5wh+ZI8tyELoMFclBrWSpPEMoRkz3vddmITiNsAKiWsa6gvEnqXfHy3SHzOpP1bCEgkth0WSVyHzNyU/VLJoj28GRY8b+Md2YpvITKnkxOnmFsMJeAFV+HxIRlyZvKYefsgGzSRbwyRvYdLuu1GW0HM4xMYXomaLm5mL4mgwHZXOcjMhpxygDcXSyOXUOJMAQjg/B2ovLcMsJa2Y5Uhjnm8EAgsTeLF1FJUbRvdOtiTDmEDkY+sHoK7JiSJjPvAgi2WzcFwZKlktbRvAFOqBTa1mw6ji3RpSEcLHkwPzgt0rkSEoFGBOIBmHCrcLh8cyDadI3qS/zcLMz6XXjyl5G4JClFV/k1lt+kspaizqWqCyGNd1U9JbhI3wODYYEd1RwLKGOQ5/zGW2VUaEhFlYYbnCE5CNZtLsk8c5USctbeX5TuIAHZaxNlGNOIo65UwGUBe9tOGPWc5MEbpkgNp2BbYlEXsUxlAAILFFOrpFCJm7cbSOW0pGz9VngWM2hgXjKfWaO0SxXf8EZGjJrEDjCiVoO28IHmwxOJsDdLAL+BCd1sFEYxpmue8flUqtObpQYs1iGUw4XFqB9rCyS4Ty1AyEDjAGXVouBCFaw8naXSTsginXZYd0XczMJXEAkMcSkImODR0kEZxGaucqZrkOEKzToSCnAuATPBe5dcKpFMGW9e6Kj4Aa/kwsO7H5QJHy5IXmlpKJHLYXcUR/1ne8EdZObAFejyMsDBEIMTBAGgNis9wlUAJA7+IpP5nY5dRquQkRw/AjFxFRhkrUZqNE52D8V3EpGoZiDcAcFdC8N9h9lB+blVCNJTO6rjDKjAdYVDLspO3QSBpyVhF26fDTtFFd9iQ2jkgMjoIgRyPM1lR87uFxx6TD3OikXgoXxywSSRq2N85SxBtUyUaXp2BapG4MUEW6I48QiJ381KuCAKjBYiGVu4rtqUvI7wbIzzYNpCUrG8JV4V6W8NSNEHA2uglKB+FlF+WaWA/5AhzuoJ2Og3Rw0mdWEfmeJKepEMVS+ATAzslzBvL5RxozuZSCOcDDqiVxwZZ/nJZBXipNsPxcLJNUJGxWMGAJIZgLlS6Xc9Ehn8ZZzgT7W5lj0ERDoQjcEHfqVqtRY800LYWVAXDLOOEqik9RhROvQt+nVd0GGuTrrK6EqjI7dMflkwPDRbWoAJRsyRPqDdLxFoywFvBTtegYhE59+71M0KrG+MMIHhMFirEhhBwhgloJ7cTKhDNhSioTdLyYz8fwdFwxDi5fC8fCUGV+aasyUX1daJ8+wZ0QqmtiToTiQSRZxPE6pClNyGXwBUDySRgSb5fZlBHEKH0kJc4rTH+FeCIzkHzrkDSkCU73JLEZjwUuJcIYS2y4RA4op22SpqiGy4lHeKVuRiEQ1/XF5flsRP8ndCFiGiaqQEjflytluwrSjmpEmwOlUqcjg4LiW2Q4ApEubLPIfPjnIlr5kdY4c/Ts8KPfRaaCwHrCYmrcGGe/kIpKSU4TgX7USrtGZ0NoGPVZKLza+ipbnZb9kFiUZgUUK4pU/ei1SxRFjruwHcPRg2FxT9DScfbk4n1XRjhKjqz0iqTc5eSLoyASFYa1Z43gCIomZHJjlzY6vB7WKJOdLUFNa8WmdgrBu7SMAM1bzmkTk1+F7DrVcmh9FkBAuRq5GLPasJhhC5OtpbNA7PDU+kZDEjJTNhXTvdsVhdgQE5kyaHLdw46A6fLsYEfIWO3EBsk6HH6iCzeURNa4xEBMh19yzFpQbge6ps9IJxa6AqY0ecoJh+yh+SJr8pff6I5BNbzHbtluiuudBNtb0twmnR+MVUJFDYflfd+ANFREGNDBbSxxOIf3VMrRBnAlm9yIJWAST50J2ssYoO1B2QHZz+WWa4UEg/TN2VAhkoMPgobII6GfnFreWOLTNIqtcnJUcEcCuJEJIhggG4l9fOOQIxyt3biaEzaEOsyN2aSMURCM+FG+zX5kPrJ5kPurzAPWzMDKuUB7LkHzho1n/UN4hu/yA31fG9zlBwHvVVN4mAbRAD2LN0J7ZRjA4etHy7s0PDDG7orUgmquV1g3lQbLK/mPQeKroNLPVAQ18bci0ZLLarnK3yPk/r4HpnBoqGajtCDEiCShP5K62lJEIZkMh4lwEkcUKyY6zWJLacIhqwn/7IDv3yF2fjbVJjWJB+NDkn7qQ1f7Z35O2v3Ay4xkBEva6f0hdXxyhZILAUOlW4dwIm/elGGHk5w0fjqVUXYQoNL0jnuYxy1Ffm9fl7g6gRkjRXYa2aZrRe9hhmGMTc+p64lWp/vFklTluu/rBpd5XMnQyye56Ptp2ENY0sIiNozJKhr9PoabZ+RipAy7yI1F2DxXMBvj9HhNLGfYDxDeAikcbC7v8SfebqhX49osrI/uw0mszoTqLLxlgd/iPWw+a4nKTL+yetnaZY4O12X+O1pfndXnC0FUTyU9vRi9EvdZhtXLTVwyK1rJQM6I1G4s1T7dN78Pxjq8TCW5gwtTZX2FpDhaN5p+ME4xfV2Oqw6FNUNMp+ebrKRFEm+aEukfUEqOlw+P+l8RyhWhkP5qmeBjK43U6GxRWZqN1SPsbhJPvFQBJV6LmjQtA344ePW5irjpYKSrmVQgOAlQAMYEz+MEonxs/7ErunmzIzdMKGjk6NiTmMrRQzxoWcO3omMOKYOiuDGuHj3HE2k6ercV664eHBqcikyOdEvqiJoaBRaJy/rZ0mwQ+StIZMpYCySmbFnxJFRPtFVJlcftn1YmnrCmJbMhkWanSOBJ63AP89axIjEvcVLEZpcwjMgm8otBhWSCyPLKYclaFza5epcATNJ8ESAjtuqpoJPSuadvZrQxsdYiwJ0mzKWnaW9clRZFW83JSID/6/Ur3ux09HTiPSLn6NwfXYIL5WzsXGAyNLPJ9oC+DB0vn8R0f7gTK4l3jabs05BYPaf/1UhsSmvlRsZNIKNTe4WO8aRd/wiJix/044JeNti/8/FzCz8HyYOTvaisFyId6fCFzGeY1Uarhmr+Bu6uOC3btiaBn6HT9rNxh2OEz5zZTvYkGVpmBPOllwvD+rNueA/IcPzMGzWQMdF8PovcPN7Qp5P3/p6a7z6ePoNTFtC9vfy4Z1HNF3NsSzdeYOqqlzgcA93diQcz/JOUEC9J3PKxDxHNxSD/BrlQGr7vml2VWRVxo86GaRTYu1WZ5ChuCqu7ISepuhtyiBATzZbEPrR+zgkngsxInvwEylJRiTeFOEjoH3NJQZ2X/LBHkG1jsHe2ijKsQq2CEdgaGSYdt/c3T4ND98NsGlIzwlIWeTkLS0I8KCZ+sHBZuCjFipXMhkqs8+VIhWqiOMK8RBjknC8s87lPJPOF/FhoaDIXajBtnXIL5VCfKUJIQgLrwg2PJwmd8ZTi0r19S/DyBcJSBnfFyFsi33ZN20lk7RHm63xDkfvmV/gusgVwo7dEzx6cmqEKV2oKQSJp5EIgWnbg4vWRiaXrS9GRakeaaATn45KoVB6vxC4IONPoJkrJbnQoQxCNjtMOyf24I2g436eNeH4OQc2vWQZdpsxGEgcXDR8idaOEjvezwWCii7pV5VWKSIk1++rCCRxHWh2nUU0YagYtI2KEYt1X2V3QStCERCBiQyLjkeaqupSUP6C/RBLlcjbWAR9j+RP8xAu0JiqKKlPMyI5H0xhwZ36A3GH/NuFxiPm/LjEH6yyJ8NeXuHoneIUX6qHliFTArUQWC8T5iMpEuiAn8IBciN1ujURM4EsI2jY6qyGhl9M7d5eRL44OD4o1LWEdQuP9bi3JhIMTt/ABLy1xxkiCX5S8yfya7nKNMU3oJ1B3yDKAnuQHQlalkg43SQcRpiO5oD3YdW7s/XRyydIAjp9WSN7jSOhXwtGdqF+aYNSkHkn5VswND+Zkj8YBP6IEBnKlJxDVfGqealHPS91BPiwLid0LLSzLunSFdY/Y4xTOOQ6f2ByMnkPfNUrW35Lw4+bIXY5WQXPjUqKwo0elChZu8411dk6Xb60J+pEgG7myK8fwfTSNhtF0DCduYC9hsnDOEe3vZuCq0aze9g3sExq7pBMd3yDvia7rCJ0ccDllnrWjAl+YQFJjnUDos4MhjCdMIygBheCitdyN0LWoCVs5UcjpeDtwEh7FWhCne3IbkmQFwz9BmTb5l/THH1iBCVPb4SR3hOvZUbXgqjM6MwuIz8/MLnk0NuyFMM5VsDkWUbbE/auHz8wXxMEUtIrUh1ckE4XdayTfDSwkc7JwSb+Ghp9FdioZDnG8nTi05mdyq11u2xL32IFG8r2sL+RmMFE6S2RoIDXOn5rhaOyuW9r9BSZmn1Elby/jVstkZn/MLja7Hu+pW1l/gHay5YSrHBqag75AjF0sP+3aqQNdgbEXt9VhpsDsQCdaEnDXTf+/YtycZTsvRnKK8kr3tWRWxsqKybHiikKXDYXqS9M/RjnjJThQCTcjqEnH5X2WNDz5+JyMzT4+v2KTUA3NuIj4/5cI236LNpumbosjxxq1ZjYqX8ZqZHus7lPsscaqrMtVhuAdGx6WMgxQuaynhGogzS/RTF/6jghMCaqWtNPcTGyL5A+pZNJyBlJzkDsZVJKrMoIVO63opp9FJu1Gma+5Bh0dK3d16eImaUbER1ArDcH8OBvOOBtIgjiHE5wo7uoCbgD4t/3jY2glXUKvroabzeyns9rqOLrnt0OhBQx1YXz90J/wxM1wEVkRGioiy4p4K1zE32cY/6pmkxb/Htee3gFSx04d8miuzq8Unc3l1Ilwnb4SjqqeCFctRRZE5BiAIjEBWrHwK5QwbUqyopxsVrXDmk3bjdzMHt9f3+W4PQz0o5gdzc1T0yryxe+75A/fXRIrhFj7zU7cxDts1+5fF+9viKM9rNvDIDMz439i89CIqIuxtg00KUI5zG87yL/iE7NWXGbww4oFbix656V0M33laVwglngFKACI4nGTVLyzuyYl9zXiS8PL58keyrdP31Lh/eQzgPUSPVRDY7sCz9Tii3WjK9qPXKlL59OREEG+2zthRCN3YEfHES/ALsYuwPaHnvxehawodEYXfJ/dwRSXbj+yhYufWIMEbqiSt5xhQ1hkQNcJXjWLX94g9RsFOCDRRrhkdFqI3BeNon+hgZzN6BnXAQi0/U0tEzQqqW0xjO2S7mFdekKU0dRGoEGk+2LjLA0qJE8UxaVJ4aLDd07zKDJcH3bLoakRt3aRe8LGjRxhxYsK5L0A3C7HMumcYCi+gN1lmL3EaIfr8qVHmXJAskowLfzJndQmqrNmNYD13bBkzUkVU8m4GqSWzA55Loe7ZU4UDH/u451L/jsafwYf6JZwON4WHXvc9HvcXLrHhlndpFfT+4ppfCvMGO4xe8glegVDHcwRv+lRmtfdnTQ7/G74+RgZ6O5+GnrrU0xO/GXymUtogDwBKokjzhYVYXcdi0wDexFBSo1Ih/rK5lt8sqWN8rhW3f3TluXqyyF1DACMyanEq0ru9lups4C6jWOxBLaggits95u0dkgrjEw7QZKVlv5KNM6PIT4oMRYiZlMAiCvmspNXuNVO3eXt4isQGupaE9FzwLH1eGYmQ45TEg8Mx9fmLB2W18tdhQT487s9tTB357stMl3pCtL0C0LT3F74YuC02CyNqgakIszIRaWzmiuOQFlNtJiuJ+nEupa+KCGi1JfuO11ySLLBgWn08cNOD+ObfyevsC+nawDppDMX8Ow0tZRTZtf2yBKXMFeAyBEyTYDs3HwkLFmxIRD3V9D+7vAy2vqMf/Wu7+nKZMYBGuIDG268I6hiyNcKP1vAsNAFz/wodNqJLzvYAF3+7l9yz0yl4u4XqbmZEK/vcsqZn2RW8wuPctmguZWQRs8kyWNmxgRGkB6ODlKSCNyljaaqvlIbGjSPmSlRa0bL+zFJCcQgqAgfDj1mh7ESJAAg/mtu1Hlgup9GVrmsbt1iVYVbnZhCNXQ+KrJVsF/yJiXrbelAOfLfmjSRnPIumytaZAOx4VwoUVTPHm1KWPUtqXk1PJONbuyresjXS6CR19xYkamWMGH3fIzM5aTogLrFj5mRQyXcOkhaZZhuCn1PlfPoCyaPvmBgrdArWToPEL8hHBLpkSvITXRgGUwMNTFfNBfUgtfU8FtlHMJ7bI0VctYbxorIaWPGJSbtFCL7wi78c5HSaI31KAauDzkCTkiw2XzBssn3VFmyGQpdExcMGYxIzWAaWh8rUdncBEknkISaqoXXraiyo2QGEIau1Ti6YgaBVlXfzEC+pS6yr/UW1Rrf2G6yi1hyKrrfW9mg6JEr7JEuRS5cf67cZM0lchmJLPtXEknNqyQrwJq5ZCViM6dW2e5KM+SbqbrkToubU026/yYb7oMZ34KpqsnWJf7sdGR1aOyyHZ00RLaoLAmswMpqIj4MYC2nNiNzX0Kkv4RKYju3NZ0whUzpgb/XZUfOmgLFcoiTXJqY8twac0Vsq1rypTxLOYllV4FAzsg9PUkDm0BcJaAtQ185XP7iBehVU7OncfCL7LzbcNJp3Cic8VJCKpIdFMoQmUlwwUdHIemYmV2KDil6mFUdNU+H7CLdStQaSyNHFGfcMK3msH8NIvI5XfJtbF3cFyxwCNpz4e1xfxY3rEncXdu2I+oFiEesf2WTcNQorcpaQ3eq+jDyU1ooLWsTo6wht1dRN35NeYyqkTFqxNA/mzho3D0C97GIN25q+NJi2cdbRqO2weDDa6iu2lDrKgi9/hVmWTNum8C6Bolizj1XAKpcbiWmAltYemlbzKErWUXloYjgQOyUsU+v9Siv21pT0Q2gTLYyPh3stOm+PxgZbi0ffSTLI8A1CTgJuKYC05Us4zhx00An6gJBsq1F4zy6VXac3bbmX7Q2TlWHdyIl/EzbnjfF9rwZLKA2fLAVJO6cDNiaioB3yN6QdT3sri9EvV9NBA23OgtdgK6aEW4mmbvjlz5GLojMyfSIQrLo4RWtbEJHCGjCQ2MnjH2sDVbc+V89Mk+ZVmvYSuQ1LF6a7zaTr8ZWqkGZPOcKMJOciGuIMI10aTWtVxJZgaCSXNh+IcPMMBHTLMkYNHI01gqb3VWSp5zl+7bEMumQOZ5xCTypR20XSim1g6guNXi52kKOQGj+KnwCs9KBwy/h+KrxO3aAQ6xkXiX9SghZX43hqsANPUrufW9rJEVE+QjJtYy73PhJvATKWMMSGlqOC5gjdDVJzhOHhdO+2GwGsSI33ExEyaaPkkV499HQTjYZsMOXNsSh2VTjsMzNEuiywDkXhD4pxa2MmKnp/mmS7BbtVEdzamxdTsjvuwUMWzEhAOkYE7AReoU21aNZ4/5BSrFVEGCv2upySyngReaZZ2jjNcyWBNjzl/KzZMQlGNrlmScgALlMl3wSJUHVHXdg+TzqrXwklrgnZnYbzAXGiJFQNRzcQ56oARSGwFk3SUB4rqz5MlRiAiZHhWPQlGWJjBjNs4VEjnCWmAwOLHgweikjJxhLsYeplZf0Qp54nxsewyEvqVFDr2AQ2OkkPKKRTjAgEybJu4KtHuDFxER9/1Igur9W3OlgJY2s30dCfEI2i/dOawDYTNISW1gkO9mShoYW13KSqk726SpTNrIQqcu371iCdZaoUl2NaYV91syadcsWU7NJR/vptBM1Lm5JsCRAA/pBu+W5BHxIKttndWIqJ0ooXRySyKqhz/MCZE+oLZHTVM3QCKZ4sgLmxgp1SUi0mywQ2YAU11NvUxxZsdkdmumiikcnFhU1WBInngkJLsHJT7QEJ9RqzszUo0qrZFWWvxEVuPzN0pZILlV5RMhV9W9AU5uVbNXfbiiv6DofYWAuXJ7GPbTiBgK6qmNncYi1SqwkvLCVEtOwyIyp7+HlJVyPy8xUUQMU+GvtaqooelX9eVrGm5PLCbqeGHkO2KIuJ4Qr3Ks9A26DqyZbkesJapHrCSaSrid4mnsJCG2mImMUdqO/BNnFZalB+AWcaJdAsETykE3wJBY+hEPOBFfmlD+hK88V4nMslOAvOmwZuSOhFYFtLQm2E2oC1ZcAgkRmChnOJRjdRnDaIqicT0wfOSJt4dE+riQ1TU7j4w+iwr6U2b2vh9EemN37fO7XKU/RfNi3zHzYh7BvNBJnQ8S9syA+uf3ZOrrXTvW9vEKK6WqTSC7hMYlnNrlpXwLpnEzp+GQP5IVeTwJR1xzZvaiwE8zuN5ydVH6pqzCb1P9JNcMSiCxJ66sb5mfD54GE/6jwCXjciPXN6rXaDn0S+sV1WI7P1ybwKH5Ph1PPEY2RX9DQwR0ijESD0+8Jp1yrFG7S5V8Xrvlen1UnrhtI9K7SJTteD+pnJ9fjrfCbQC3I5mit9OuX740AdNAUpzUu7owI10h7/3EHs7iQLrl+hg+Ixc9fsLXLPxc1hkl80/UVgCRcGjoKlpFIFEvewqJK9KgOSDB+/Jix87xTFeoZ2XlBMbf0tjYw3V2WzGHXQ1aLy/J9gQVJaGWIWOjFLHXCvuASRXiV7GrxVnB/bUptUvSiC8aN5p6cvaSKd9VHuai2HOjiYEtyPIIA5ldHpO0agnBgTfhMDCkrxMURwfj6HUocZ/WJOPWkK9SfCk44PoL61QUG20TEShI3y3T0XCnuJHj6aHI7jRzLXN7PT9OXmj38TZ1oaJMOfNNzVnX8+dKaKvFX5o8iflIxyZ+ImMTk1Nef0XZL9z8mNFjfSuFGy1eNyh67A9+FWJ7kKTiIwLLx1Je2N+7JbDlaIQxb/GYzulWKMvOhnQ06bbPerG0CVhDA0oLypEG1w8qIZHUCWq+IW0+YWoyF7wT2QXezjVyqHqKaqIYga5gk/QNgt9oYjp5/XRltdZLOvko8cPjga9JpZUeNOVtY6vRrAnkbj5E3Oh1L+30+PnGC9yRLRphSOmohKI7WvlKKM8xYybgU+Civ743ne0UH/t7vtODh4ul8likoj7neKq3AX3TEmxlzN5Q1EhyaRUy1lLh+T5wuzc3Gua7YqU/Od8k1hHMl+I1LOSTvb5EHpHklm3KQTGvqisONe5C5FRwWg18mhYkqy3xKlxtf1jZNw0JjVDkwk8ycUPJP9KaKHDJvIHkf7O6mh3ABKpTF7GqeDG8nJAVOUIuxyEb4kh416lZqK2SC5s0uMRKhriReZeWfd4/55gsbDXRFxfMdCR5s42ZccbF+R9qGjA4sHFeKKlX5cLY4XQojzCCWzSVcWaov5TSYASB59zAAZtxOX9oA12MMYuCSLlWdgpIq3m6kMQ2Nb2669PlaPxlH9Z0gtNGmLCyQRg3FBi242AVdqDCwILxWsVdCKHRwu/wp3lAO5vkegS787eg0zWooUgLhhlWT7mqZIp9lmajfCIZDO+MGrDSE/iDgL7Rjem9dt0PehRIbKKsoQm2VBCnWnLTrVTT/2KI07JwFeCKvpZxBgQnrcx2x3Q3JqE3HS16LRTpOST7HEIgbBZnAAGETTibQPePGpGG6PC0rsoD+yYCHgyUCvtaMrQG5OZNbWhbSJf4m6C9xL0l2oClXSg5HncjJmsqQzU38vumYRjyisF5eGx5pdxrXlbSvFZKmQ9dCopy35JbJcjbLMaJgqkuZSapN9MBRxb3jBu6RtrgmsxbRZE6ENZmBF8N0xWWSBeYO5tCwWqmm+vbQ0v11BFeEFoCyN9Cggfm4WMJ/hyxE425w2EaXRo68TqR4+Mj933LewXvSXMqKGMdHTWh8jnk+nypHj+nsi4bIpiTxOZGgCCaVZzNJnlxOL9x6Ur2wj0m1CCZNRPtMrSJOH3d7mijVNH3fi12NuKSbcNFFwk65uaTxQitBp1tbWqc7EdXpilY+V6xks0ayOW8uZHjejJJOMqtMshdXp9R9uVzJKDd3FUa5njYqGYboY5SQiOPhlJJbJSWoV3F3V9DWSXln0lATFKhp7h98TsiIkNElnLyEya3Agb/qJiNaKrDzPBZ6lx0WVYKklHhO8a8jDADJzYQWsyTZQ15JU89BJYsAeoIBnGACmAjgyiKAznl/bJbqJjP+ehLjH79S+SlYUZf0DP+1zCgd1gdOFJ49rL5V0WsRkxlRKcMK+dBABQ44tMlymRplWY4yVJNs8Ug+CaEygY3czBM1AOIqu3F2rdkKOM2o86IoKxKMmdhGSjJ1SbDD8U1/YESRRpPLhNBFR5yFq7jSttTTb2fi/VBBOZab1HeAf7J05W/vJFynzKdPj9grUpe5nEQylCTkE2VXsulShEQkNmg1jkYhQtEyozthDcE9qwZn+fcDR16SLN+qlrVbr7Fb3mBZiKVaTioIOPo37DfMCnL1b+CWKi83qGk2xOkbgLVGo5yyP6gmKBAi4E8amfCQCP8vpMIs75/1hV9/lIYjPmJQE5Zys0y47aEzX6PD0ftkIk2VthD1WXZszGD7jZDbGR3ucggYw7kIc2pNxPdHm7jV/SpexTdl4AmHxLEO823ymfpI4xPuUfAX/iQbDn0HFsCazo8cr7Tb6W7kk4c5LPfxqzuQJiUKX74VR4KpWHAhvGwuJq6VjtnaJ91s/Ne4wHipg7BDcffndKt319MctA/mxbbxN5cxl/Tvbiej4P2zHDkDn1L+LZ180U51Pu/knJU5n0/zOL5Sz/RRY0qxTjGjTrFkhs8zZzXVJtZN6hnDXy1V1wZ8aiXqeyvuM1sW7wW/kijJM3uzdL5tSbzgDgWFtOrLVJWsmWQzH2z9/d/0KBk6+xD2h5orJTc0IrXqKQ3WUfkcMjOl3aLoQThpEiS1KOJ1Nre0rwBoMDNqQHWHGRxKxM8sYBn6/cvKfFDoYAbdXY/+joxy7NbG0KHUJM43+VJwEzXXbM946V17w79YwKeZkLmSpUlulFeKbdRYNbUxuRId8o3Hv4aLPcDb9a0sddVKHJAkXeaL5Aqd3T0ducoWj+JLhFtNvTxdTb0JXCzwILWErgGvFEpFmoksY/iubvTM6FNOnoDtEUQKSb22ben7wkup+VZ2CTi7rmyZi8DDPVvuOvB46pVdCh4nhoQNKca3gBb7s8bMjJOLn4VrWGaq6Y3YlcHTnhXR1rJeeVIfs6VUQoQqHoZvzDcCT7oyeZqJLMDJJzuXlopVXZ/GFNKRFnUVuRKeC5yZWcoJxwDabkjeNCIOwwNGCKJ80TlggwiDQmFR5oaocRLHo8fOJYoT2mkQWxnHhtovCT3imBC//wmy5lR+4C2pMyGbSHGmP2w+aUdHCTAr+Qp2gWGIzZyaN6eZHEkNiVo747F6E9fsyBF3Ws1ioeH17ClbgBKvlDMSrbrywlZI2GwvLTcEMaqdDbGgMmlO3LVN258I22351u7BbUqB3TbOHejNCk+J+7boLNewXFLRZwaDApcXApa4iO1J7dGZsANYJww7Imsgv/hdXc6nTuCcU/b0U/ZZwjTmAd2OItNQDp3AYoQo7jw6wad1cA7NV3ZrEet2M8m6XeZ95P5nnWV0mVnZE6m7XPcc0b0uPaqkX5lFvVB8ILrDZNKzg/0zb2XRestvRQ64vkqxd12pEJOhuTZLdfjKmuqRX2xgFZfqzxNtm4TMhTZYtemsw80ofaTwQWFHQKElgcJMspVKOMMk4VFEv552xPkvxR9pdIqDMDqosBdDEcItd8Wzoct4WnQJjXTsqh092C2KD5DLXcg6f6XxYdc4JB40kwZJbkLqCOlJVtT6lkAGwrPN7JQcmujm3J5xLC6ZQjt0SYVEpQqqvFtIWOySmZrvxWqpE1tro4aJVAS/2YiNRm5YQ0kK1n9TbrB/b1rWV2/Cwmctq+/f3Gjok1pDWYUMMStqleLf2Sar4en6cGD+zbxDTWOcs448dQMamAm5r2ho49DhYekdtTGm0FixigJvcxFwYQ8hbZceEglTISKuCRXe/GGpiXrw9h2mGzV1AMcsMqbM4ycgLFOrYku7tOjYcoqWfGtelpVJPzlV7nhdOAY0XDazhV4w0qG0e/dQ8B3WnzWEv3Kd/JVHrr4GTDbwfj06KuG7vOUvBapQAnLqnUFMSdRTtXU0hqRrRlTfWztlfXpP7UXgRsmE2IgaNz7lFSoIAy2nLau701dwPwrzosFGf9hIvHylYpYTLKCFZquSle9QYQobJA9OYlnd3U6CVshJ1wrlSma68smRbmIJ+/yJSBmJGz+MEhjstDHa7TAPhDFnaiDt+C4lU+800MOmYpQh7TSb4vMdGX+Ji11SuNKanurcXLVl4+Y9HlrhUxOaQLbG5KtgM6y42Bax7fZE7RGZViERZbuX5NxC4T7RjV/StjKn96zWEdreJGIEkm5QbxfzzejLhk7ohFG45sxqh90wEtox9SulG5LDG6hcy+8whb0TPtqmh+4WFPv5q6iWVZmlrpTp7s4Xk9wPIAMOATV93zagYW+8kWEOdgMSXkm7j6UUj8gFjc7KKITgS4RW+pD5feOo5Fs2pmFPovFsXY8CCZXRos0ZWcAk8r3khUOUIu1+rK6u5CvKwlYLArRRfYMu6xr0J9Qz6IIq4T1Goe5gI57w/rPQ9lWFUR/pgE0pth1VycqJQidOMuzsXFfgVSFwh+wH8n6GXS1E7adWF7u7+wdDF7nKlqNxeyvpbFPEpzJ1kHUvQU2hynY/0hHxp4Wify49DZRxRUjKlmbgliduCLOUf5fsck5iKkkXJIY8ACmr/ibjX5fEDVHIFxBdL0TmITAtdbPasBwyVWdHJkuJte5aqi354mgPWpzw/eRcaDxINI0bpAtpRkwOX7qRFuzhld9GGFHMsIsc0mxyo66LsGwhNdBUoMroDGYFnT/qyN+7aCAg33pInF1Jjo9tnyx7R6KbSyQ/BLMUIZqcicbAKYTBEK15enDqK/TFlXrHIzUz1AMm2oT9X9ddhsGJ29TbpH1vPC0FPHtGyWZWAxNvmIDSJXyFEW1NmaszuQw3w0CjrZFp09X2kUUmnnpx6yD1KmQ8UXZVB43Y2DVrWHVN+HBF0wpnVhVNktaksgjDSGB3AKyGG7E8j+oz0eEXvQmNJbZrR1ZwTFugB8JfrJNnhBCCGBVkoGqGQKVWEwadDjyKe3wgj79bz28u8799MzA/JMqiofJzuOlKypN4dQ4Gs3nPGGXoEt0hCOiJWYVwFrOBlDMiSafkLspHQtvgrHde0+zNZrxmDr5eEEmpu8I9lWGy6+a7u4siioqVbk9L0VgypQTdFBfSOHFGljOxw+hGnMPR57Tc3HP5Inrg9AEaj4ISw4FqUA6nj2qsBzbrQXe3uAyYLTLkPZssYi2gR7vcUd+zQj9rfkLDo5X5WfqCHmspPWYUMD4wFS0ZFCUtDURaAhw0CWyhxgU3jEXRxb9qwHyuXBjO58Mee4KEeOUY+VhKbA7Q9mxfb7clgOwn21UYJX/MAqnScTJroSoobdxz+53QMQOLep862tYKR1vtHRgSiZmMPZsqOoXO2CHb7OKiX8eLDBsoR6NZqG76q3+GTUKmZ7CYj8roybp80XcnEQC6MBqHsbgIMS1DCBVE4mxKr/mtiC5voISiaddZSZWl4c+oXBiMaqy8yGVKSSgYu0tJrpfQD4dL58MljlrNyjX7QvJ/ZdWI7cVBvyFSS2hdSbjyNGCeMhlpk7ys+3aepMqOrW1iEHFBxcVgExRoIEfjJ2Va0BE6TfeC0fDN7Rw/pJyeWC7I1sxJ3a+Qvsq7dLUwCmjSSrlUo+bGjf1ZN/E+TeyVoSYv2qT7R1t3TBTdggqawl53FUfLuD8w23IDtioBVxFC3B5BTTVKwN7IJvgRziipKHS0gLkCBiw5U82V79NSdTXRijB0Ciha8PolzlHEijfIFRuKfHzXOUFMD3Uk+SZgX7FKXn9y+i5jFO9TH/UPMzK0nnDLmfUjGzdvVuh37CV939gmY9JwlfXwqqxvNOvauI5qHHpV1pvTCmPCQRTaYNSMMTy0b1sN/sEeWw1kIkWKrcpGzdHHNk+aFhFdZeNmCqkpG+uEFGOv13VzDIMmrEYNw1/f+EI8cgrdGFHk1nDkFmuvbldZia9vCce98sLLG8NFvxwte6fhNnSRfWc47lWo0i/6VWWT5tQVvlMYdGgMJfOx7ZZhusqmzRAP/HuVzIzhVdlkaFXbQBDCm/L8lPWmwX4h21TTMvGOW/YNSx1bh8KfYxvQLwAL245aFNNlqrTn97kw0zD9Pld50daadX1KZ6lftMWTh7K0GI6Jg2HGUd68aWSMeRwd28bdvGLYBorYacdjdsIPDbxhtnR434jfxIVjrAIrqjWJFUOf8V35WwCNjyjsQ+FOnse22dADaFRVJ0KhbNn2vOIPKHtTtmpuXXnFMv3DHzLEX4EBsxWu7B9jQgx+4qsf/HrdcPUxupyT4l4fUdBmnuA4tlWzdys/pd8dWo1cfe/QJ8mV1thmEwOw3zs2KyPI55tVfWwnsyRvKCP4poxYE+7YJovMPUc2KSJ2bDvO3BYbLEr4qokjWhvzIaS8SgDy0Yy9Ka+hy2Nq2wjwOuSi6bURRe6EQ78/k8fhZzgQP/NHAt5GMuoU0B7gaQSu1Ma2G1AcH52Mus8tT1E0wzHESOV5QDzlecQ0zIXpM+qkW94/VJpw1WKhNAW/RfrtLe2D3z767YffWXUPpYP1ENLhb5F+e+m3j377Sxmoy6iOyTPhZX26qjXHxMk7ZceLm8cikyAh7gVYqZPCdyYH//z1v00Izsyq00AEiSCNbWGWels2KhsbFtAseQC3A+GyTJNGIxxRVQRub6wqVXiDF+JcqtOAhFPjEDFSJdoRzof0oWpMAaK80qJ7nl+pKTWalc8L9RLDza268kIMobZPKC9Y9pTmKhsnlM1MyR5OYCiiP/zFr6ehoCgN0MCdNcSunzeCSedDoaGw2qF7U+PkUI43B6aj37EpxR8ikU8KEql24/RFnA0KMRXRGgVoixluuqNsI4f5G9nTL9ri3yKr+A5lFoGickvBvUfCebnLTYUr/sZedXBslVAhShO/FCm9QjNPLsGhoKBLVWUExt1CrZayESJ5/Yq/wvj9cIEUaGId3WgGBMBP0cqo47g41xralAK/8FO34MeEqhuGZo69BPC1JhvTzbqjvNRo7VXWw2KECzU84GdKNyEVvsDPHh04A3w6rrJBQ50J9Bhf4GeqNUW/8OM42thrWp3e4MfVduMv/ABHTYnhqWyoa8Zup7UbPuu7IZnVtKasCYtelA22Vp8y6IE/RgOWe3wqG1qTvFZ4gZ+6UcNf6LxmAs2F/qwft2x0gABUFcIc+LGxA/iAnxYAh1I1xjXWscn6OK7Vu6c0iN49he/+D0Bmt67TCyLvFAzoz6enp+G9iQsxPpSfahq8tUzdAF5pSvmZ09qnbJxu2oYFM6oJBHTjtA3tx+TTMKM34faFDgu8A1Gb9D3Q7ElsGr4qm1rNhjUNrcIX5fnJaagmMkQYqDwPrXcgGT6V54Fls5pQPr4oL+qWPYkdwxflRSBtMMzYWHxVXrRcXE3xgWu66QIvhk/40fXd+As/rTcRMQ18gRJa9lRrNxbcslvKS5AU/gz8mWw16IE/LdOy8Ik/rk2JXBuYAhCb99JDecmAqQOdpRdl8xTgKRIawLIpjbANhnuzCYA2cPX7uWHWEbIYxo4wsmV0u1ZvaHsMZXu9EY+yoW9Q9XYb2v63GkAW8QRflJc1A2HzMv1oJmAKhJn4g8iJrXqZ/Uxr9bEtmAaKfxn4AcupUx5kDV6uT+n0iz/Wm7sNesBPq6btBdxTRkDKVrZoFv7hDyyn+As/ehNYDnoAwZwab9Ev0U7NHluPL5r42oAvGOe0+M90FXuFD/ipsXeobatW197EoYCXN+GnAY3HOb61MQ0/GvQOwIpP/DGgfh1ybmUZ7CowpfSEHwetIsZexAt4ADFMyKzrrg5LpjYN2LAVXiEE1vyxl43d2u4W+4If20K8GoMlykFDGwioBqEyymKgstUAwGxv2DUi6vBjThL9oTdlK6awAWpbgSOmNsJT2QpTYQogv3UaYP6KNg6DhZ14BV6UV/S9sEAbY1uAY9mpNVoYoPGf3Rb+wU/LqUME/mybxBm9bRJ/GmMb6wYM37ZGdTf81MZeapmTjErgGwVtdjWcsvig71fQUHeMSCO2QLPHKXg7smhVBR/iG8mL8rMmcGMYAPK0lG9E5NvZsndDvm327jr8GNMa/OKPo03q8Es/U5pJQUCYAO21vfWxl6YQVi9Nwc92rTE1DayBTm/w0xrbCPzwS1oL36FFdW3SgTlBL/BjARknPNpeN4GtdeiWJnk6NYFXfRNn84438acFyfHXhjbDEBgutX4KP1s2cCAwyelVGUFeGmbSSB2GFj72UD+huTAdajUEOj7hZ9J8HcUXKHxk0sRYsw74Sk9YWm0NQAVEAaMtLNuaBmbBoieshoDNNJvxDdbDhuUaY6/AUmzQB/zA6FXxUQVkgDXGmlR2TjYm8QPoPOAEviiEL4QuOr3vxOZtwZmPX68ZQJZ3anvwZzeUjL/wM2U08Bd/gOS59AAuvNGabNFDgVKoCHjgj8F/DJB3ARTwhDzAxQCdrys7JzCzYddbrkZP5VXEPKTP+AIMu4F/hvK6htoNGFOXvSt/Z8B/iPg51DWu/RIoxchbLc3WMWA8o4655XFkwDchT06/QLDNNwHCwcwmSg0tGdth1WEcALngBeYeUEAHZxk8Ya6igzejBtIavk9wJJ4kugNPHBH/o5ZRd7vlMWL8geogwcEnTA80p2XrGr4rr0wb2m4YW+CvtGq9pQeY3ITegTxmKa/DT0Ydccu7sbiNdUACZ4oW7rrtoMi7G36A/xhbvxsXopfriJJjI8D1NsZGaBlQXjZcR/k7/ZcG/dSMjLrRLY9QcbAeW2NbDdPCApvAymC3Xp2erAMGb2tN2jSqDgyJiT+WaymvwYqxu/WWQS8ZdS8JJOMkuIyR4LKbBJcRElw2kuCyEat6yd7t+ssKSKVj/sL3srYXwQFMHqIzgWYSRbndprUX+Ipf/vKXIEM879JBUKFE2+wG2prn8d748n52g1LptewkfkONmdXTbk5lwdsm2AWrDsTvwficalomE8pL+5khFJA/YCwnLSoEszLwwcdeyjE7i94lRK4eFssEf3boOh6rykGT1VCKaKWhtE51udKc6r7yks2ZFSqq9W65oG53y7uGYJBghGB4YGxgYEaH17vPbhc3J8MHGf0BaLe7u9ZjhzH3K+ENv9cSNvxoG9YOdvwaRu0F2gPMTBpTmdVZN8VOvpJpTWdAaM2lJhmqZJylUxT7KpnaMkkGKpk9lETlyn2jatXEIRA8TowYlJK3vwIInBjJtyy5Xz+homabn2GFNbccZn6vX/WtTdn3a5HvV4IDjIEBN6o/N+MWAZ6ZkcIYUrNgUSeGr3fQtgAaudn5aUuj7RfaMhZFm62pjVrTbWFu5jJHlDql7dugVXfv0Cd0FLD92iZtq9XE7ctgs3ZcTieipDm6U7o9WukbZLeKuM+V+9Ft/v9X3bM2t20k+f1+Bcm70xIhZBEACZGgKFVsJ45rnTiR7ezWOT4dTY5tODQpg/BrTf73ne55P/CQkr26c5VLJDiY6enp6enXdJ/NR8l+P+JP00T+Oo3w1+kIv0Vxgl+jeHyQHT/SO6aN0jF7Zcg6OOVvxIdfS0W5GFxWVjhfMZwtV6FrH3sBVoo1n37o8eu5fFn3pUECZGASQS4jRNkGqaTOvkkeQ4s8hhZ5DIPMfKNoMUxaT3NtupgGh9DEqBUkYbCD+rvcD1mGkU5BqLYEXFzGZGSdk95AQ+ugd5JRVl7agy9sJ0RD2gzsLKSrItgdxEacz4VL7DiaMad7bsSC4VX4rkwwzjG+3xdn8/E4no7pp/P5+DQZAbkOItWfLLBk9jeIVFFR+mKaxHQzLM6wi+SiX5ydRcNgsDgep2mUTCaTrLCmDZEwD4Eg/9TZd1glBqjjZ8+fB5q7KFhIFCwsFOz3/cKdd3CG0wWMsdnSh1k5iK0Jcp+kL9rCSp4irwgtSpWGxKGT9Xb7++INWaxu06PEtj6AO8ZiRZXqZW2mF9n1tYh+8vZtdUwWFa42d7mNsOc+CcTI7F4DwgeRoZR7uGOAhX/XTFDqMoEKTWI3COquDsirUZD8jWX7RY/8Zr/fUP66kHcaZrmNmDy0ss4C8qCc0iH8qWSCBhWeLsnr7z5fM4nDf9Gi1IQSDIdHBh3yguBdKAg+nC3UPYzFYCCqwzIyhhzywQzBJvI82FiVQpp5WwfGxbRHso9wQbcGBoP4ugJzF7hHSE1n9FgCbMIlA7x2Qw8v/r2A74ea/Nb03KRHVHHLaXgWgbuD3DOBpdi/4rnxIfykW4rDpy51BGR/0GQPkYKQpWVXJ2LoH4SBaD627q5yIcuRsLziVaNsVSFYeaUqd1r41JWqtF+1Wa7y3Vv9yiDMBOOgGa+XKSUpniD2cxRhSTm2xr1nm3cLijqy6vwlgFB/3mia4G19+EgFrkB/4xHkdnjP5wuVdtmF5R0my3Xmd+7DhNaboC2WLqynWAu/FOXBgntPiolucDeK7UwDo2KD7QLPsBDLs+osETzYWnwcCD/SKUZDscNY9KUQlb3xjh4VETkCRwFPnlXRTPuJvvCLxC0rFauB/RMYpzevO1T7Lsg1bdvD+2s4SNJukfRpaXA405ohHZ05VGQBC85WvKg10zvmP3gzYJrvyz1Em0DMf82+csbWEYWT5xKJZ50VKnp48mXdrmQbzy5smLAGp0h8Ih8Lxy7/WYaIVQDEDlgDJ3Ji3jtaFN0syUsjb8EdOpI7NElFEFV3yHrABjEvL4Pf0lQ2n0605ozvkYNsOGIEh+8kgYh1ZjGptdy5j7fL4DW8WM4+RgrIxMy1W8W8OIuC1ySL0tLJ4cZGqq/FEooGKlUnTDHsRtZyqOVqLVp1u5VL/jNW6MUOJK+lGPSQgf2Of3SOilhicKR4cpqIOwKqV8ygtzKYB7FHttv4068pShScRbDYIerCkhRUx9y9jpEuO9yNkHrPOEvF2o4CZyN73i6stxWfo6eR1NToMUdlluJsxy4SS5LZoNN6B9e7oOLWFiJfIDzr68HmBDONaxhdPNxA3g0MfzVeYdSUH+T9W2uLm5XTqtgeF4/uyRyr/VKtc+ou7iUk59iRJ1vKzD7sYBCWiLdfum1lp7ygitvi2WYpDuQHsJ+8vdgtrIlWQVTP2gzG5HJdOSmXQVXg255K8/CjocEXE8nuxhMXrir2pMNXw6YODdDfq4bdhbea+RoHGA795JpuKX4QZcymJjVCnxwk2Wr7uXd8kh0Vx8JGpFQgQz9fvVvo//LucFpwzLpc2W0qJm4zBXfTVXTaguF4Todm0dJZIhbzJwH0bjZJZsJg1H0KVggWsqzrVnAiCHuE75h0eGSlTg/2hxzuX8CBgHKIBAKylD6FQk1UAlejzXTRAO7GVpCiDUK7CTOrBtnv0dRN/xJm6iaaqZtwUzf9O+WtpyP2l+oLeBOGJXipQpC5zf2sAwU4l9M+EMqRYrTsFrdPbXL0X51olFVCqFDYA6pVlH5QgDJ6ZVdOnC5nVQzpYC2MBN2dsFdNF/KoBwvMTqHupHCESOE39jF5AZ5vulV8zTdQO/DrAcbgU1hCpobaPQzmT60d52iado8/sw5hq7ToTCYeaTlvhLfqfK7N/BlFmLJCbLRc279if+RBOI311A0WGM+Yq4+dCyI2Fa+DeETVIPQw1CVjmXxXl3S/juHvob+TiqtkbbuQ+Wak5hE04Obn/9eoWftRs99P4uFIfvoD6KoQL8UBY29twwLVLAS0EBb0Jpa1UrX+q8FY4aaz0i3602mjEMbd0dIWFlZayQIPjkyzYp0Y7FW+lOgt1UB9jZj8zKcjJMD83DX44anlWDlz1LVoH/nZ3Cc3tpb3/1pzAqB+ODxte+Z1vCbWihMq9J0CzHoorYbVR4BFRy3kNR7nXkOavMUjkdXSafFfpNj6nv9APtt73SdS17GGboRXUjWDm/n2I/J6sfzyeFkKuqobinHB8oucq408Y6Yt9MuplwJsfLUmOcCjb8VGE3tHdx+XeC+P+xn7gUfqHTZIvcbCt5I3O1GEEqXDVqf2UBkvkee0jIaephN/08htOoz9TWNPryNuT7PbJu3wUkMEruLxqELx+M8kbhithvxbutvxWIbTuwCZXm4Vza4W+TnV9/lnsqJ7VFjDwlEgL8U7LLk4OgKf+ziepix6IE2iqfBYunYXIdzC2M6mrRx46xl4K2MWtjxmQXFVi7Ti0Tf9xTHCGAz622N8Lxik43GSgpmWbb+N7XpbqMx2bKKGo8NhaZrxUFkK6ZL07ZMsOJ9TqOk5FFFipP81RlC0O5QB3F0VtzC5mXtImUeoY0+2NGzkl7QRM32ceoh5dArkO6tWRlHwIIbcQg9JpWHeSCc3hAXLgWqyOQ9EdP6gCU9REx6fBl9X268OtXxjPhn0yfEIUskqsA6f3uRr0u8bndNVHU1Exx7VRAWjXeoxYxhAJkV52ea+3uaStQHeHqgmj63QMxi9hNFVk7tVTTA6jceqnZqxasNYvf+jP7rtdHhRHqfjQTTMjBfp0+kpPqUYU718XwHF+OAXUTSRuIHN0vX0HIvRcMhD+SbsbxQJbSARD6b8wSlTCUhQwTyOzcMmmhneKEv8qHRMURYwQQ4dwNgssQr3aCiHW9WYOtcR5YR0W6EeQcrKCegV+gKDHUm5+ehIKGQ2u5EF3rgJZTdraiLcXEPHMl4H2g0UBKsj204SWRqDJjU3d8aqcZTSweR24RGPRaSJB7BvNyveJV7vD6MD82wyxdKWUrcbXx+PCxOq4g9DJXsMC/9ytZiRE6/6LZ2WE8CswsBDovtQq8irtgvMNQuZF/ParjDtnBlY0IyLKp+nCw4L22eAkOAiysS+/xVIsKq9DPOXL8YZN0c2bKfaXeQonjxUZeY1wc17vRk9PcyDqsK6RowzjhNYjyU0tJq32Og3g/H+vxzG+q3WQh+u4BtVejYeYn4LwVQwLDKXkRTCxMZ7wkyDoHBAYlYV+toxYqN8Hi6ZNkEkK4S8xMDqc93Tgsn4nMadd4svsggnq9ywQxe1V9I0QPThb2o5/fSNc+FM9gkpjWMrM/g25QjfvbsuvyBWLzFpB3gETROUp5EnqMjSyaEtj6eZqVVxDU8o/o5dwV/voMJwpcwU+z26OQhPWpt7mJq7gOYrVMI819cS5+mEGTi9HGw/hoT71u5y03Jpxf8IJUNiRAltTB+gc/8e+LrPDMmosdkIKZ3b4uh2DBPThCU1du29Dbp+gwhq4mdSJT1OQgsfQmYZjateGY35O13npSqzktiIbWxLnT/NDu3wAmMHu1ijHM4Xt3OPv4p0DIDLLOtkXtEU09NsVrjhYm73yOexitzkhg8W/YgB5f3nySRMJi/oHk8mXcto1mqki7grRsIquZXb1rf7YN4sIpaCJWXwGY9yVEDSxR+NX1ixml54ajlHexBYdsGbdoVwzwIk0obVBHrttkKwQou+pl62JQa4gQoh3tPtGnV+hlp27+3H9lPNNL92zrk35UT5+e7m3FsZqaoDeUyMtjHwe6YCZ7SvFQoD941wHIdF/ETFXLISQS0WeNqPLRiqrtEJAWlXLyCpl5M6Lfdmos/OjU7Fw1DLidrISll9F3kTy2LHWFbat5I2xhuxxlnINA6jKHmhR5ip+EmPkOkM5EWqYTuoYBoygL5hivXDVoXY+OG2Y9xjkV7T2xRZfRyovHh+qKpKpMxabKBZQAYD6RZBp0SUxRV7tT6qx5HBhD2123g2iwtyHr7JM/OL/EfbQnqKuSjjOFEmjm9c3ufzGHvzs+F+n6Pkr7mhjo48/ChRN20TZlhMJuxWbsxu5Y7UrVz6dMzMhumIByqBl5//GsUps+OhPNnv+nxl3CY4ivhfbhIcnTrXfRPnum8/t2OhLBxBtHcQVJ1VDs5beo9qcJZw8BMOfsJNnaOROT0Nb/F+n1bh7TaWeFfubBmcBk5KGHA67lb4AJrdY44LuXkLRfGwnbvLjLuqvtJhOWQqj2YjuLwmxka3j2huDIqt3GsbqfNZ5LbPoingUCLg5gDebQYwtQH8EXS/m8BX6dD3Fs1U7+EbODMpqXkV/Ma3HDmRUH7lyIfGixcWGtLRN2Qw+SYfmM8zm+HSVvKQNTdGY8ibGr+d5/57tEw6G5BSj+M5d+MI3BAgcy/VXO5wiEjpbsPZ7ozMBgNV7dD0+HQpvRWa+swv4kazNkRXmI48iU480Z55EopgNmSWFDlUNU5EuWg9tYaRnZdgKW4oddUyK3QpE/qyzMuQ2bcxvbMcEt6ARM/vKxI9v9VccHqtGmhFNY+7+WuKJFY3jX2G1M3ker2gWDq5Onkd9qCm0PsSL0QbSIKS606FHFEYT9VurywRqCViYPu6sxN5O6koLooc8TQM+hhWzunt5un2d7KxPHH8KRZieMYu0geBncZ5LlYsdOrtzO001EbyZ/kirpr9rmygFlZcKWdA4XrdeU3Y16rc7bzeiD6DQ9iTWeHVIrIUlJRC3pfP2ec7eckS+b7wl/nhTOArDJFZLYDEBWiSXXxdbTckI1pduu2rkBX9IQf6Lwg5iTgz0tK30818j5Uv0rg+HK/XvGwU5t7k6uXu9/wav/cDY6/JNAWV2cl1zMuBRWGSfqBSIJzrxZf00kEsqzfDAE4V7D5AuUW+ghJS4iNbFO7cYcfBYsVe47VF1ut7MgEFBaEfsKWX7eYV0b51BaCpFIfazoUcEkqVibrKYum+L7bv7mGZJTakA0vFIvlLUYHpCE9LmW+j5FE4kh3rJXQqO9FSjxAeMoR3FDB1x0VJjxqWfITI5CMIPBADlq2DPJ/VxavU5uftBDvS1z8kiohyHVyZYuebk56kkQGojSJbRG4mKRA1auLQcsWwwXtaso18EFdQbKDOP14ctKCnfX83/12v8VPIrgJI1DALBgOjXg63SchCOXNeHLUKI87zvshfYJTSo1BTYU2V4wnL0LOh5BIBKM4Kudq8J7C8fsV2TVQ1F1fZ8d64vampUnzVp/QbVPXDkYlEflO0RT60lWq5dOzltdhDbmcUCMqU48o7sVnbnctUGVgKzD+exBn+jdJhpubOarTM2C9JFg3rq9Ox3Xx0pHXAXh2yziexGIZ+SrRxqlm3RdQWSavpaICOTjMxuSZQ+eRHcSYPGJ2n9O1+ZSuNrPuxaLViBQIy/NYpD+ZTNH6X56iARyyL2Pg0HR4dPWFBAczedOcVMGkOLJrCA97dTKELHHjvS/1MsqRrJXa2OxuJJsKYpKhna0IxUhOEdRmYL82Hawi0EEd6bh1tV6ttedMzBo4HlhRKBqxZN/cXK5YVvK9FHtZ3GZtV3PyHqijGyP+SC423JKFPKOB1eQOqHtmkbbakaLBP/asdFRff3AY5RjH3z9fFt+v19hNZXTgwwFiXqJ3Rdc3SSAkMDLrH1xQ0lpw8jLnooP2CAKKX3YD7HZTEeAfFmrZXtOuq4qJ1UwBvIGXoIybCsGqA2cc7rNPmlTqlKxTzlRLuosEAQp5ZV/A/bEETQZgyI20FTvJBZGOF8m8bH9f5NblavLsVIjAmFUts1V+xjmLwt6VRMzeOzTQX7qQSk4BkA3btE1ZjzQp2PL7M5Odvf7pPKUTY9Oux5lCS6vllXn6iUhP2zD9Dzw6JLRcFKT0qURsERMENSJwD8ffHly4Q1+sPuysqzt1qXYV8ixMfoamT6zSi0Nl+n8bdFsu53w+7Zu1Yqn5SaYaHpDmCh7dqEcqMDl7yzfI+WQJe+t5zLhFal62GaVos5yvkBkgHxP6Yb1yMU77yurwtPzFR3s/nKWcRadxm11wkWRy2oa88uAG7QAp78iZ/hYW/siRhhJDikjoEgXTSgiDatEuCC8YvhC89tCEryHrBMvMjbH4SGLUhAWsZyXt6LizXf2TfVNAUef9hsc7LL2E7TghrKs49TgekLlg71U/82HeOL4pi+ymwV5mfrABfBsWRIamOS93vP9D9apVF9eitGkRcDIqiG50nTHgxXL61ghHeihxN9vv83JK0NMwL4O9vwUMCDvGU18vkMP7rD6iPd5bbxZrslgQgODQA6uKfJeWBNPfuCiTj+vxSUaI0ExCvln2+ah7rDruKzMwzvrkKWpJFtEPDhhOBDO6xMIB9QRTV1gIY/tIbPKUbbND7S8+0KArbj7ENLR1wlGa2ZC3FdqoKsTZD3qZewr2Ge7SPxDtR+3cu+Tvjaat3oHS1GGXU6g2wxCz4K9N2gPF0dWI60+Qmb4kJRXH718gj+dK4/UsSdZOWiFhvN2JKaVZD8Gcp00FnrUChs4YSa0QsyyS7AbeK4iG7HzbB+56Opgd12j5zdS9Kg/ptmiI7iiKe0eR02tjlBHucTnhKlLTxBcp62CynzK4x5paOccT/cnvHOOF/R/zvmP9N+d/TrEqpjTgiE/5qMnWaqvgXYajw72NU4cROTk4zYfzwt7Y0O9k9FeA5JJOKN4UOJF+ZjipaomgveQtH0mhc1S+XwWW/KUd3WjUHlCFVc74qSVLRnMsq6oWqhuJc6UucmLxTl2+FAMDRXjU5dSD1eXLc23F8MbTf4erVD+RWho1IzAMXpR/i7vRSV32ZWcFbpheuB0kz1GwmcrF7XS2GLT23TOhuvt9ewKvYW6zF9lBw3WgX3Lj/sAwgRTaGIQMv6T2HHMa7gED9ahGb3HvRY4GFBJ5H6vkJf94lnH+W895vv+HDg2bM0wII9ZXJla6mmf5mWkFyWLbN3BYXZhXu1g+SeiBntFYXnHnsn5QUCxD7ZT1Cp/Svwl0627J6BRS6ItwEWmUNM+F1f+v9jWewor8iAG/m4GWelcWXr29wHNaqD11Tvsplk0O10MTgDL/yHMpZEWIG7WzDHZFvDopGH27cKgtakHiNseXoSF2rDwtw+bBkC/UW9tBYpWG4pf8hWfI1ThqDAU+GGZm9Obum6/sm1DwOuFmXjQOsuXsIw7khhIoCtQyKWvc6MhJ6tJAiX3Z2sqRhvutstmVnwWyH4G1fY4xNZwsxJJ0Nf2GNTuQ1hMPiaNvbjPXuw67svCR0o1EOtqZDbEgHXNjFbrktIIQKEP3mT5jFoqQ0Qzqv8mKHMdVYYxNg386Xckv31/Ml3Fu+WPL7yku42ky/sTvNS2Z3XoLdmT6k0gxdtYDyLr6laVd0dTfflIO1VELEWjRi5zhqPwuw4RiTkI7E+Xyx3wNNdaU+C30vwLjAwjg2ilEr2aVKIceIHKX3zoxYYdxG2h00RsoeJyh62wdx2PtOHFnsfAPSKgAIrJ0R1qWSOjqKWjicAjDuvPVYvohm69I3V7as9sR7nblhT2XG6rCq65RqF6/g9GWT6gU+SZj+pp+RLbAultHEdjQMuRsYVUkNQqKy4QtAZmYhhGNyPo9r+RVUPuDThlj3ZWngoGqEXZvIgG4Oscd1Jha1yDLAq2kpXSXkf3M9i+BAJ3XyfDJ9cVJhcdWBRWMbZGoepXDjY7/P6Qnr88uwdW52a4OTYsouj0TDSPU5AlNiv4Uzm4KE9kL6ngYH28Y22QVNpBD8S3DPRBzKVfuLeR12w/wCS/oAsItwEmT47fv1dkG/uxFrPjuSvrQbtVVhGlhk3DENMR01aeZKXM71atOuQCb8lpqcV6rV+IFgCpa+LzDloOJSgmOFGp3GznlqGT5szhaR6YwMAXRpAf7ONRZW5zeQXm7poQy3RVnwqQvOSGFUYq720kSvR1UBbYo3UAb00EBDamf3c+C6DlQ6Lm/CnnZokmPHOEtJeNEng1pBPBS/w1xZiOIKcdGNAk3NCTKIdJjjLoNIB9Z3JUFEw1vONWwTQaHHTwwGlREUQda/slWkW0Ei/YL1uBwMvEyW9Qy54nEhH2B5RUpcVEe4BFWZvKPbuiROTCEfSfz+3ZpgyBFE7VPtQqna9GcRcCkVDDAiUZb4gCp7b4rtJ7rLNUaIm8UYVqjnntEi3AjuDrN0cWG1cnqozR3DoXtQGvZgTKsvLNtidl5NHPYfmf+pu6/k4JtyR/22w/smOc/OSQ/TNux0EJmmc15TRoLFpSIIS+lCKKqASwtHxue5uZx0Tw7qjxgPhYq+wxJceDiJRkfRarteL4q7zLTbGB6iTKgMYZiyIWgEtYo1DfX4RmmduIL7UdID0NC3Bm/OnQXtwsH8wWB0uN5vm54VNkWf+mKgcqtU1C2iw7T542mmR1Ip84C70+1tVBd3p/E1J/rsufjxBUMeWIH8UXa9/+iBJb73tWf4dJ+rjfAi0Fr/Ty+rFmosYg/9tj8tnh2PgcPN9r3En0ZyrV29epAlR5pGaURQWiR8Tkg0/NlIPivEs1i063hj6Wz5JQ6E8TaSBvOnqpkUAvuqXSoHLfmg04l89FLCpp59FM+GsXz2qjf7wzvIFxTlXilxdkJobpiACsYz2w8hDidDG/QIjboRw7wFJ29toAH1q6WRRrOqHvPKjsBqIGiOCx+U9LTISqIS7o3lFXyN3j+8pG/pICfBHSw11j/57+fD49MXg5Pg+fBFWMylSrGjKoUQcIvzeDzGjGs7vneG4XEU2M0DLUZclEejY5FGS15vyE3F45RllhifstCQrrEUXRUkUrMcx2LosLzo4R0wYbfzoTFzm7DhOu8olHQFfXtJJQ67gitjvV7ma0UCxV75pqsxf4SWkSlKQ9vOJA1Nfh3m7kJ3jLi0mEto0FTuiI+azRzs+Jbg1B2GRoHJGr9jc3x2URkvACf+ul+ElBUrYirO5pCgdAz3x6XlcgoBY4VwLTgTGIZlvTJjuRJmlA1WBhJpnLqZIwijH6gIz4yEpWpD//bbh7/Tf4bmMOOJYj0ceNYnF8tsHfQ3FDHVm2ChOMgzJ1Mq5Azb6GraAdw10rswqMOVQTkVITuaD4aSy8c7kMHNsDnwy2o8CRxPQfAZi747xzeIl0wF+oHS3+ROFN1JeuoO399KI1PdW1bcmGkDstE/SuHnMJupzDzfihbqpV/snkuAJ/+HKOH19s5iuS02868/Yznl7G34kdF99kMZco78mO2K7G4oIsmzy/AJVu57xA+p7H74mpRwCD3cvNpmj8Of6GJl6zLE6T+lAnv2IaRDw6dd9jHkuGNfP0MrHmSe5SW049922a4M850yMsHuytbGIzwSsyUbKXsG7X8inwCU7CqEM/Mu7Kjsi/r8IHsZbii2ntx7+PDTG8oodxD7lj05zMjn621Rfl2XncWuA1MI38InhpvwEj9zFIT34ZuJhTDHF9VswmfiAdmEH+RHmHZ4F76aGA4fwzMNkeEaHtgICJf2U8RBeMUe89mHn+GrjujwCzyRaAhfGl8fhE/gu4uY8G84CaS18B/qs0534Q6faysXfuQP2NC/iN8Z8YU/4HdOawLxAh14Psz+7eTk3zusQOSPi+tryhWeXT6an+zenSRLQl5NVvHo1YqM09ViGJHJOCLD0+VoHMfjl6eLKVlN0tWrBYnSl9EqSuNXKRlNpi8nJBkvp1RWuP4nZ6Cvw16yAQA=
 </script>
+<script id="@tomlarkworthy/acorn-8-11-3/acorn-walk-8.3.2.js.gz" 
+  type="text/plain"
+  data-encoding="base64"
+  data-mime="application/gzip"
+>
+H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC5mydonhQbDnRjC17JRkmh+S/n5bkm2zHITsvjNWt7v76olYrM3779o311rrMaRjj0JourG/8GsfkiVk5J3Rm3aZxnGfW06H7/sQ9sBANrXvMOGbW06/uwYl76Er5z4zMCEWxFZEYn1pjmiVjFKSM7j+j+Pu/f3OP3MNxSLgYy7WbfOMgJQWvU+vT53uwha272xvrmYi5FS4oSkiA4nhhzTDFDAmAJjXzHetjyrBFaJSyBAmS0lNrLkTGT8fj5+dn9xsPFXg3SJOxcmCfM7Iv1e4XaveVIrA9fhPlNJA6LGELBzvUYU46eqHLpU39ZOQ02MBwyOjlCTEL+WS5ZK5YZNijD+hR8cTIwfC9t4cLymgFKtW/lRbcNCI1Ef/h0VtnDek93EelNSfz2Y7vkwfixpjOwKODRy/b2yNulvO5zUYOfeANOFzB0ZTlkgB+R+9OM7sHHu3Co+eRDYTl8ikloTUZnTJvpwFT7R69kAfYgRXER0UTSjs2tDNbjF4YFjmju1wwSMyu70uRNLLEebnNxuUmC/vAX52K5bJilrydyWolAaZ+xQJzoxcxJ9ylaYh94ahvLqByfLzyKhik4+QWCfCa8SWQCra3Z2NF4EDwWU9UUWmwritPYXdU9ncMowj0KKOZz6usBz1ZD8ysZ49KGFClDVRIJd3JgArQnMDMfQMjLzASDQDkbCQDAh7ZZOQJtngxcXJQqnAGflYFh0S2TfM49n0saRB7Js58PAI0mkwlGdPwd58CET0Ej0oVoO7IQe57BIEqJYkdAPyRmLP02aL42UqlHuUV/A2QCOay2ACPgEYB+mggqywdFZUlPC0qVnUIsjoEkCjwm4L7EAci89UNQF+iZAB27MKB33GB+Uz5QRoponYm4bfwI4Uf/VP8wT/AX+DVIHvdKZ3x8d5eAbuN2mu4tvopF/KmC+rkecXulj9Oy5WscqUI/ahbnNpN6Ye9Ay7qNqFoijOS/smqAj73a+/AqC7ThnsOrzFHuvFIa9T/PP2GA+EGDEPXsaEAIPRwTdmSC40G4I7oA3v0BfypXKt1xdp/SJ9SWjN+lAzV9BL/ZeUl7heWzhhK/MS9jNPg+53sdAmmAgjymwSKbDRIqaLC40+gKwh3moYLj52lRW/x2C/+gUSQAkaQ2K307oL7jtat7cSw+iPJxKIm/ZCkHxnDnIPJJqQviMHHHHPyPxzWW4BzNUeENihtwGWcbOHiapdEVssANDB8E9UG20qktMBctOUcyQhSyvHfOci1HHaEi2KBGQWKrI/Gsh0asP8BTTFMUOtBNDyRUe9RcQmVY2TyKqWC0BybIf4LhplhX1NVib3erjF9BxNSsEErjG8BIwmMebSj22sXVoA45t3K0nOFrC6PqJTIwJLe5FQqEajkPmkkykNnvNSLiorlMHh1KrZ27QrwdLwSFQQxDKHyqoawxaG5VZlvJva/BMfmObh4RkQMnAMoPjbLpXhRisWq7yjcy95qdATgo/CPeGNhDmpli+H6mMqO0z1DcySfFkzDLhbQ34ATyRcDdISCVy176vNKXilXMcp7s5ghaIVaifqUCr4gIQ/rcNn/NYe3QDNS12mLtFUrWWPlz5StVyhcQkmRVPkl5UHgBj5V+IYrFDbkWVg1KP29JbYbozSB8HlDK41x1IIpqfACnIutTZOuid3/IEbQNMbXOIghnZK3K18D6io/19fjqd7eqdJrPM1nM8zMlvlnYaKhceAYKN8Krtbag2jj1RrWe/n6bqE7RFt/ynoDT0Kzsvtqpx2Q0pG+wgsLUVNtp+upM8WHOl4lu2rku3ljnzdxnbYroRDvVsJNCHtIRDBrF4BTVUll+3T3I06mmDUsdYT0jlqkmLUaKSixyLIxdquJ5xbO4JZ9tI4NyF8whhbr3G3HHWtDG65RdYOahqQlPY2+1lTG0gwzQTbc2btf9L6FjCzRkbXlzZxkucChvsy/40VPGyDuE4pzbACFlDUCWuvUevqDuDKGTJWUe3jrG5fpXQ4gfZk/gUrEKqEq/AO37E9mwDh7dRK2MDiUB7NllOfanCIY3Py9nJ4OKGcjNcwEeJuQVFsHO0InFPc4yWI49R8IJBLFG+38nSNOBqNQShCQQC1k5AyVYqQQQw9kGFl5rmWhfKWILYwAflVX60CgNs1Pl6Sj80M6kz9zblBaXrede7X3xlVdBr5nVAIxq6Mir2sLTXPmALXWFrxRQiJ1bPTjlS+wDtt4dbXNf8LP5nsSxUM4SGQri7AL455hqkwgH7XrseJsVfXtG2mb55ow+mrVGxZ9YYB1ysQnlOCwOaOUjGscoTwWQ+OLMbBogw1CYbPHRn3HLpeGCIwV542L/rTtHE9zFhRzq/5e79hFHA9jx2pbGalyJZ8Zw+pvEh2e1491PMOBmkgGe9NrrG6oik3idyUQv3ZDZbnLkDnjGQqwwapmK/kDDSNPkCmDVnZq2Q/vEQzVYdUpNxx0NOs9yKql9/aQGHFu1q0ivep3IalQ7W7oev2wKwtRTgtKrCjGaj3wmqltXcL6J39nK3uFmKdwtCI5yusolMNLL7HHSbNh9A1iQo9hekM1kRkJ8fTxecEW4pb85ZbDe8RJ5GqKOHYC+QV4wk9piC8iiKOTGSSW5jR0uEETTt5cX2KIEHaIouVx7KDy66I0GElKgr6Da/KL4SBnnDzBu0IuOYFSxCVWK9Slb8n/MPDejMf/svTx+YiyjNDZ19sP/pgn42gSTN4fTw7fhYfRydFheHz07t0xOkYBmh5hdDJ5Nwl/C8LjSXR4go6O8WSCDkHz++gwPJkERweBm6Ds/8t9I8syHQAA
+</script>
 <script id="@tomlarkworthy/acorn-8-11-3" 
   type="text/plain"
   data-mime="application/javascript"
 >
-const _k54r8u = function _1(md){return(
-md`# [Acorn@8.11.3](https://github.com/acornjs/acorn)
+const _1emgxs3 = function _1(md){return(
+md`# [Acorn@8.11.3](https://github.com/acornjs/acorn) & acorn-walk@8.2.2
 
 \`\`\`\`js
 import { acorn } from "@tomlarkworthy/acorn-8-11-3"
@@ -1187,6 +3693,18 @@ import { acorn } from "@tomlarkworthy/acorn-8-11-3"
 )};
 const _1xdqqxo = function _acorn(acorn_url) {
     return import(acorn_url);
+};
+const _vctqpi = function _acorn_walk(acorn_walk_url) {
+    return import(acorn_walk_url);
+};
+const _1c0mco9 = async function _acorn_walk_url(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("acorn-walk-8.3.2.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  return objectURL;
 };
 const _jdtsxp = async function _acorn_url(unzip,FileAttachment)
 {
@@ -1209,7 +3727,7 @@ export default function define(runtime, observer) {
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map(["acorn-8.11.3.js.gz"].map((name) => {
+  const fileAttachments = new Map(["acorn-8.11.3.js.gz","acorn-walk-8.3.2.js.gz"].map((name) => {
     const module_name = "@tomlarkworthy/acorn-8-11-3";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
@@ -1217,8 +3735,10 @@ export default function define(runtime, observer) {
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
-  $def("_k54r8u", null, ["md"], _k54r8u);  
+  $def("_1emgxs3", null, ["md"], _1emgxs3);  
   $def("_1xdqqxo", "acorn", ["acorn_url"], _1xdqqxo);  
+  $def("_vctqpi", "acorn_walk", ["acorn_walk_url"], _vctqpi);  
+  $def("_1c0mco9", "acorn_walk_url", ["unzip","FileAttachment"], _1c0mco9);  
   $def("_jdtsxp", "acorn_url", ["unzip","FileAttachment"], _jdtsxp);  
   $def("_17n6uge", "unzip", ["Response","DecompressionStream"], _17n6uge);
   return main;
@@ -2245,16 +4765,29 @@ const _1i8jhrq = function _copyCellButton(Inputs,cellsToClipboard){return(
 (cells) =>
   Inputs.button("Copy cells", { reduce: () => cellsToClipboard(cells) })
 )};
-const _a7c096 = function _makeCell($0,defaultJS,defaultOther){return(
-(value) => {
+const _1ud4fa1 = function _makeCell($0,defaultJS,defaultOther){return(
+value => {
   const id = $0.value++;
-  if (typeof value === "string") {
-    return { ...defaultJS, id, value };
-  } else if (typeof value === "object") {
-    if (value.type === "js") return { ...defaultJS, id, ...value };
-    return { ...defaultOther, id, ...value };
+  if (typeof value === 'string') {
+    return {
+      ...defaultJS,
+      id,
+      value
+    };
+  } else if (typeof value === 'object') {
+    if (value.type === 'js')
+      return {
+        ...defaultJS,
+        id,
+        ...value
+      };
+    return {
+      ...defaultOther,
+      id,
+      ...value
+    };
   } else {
-    throw new Error("Value must be string or object");
+    throw new Error('Value must be string or object');
   }
 }
 )};
@@ -2297,7 +4830,7 @@ export default function define(runtime, observer) {
   $def("_10uloef", null, ["md"], _10uloef);  
   $def("_1seifpc", "cellsToClipboard", ["makeCell"], _1seifpc);  
   $def("_1i8jhrq", "copyCellButton", ["Inputs","cellsToClipboard"], _1i8jhrq);  
-  $def("_a7c096", "makeCell", ["mutable id","defaultJS","defaultOther"], _a7c096);  
+  $def("_1ud4fa1", "makeCell", ["mutable id","defaultJS","defaultOther"], _1ud4fa1);  
   $def("_h1t91h", "defaultJS", [], _h1t91h);  
   $def("_but2s9", "defaultOther", [], _but2s9);  
   $def("_lj7470", "initial id", [], _lj7470);  
@@ -3502,212 +6035,227 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
+const _11jras6 = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,sessionStorage,invalidation)
 {
-    return function () {
-        var port = cc_config.port, host = cc_config.host;
-        var ws = null;
-        var paired = false;
-        function connect(token) {
-            if (ws) {
-                ws.close();
-                ws = null;
-            }
-            if (token) {
-                try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
-                } catch (e) {
-                }
-                var hash = location.hash || '#';
-                if (/[&?]cc=/.test(hash)) {
-                    hash = hash.replace(/([&?])cc=[^&]*/, '$1cc=' + token);
-                } else {
-                    hash += (hash.length > 1 ? '&' : '') + 'cc=' + token;
-                }
-                try {
-                    window.history.replaceState(null, '', hash);
-                } catch (e) {
-                }
-            }
-            var connectPort = port;
-            if (token) {
-                var parts = token.match(/^LOPE-(\d+)-[A-Z0-9]+$/);
-                if (parts)
-                    connectPort = parseInt(parts[1], 10);
-            }
-            cc_status.value = 'connecting';
-            cc_status.dispatchEvent(new Event('input'));
-            ws = new WebSocket('ws://' + host + ':' + connectPort + '/ws');
-            ws.onopen = function () {
-                if (token) {
-                    cc_status.value = 'pairing';
-                    cc_status.dispatchEvent(new Event('input'));
-                    var toolDescriptors = [];
-                    var _mcpToolsVal = $0 && $0.value;
-                    if (_mcpToolsVal && _mcpToolsVal.size > 0) {
-                        _mcpToolsVal.forEach(function (t, name) {
-                            toolDescriptors.push({
-                                name: name,
-                                description: t.description,
-                                inputSchema: t.inputSchema
-                            });
-                        });
-                    }
-                    ws.send(JSON.stringify({
-                        type: 'pair',
-                        token: token,
-                        url: cc_notebook_id,
-                        title: document.title || 'Untitled',
-                        tools: toolDescriptors
-                    }));
-                }
-            };
-            ws.onmessage = function (event) {
-                var msg;
-                try {
-                    msg = JSON.parse(event.data);
-                } catch (e) {
-                    return;
-                }
-                switch (msg.type) {
-                case 'paired':
-                    paired = true;
-                    cc_status.value = 'connected';
-                    cc_status.dispatchEvent(new Event('input'));
-                    // Provide send callback to watchers
-                    cc_watchers.setSend(function (m) {
-                        if (paired && ws)
-                            ws.send(JSON.stringify(m));
-                    });
-                    var modules = [];
-                    var rt = window.__ojs_runtime;
-                    if (rt) {
-                        var seen = new Set();
-                        for (var v of rt._variables) {
-                            var name = v._module && v._module._name;
-                            if (name && !seen.has(name)) {
-                                seen.add(name);
-                                modules.push(name);
-                            }
-                        }
-                    }
-                    ws.send(JSON.stringify({
-                        type: 'notebook-info',
-                        url: cc_notebook_id,
-                        title: document.title,
-                        modules: modules,
-                        hash: location.hash
-                    }));
-                    // Set up watches from cc_watches
-                    var rt2 = window.__ojs_runtime;
-                    if (rt2) {
-                        var initialWatches = $1.value || [];
-                        for (var i = 0; i < initialWatches.length; i++) {
-                            cc_watchers.watchVariable(rt2, initialWatches[i].name, initialWatches[i].module);
-                        }
-                    }
-                    break;
-                case 'pair-failed':
-                    paired = false;
-                    cc_status.value = 'disconnected';
-                    cc_status.dispatchEvent(new Event('input'));
-                    break;
-                case 'reply':
-                    var msgs = cc_messages.value.concat([{
-                            role: 'assistant',
-                            content: msg.markdown,
-                            timestamp: Date.now()
-                        }]);
-                    cc_messages.value = msgs;
-                    cc_messages.dispatchEvent(new Event('input'));
-                    break;
-                case 'tool-activity':
-                    // Update the activity status bar (not the chat messages)
-                    var activityEntry = {
-                        tool_name: msg.tool_name,
-                        content: msg.summary,
-                        timestamp: msg.timestamp || Date.now()
-                    };
-                    cc_activity.value = cc_activity.value.concat([activityEntry]).slice(-20);
-                    cc_activity.dispatchEvent(new Event('input'));
-                    break;
-                case 'command':
-                    Promise.resolve(cc_command_handlers(msg)).then(function (result) {
-                        ws.send(JSON.stringify({
-                            type: 'command-result',
-                            id: msg.id,
-                            ok: result.ok,
-                            result: result.result,
-                            error: result.error
-                        }));
-                    }).catch(function (e) {
-                        ws.send(JSON.stringify({
-                            type: 'command-result',
-                            id: msg.id,
-                            ok: false,
-                            error: e.message
-                        }));
-                    });
-                    break;
-                case 'assistant-text':
-                    // Side-comment: Claude's CLI text output from session log
-                    var sideMsg = cc_messages.value.concat([{
-                            role: 'side',
-                            content: msg.text,
-                            timestamp: msg.timestamp || Date.now()
-                        }]);
-                    cc_messages.value = sideMsg;
-                    cc_messages.dispatchEvent(new Event('input'));
-                    break;
-                }
-            };
-            ws.onclose = function () {
-                paired = false;
-                cc_watchers.setSend(null);
-                cc_status.value = 'disconnected';
-                cc_status.dispatchEvent(new Event('input'));
-                ws = null;
-            };
-            ws.onerror = function () {
-            };
+  return (function () {
+    var port = cc_config.port,
+      host = cc_config.host;
+    var ws = null;
+    var paired = false;
+    function connect(token) {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+      if (token) {
+        try {
+          window.sessionStorage.setItem("lopecode_cc_token", token);
+        } catch (e) {}
+        var hash = location.hash || "#";
+        if (/[&?]cc=/.test(hash)) {
+          hash = hash.replace(/([&?])cc=[^&]*/, "$1cc=" + token);
+        } else {
+          hash += (hash.length > 1 ? "&" : "") + "cc=" + token;
         }
-        // Auto-connect: check hash param first, then sessionStorage fallback
-        (function autoConnect() {
-            var token = null;
-            var hash = location.hash || '';
-            var match = hash.match(/[&?]cc=(LOPE-[A-Z0-9-]+)/);
-            if (match) {
-                token = match[1];
-            }
-            if (!token) {
-                try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
-                } catch (e) {
+        try {
+          window.history.replaceState(null, "", hash);
+        } catch (e) {}
+      }
+      var connectPort = port;
+      if (token) {
+        var parts = token.match(/^LOPE-(\d+)-[A-Z0-9]+$/);
+        if (parts) connectPort = parseInt(parts[1], 10);
+      }
+      cc_status.value = "connecting";
+      cc_status.dispatchEvent(new Event("input"));
+      ws = new WebSocket("ws://" + host + ":" + connectPort + "/ws");
+      ws.onopen = function () {
+        if (token) {
+          cc_status.value = "pairing";
+          cc_status.dispatchEvent(new Event("input"));
+          var toolDescriptors = [];
+          var _mcpToolsVal = $0 && $0.value;
+          if (_mcpToolsVal && _mcpToolsVal.size > 0) {
+            _mcpToolsVal.forEach(function (t, name) {
+              toolDescriptors.push({
+                name: name,
+                description: t.description,
+                inputSchema: t.inputSchema
+              });
+            });
+          }
+          ws.send(
+            JSON.stringify({
+              type: "pair",
+              token: token,
+              url: cc_notebook_id,
+              title: document.title || "Untitled",
+              tools: toolDescriptors
+            })
+          );
+        }
+      };
+      ws.onmessage = function (event) {
+        var msg;
+        try {
+          msg = JSON.parse(event.data);
+        } catch (e) {
+          return;
+        }
+        switch (msg.type) {
+          case "paired":
+            paired = true;
+            cc_status.value = "connected";
+            cc_status.dispatchEvent(new Event("input"));
+            // Provide send callback to watchers
+            cc_watchers.setSend(function (m) {
+              if (paired && ws) ws.send(JSON.stringify(m));
+            });
+            var modules = [];
+            var rt = window.__ojs_runtime;
+            if (rt) {
+              var seen = new Set();
+              for (var v of rt._variables) {
+                var name = v._module && v._module._name;
+                if (name && !seen.has(name)) {
+                  seen.add(name);
+                  modules.push(name);
                 }
+              }
             }
-            if (token) {
-                setTimeout(function () {
-                    connect(token);
-                }, 500);
+            ws.send(
+              JSON.stringify({
+                type: "notebook-info",
+                url: cc_notebook_id,
+                title: document.title,
+                modules: modules,
+                hash: location.hash
+              })
+            );
+            // Set up watches from cc_watches
+            var rt2 = window.__ojs_runtime;
+            if (rt2) {
+              var initialWatches = $1.value || [];
+              for (var i = 0; i < initialWatches.length; i++) {
+                cc_watchers.watchVariable(
+                  rt2,
+                  initialWatches[i].name,
+                  initialWatches[i].module
+                );
+              }
             }
-        }());
-        invalidation.then(function () {
-            cc_watchers.setSend(null);
-            if (ws) {
-                ws.close();
-                ws = null;
-            }
-        });
-        return {
-            connect: connect,
-            get paired() {
-                return paired;
-            },
-            get ws() {
-                return ws;
-            }
-        };
-    }();
+            break;
+          case "pair-failed":
+            paired = false;
+            cc_status.value = "disconnected";
+            cc_status.dispatchEvent(new Event("input"));
+            break;
+          case "reply":
+            var msgs = cc_messages.value.concat([
+              {
+                role: "assistant",
+                content: msg.markdown,
+                timestamp: Date.now()
+              }
+            ]);
+            cc_messages.value = msgs;
+            cc_messages.dispatchEvent(new Event("input"));
+            break;
+          case "tool-activity":
+            // Update the activity status bar (not the chat messages)
+            var activityEntry = {
+              tool_name: msg.tool_name,
+              content: msg.summary,
+              timestamp: msg.timestamp || Date.now()
+            };
+            cc_activity.value = cc_activity.value
+              .concat([activityEntry])
+              .slice(-20);
+            cc_activity.dispatchEvent(new Event("input"));
+            break;
+          case "command":
+            Promise.resolve(cc_command_handlers(msg))
+              .then(function (result) {
+                ws.send(
+                  JSON.stringify({
+                    type: "command-result",
+                    id: msg.id,
+                    ok: result.ok,
+                    result: result.result,
+                    error: result.error
+                  })
+                );
+              })
+              .catch(function (e) {
+                ws.send(
+                  JSON.stringify({
+                    type: "command-result",
+                    id: msg.id,
+                    ok: false,
+                    error: e.message
+                  })
+                );
+              });
+            break;
+          case "assistant-text":
+            // Side-comment: Claude's CLI text output from session log
+            var sideMsg = cc_messages.value.concat([
+              {
+                role: "side",
+                content: msg.text,
+                timestamp: msg.timestamp || Date.now()
+              }
+            ]);
+            cc_messages.value = sideMsg;
+            cc_messages.dispatchEvent(new Event("input"));
+            break;
+        }
+      };
+      ws.onclose = function () {
+        paired = false;
+        cc_watchers.setSend(null);
+        cc_status.value = "disconnected";
+        cc_status.dispatchEvent(new Event("input"));
+        ws = null;
+      };
+      ws.onerror = function () {};
+    }
+    // Auto-connect: check hash param first, then sessionStorage fallback
+    (function autoConnect() {
+      var token = null;
+      var hash = location.hash || "";
+      var match = hash.match(/[&?]cc=(LOPE-[A-Z0-9-]+)/);
+      if (match) {
+        token = match[1];
+      }
+      if (!token) {
+        try {
+          token = sessionStorage.getItem("lopecode_cc_token");
+        } catch (e) {}
+      }
+      if (token) {
+        setTimeout(function () {
+          connect(token);
+        }, 500);
+      }
+    })();
+    invalidation.then(function () {
+      cc_watchers.setSend(null);
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    });
+    return {
+      connect: connect,
+      get paired() {
+        return paired;
+      },
+      get ws() {
+        return ws;
+      }
+    };
+  })();
 };
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
@@ -4177,7 +6725,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_11jras6", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","sessionStorage","invalidation"], _11jras6);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -4393,80 +6941,64 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-const _13upker = function _1(md){return(
+const _tku1if = function _1(md){return(
 md`# Command Palette
 
-Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open.
+Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open, or pick **Command palette** from the lopepage-2 burger menu (registered on the shared \`"lp2-menu"\` plugin bus).
 
 \`\`\`js
 import {commandPaletteOverlay, commandPaletteStyles, commandPaletteKeybinding} from "@tomlarkworthy/command-palette"
 \`\`\`
 
-## Registering a plugin
+## Registering a command provider
 
-A plugin is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Plugins run on every keystroke; results are merged and sorted by \`score\` (descending).
+A provider is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Providers run on every keystroke; results are merged and sorted by \`score\` (descending).
+
+Providers register on the shared [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lopecode_commands"\` — no import of this notebook needed, so any notebook can extend the palette:
 
 \`\`\`js
-import {viewof commands as commandsView} from "@tomlarkworthy/command-palette"
+import {plugins} from "@tomlarkworthy/plugin-registry"
 {
-  const myPlugin = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
-  const unregister = commandsView.addCommand(myPlugin);
-  invalidation.then(unregister);
+  const provider = (q) => [{label: "Hello " + q, href: "#" + q, score: 100}];
+  plugins.add("lopecode_commands", provider, {invalidation});
 }
 \`\`\`
 
-## Built-in plugins
+## Built-in providers
 
 - **Module finder** — type a module name to open it.
 - **Cell search** — type to find cells across all loaded modules.`
 )};
-const _1eng7wy = function _commands(Inputs,Event)
-{
-    const input = Inputs.input([]);
-    input.addCommand = function (plugin) {
-        input.value.push(plugin);
-        input.dispatchEvent(new Event('input'));
-        return () => {
-            const i = input.value.indexOf(plugin);
-            if (i >= 0) {
-                input.value.splice(i, 1);
-                input.dispatchEvent(new Event('input'));
-            }
-        };
-    };
-    return input;
-};
-const _7bve6u = (G, _) => G.input(_);
-const _bpk8h7 = function _searchIndex(liveCellMap,modules){return(
+const _yavx6b = function _searchIndex(liveCellMap,modules){return(
 (() => {
-    const index = [];
-    for (const [mod, cells] of liveCellMap.entries()) {
-        const moduleName = modules?.get(mod)?.name ?? '<unknown>';
-        for (const cell of cells) {
-            if (!cell.name && cell.type !== 'import')
-                continue;
-            let source = null;
-            try {
-                const v = cell.variables?.[0];
-                if (v?._definition)
-                    source = v._definition.toString();
-            } catch (e) {
-            }
-            index.push({
-                module: moduleName,
-                name: cell.name ?? null,
-                type: cell.type ?? 'simple',
-                source
-            });
-        }
+  const index = [];
+  for (const [mod, cells] of liveCellMap.entries()) {
+    const moduleName = modules?.get(mod)?.name ?? '<unknown>';
+    for (const cell of cells) {
+      if (!cell.name && cell.type !== 'import')
+        continue;
+      let source = null;
+      try {
+        const v = cell.variables?.[0];
+        if (v?._definition)
+          source = v._definition.toString();
+      } catch (e) {
+      }
+      index.push({
+        module: moduleName,
+        name: cell.name ?? null,
+        type: cell.type ?? 'simple',
+        source
+      });
     }
-    return index;
+  }
+  return index;
 })()
 )};
-const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
+const _rmjyys = function _commandPaletteStyles(theme_assets,htl)
 {
-    theme_assets;
-    return htl.html`<style>
+  theme_assets;
+  return htl.html`<style>
 .command-palette-overlay {
   position: fixed;
   inset: 0;
@@ -4588,15 +7120,15 @@ const _1ptnr90 = function _commandPaletteStyles(theme_assets,htl)
 }
 </style>`;
 };
-const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
+const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
 {
-    const $commands = $0;
-    let selectedIdx = 0;
-    let results = [];
-    const overlay = document.createElement('div');
-    overlay.className = 'command-palette-overlay';
-    overlay.hidden = true;
-    overlay.innerHTML = `<div class="command-palette-box">
+  let selectedIdx = 0;
+  let results = [];
+  let providers = [];
+  const overlay = document.createElement('div');
+  overlay.className = 'command-palette-overlay';
+  overlay.hidden = true;
+  overlay.innerHTML = `<div class="command-palette-box">
       <input class="command-palette-input" placeholder="Type a command..." autocomplete="off" />
       <div class="command-palette-results"></div>
       <div class="command-palette-hint">
@@ -4605,147 +7137,156 @@ const _fomuvm = function _commandPaletteOverlay($0,Node,invalidation)
         <span><kbd>Esc</kbd> close</span>
       </div>
     </div>`;
-    const input = overlay.querySelector('.command-palette-input');
-    const resultsContainer = overlay.querySelector('.command-palette-results');
-    function search(query) {
-        if (!query || query.length < 1)
-            return [];
-        const plugins = $commands.value || [];
-        let all = [];
-        for (const plugin of plugins) {
-            try {
-                const out = plugin(query);
-                if (Array.isArray(out))
-                    all = all.concat(out);
-            } catch (e) {
-                console.error('[command-palette] plugin error:', e);
-            }
-        }
-        all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-        return all.slice(0, 50);
+  const input = overlay.querySelector('.command-palette-input');
+  const resultsContainer = overlay.querySelector('.command-palette-results');
+  function search(query) {
+    if (!query || query.length < 1)
+      return [];
+    let all = [];
+    for (const provider of providers) {
+      try {
+        const out = provider(query);
+        if (Array.isArray(out))
+          all = all.concat(out);
+      } catch (e) {
+        console.error('[command-palette] provider error:', e);
+      }
     }
-    function render() {
-        resultsContainer.innerHTML = '';
-        if (results.length === 0 && input.value.length > 0) {
-            resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
-            return;
+    all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    return all.slice(0, 50);
+  }
+  function render() {
+    resultsContainer.innerHTML = '';
+    if (results.length === 0 && input.value.length > 0) {
+      resultsContainer.innerHTML = '<div class="command-palette-empty">No results found</div>';
+      return;
+    }
+    results.forEach((r, i) => {
+      const row = document.createElement('a');
+      row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
+      row.href = r.href || '#';
+      row.style.textDecoration = 'none';
+      row.style.color = 'inherit';
+      if (r.module) {
+        const modSpan = document.createElement('span');
+        modSpan.className = 'command-palette-module';
+        modSpan.textContent = r.module;
+        row.appendChild(modSpan);
+      }
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'command-palette-label';
+      labelSpan.textContent = r.label ?? '';
+      row.appendChild(labelSpan);
+      if (r.badge) {
+        const badgeSpan = document.createElement('span');
+        badgeSpan.className = 'command-palette-badge';
+        badgeSpan.textContent = r.badge;
+        row.appendChild(badgeSpan);
+      }
+      if (r.hint) {
+        const hintSpan = document.createElement('span');
+        hintSpan.className = 'command-palette-hint-right';
+        hintSpan.textContent = r.hint;
+        row.appendChild(hintSpan);
+      }
+      row.addEventListener('click', e => {
+        e.preventDefault();
+        close();
+        window.location.href = row.href;
+      });
+      resultsContainer.appendChild(row);
+      if (r.snippet) {
+        const snippet = document.createElement('div');
+        snippet.className = 'command-palette-snippet';
+        if (i === selectedIdx)
+          snippet.style.background = '#eef4ff';
+        if (typeof r.snippet === 'string') {
+          snippet.textContent = r.snippet;
+        } else if (r.snippet instanceof Node) {
+          snippet.appendChild(r.snippet);
         }
-        results.forEach((r, i) => {
-            const row = document.createElement('a');
-            row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
-            row.href = r.href || '#';
-            row.style.textDecoration = 'none';
-            row.style.color = 'inherit';
-            if (r.module) {
-                const modSpan = document.createElement('span');
-                modSpan.className = 'command-palette-module';
-                modSpan.textContent = r.module;
-                row.appendChild(modSpan);
-            }
-            const labelSpan = document.createElement('span');
-            labelSpan.className = 'command-palette-label';
-            labelSpan.textContent = r.label ?? '';
-            row.appendChild(labelSpan);
-            if (r.badge) {
-                const badgeSpan = document.createElement('span');
-                badgeSpan.className = 'command-palette-badge';
-                badgeSpan.textContent = r.badge;
-                row.appendChild(badgeSpan);
-            }
-            if (r.hint) {
-                const hintSpan = document.createElement('span');
-                hintSpan.className = 'command-palette-hint-right';
-                hintSpan.textContent = r.hint;
-                row.appendChild(hintSpan);
-            }
-            row.addEventListener('click', e => {
-                e.preventDefault();
-                close();
-                window.location.href = row.href;
-            });
-            resultsContainer.appendChild(row);
-            if (r.snippet) {
-                const snippet = document.createElement('div');
-                snippet.className = 'command-palette-snippet';
-                if (i === selectedIdx)
-                    snippet.style.background = '#eef4ff';
-                if (typeof r.snippet === 'string') {
-                    snippet.textContent = r.snippet;
-                } else if (r.snippet instanceof Node) {
-                    snippet.appendChild(r.snippet);
-                }
-                snippet.addEventListener('click', e => {
-                    e.preventDefault();
-                    close();
-                    window.location.href = row.href;
-                });
-                resultsContainer.appendChild(snippet);
-            }
+        snippet.addEventListener('click', e => {
+          e.preventDefault();
+          close();
+          window.location.href = row.href;
         });
-    }
-    function open() {
-        overlay.hidden = false;
-        input.value = '';
-        results = [];
-        selectedIdx = 0;
-        render();
-        requestAnimationFrame(() => input.focus());
-    }
-    function close() {
-        overlay.hidden = true;
-        input.blur();
-    }
-    function navigateToSelected() {
-        if (results[selectedIdx]) {
-            const r = results[selectedIdx];
-            close();
-            window.location.href = r.href || '#';
-        }
-    }
-    input.addEventListener('input', () => {
-        results = search(input.value);
-        selectedIdx = 0;
-        render();
+        resultsContainer.appendChild(snippet);
+      }
     });
-    input.addEventListener('keydown', e => {
-        if (e.key === 'ArrowDown') {
-            e.preventDefault();
-            selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'ArrowUp') {
-            e.preventDefault();
-            selectedIdx = Math.max(selectedIdx - 1, 0);
-            render();
-            const sel = resultsContainer.querySelector('.selected');
-            if (sel)
-                sel.scrollIntoView({ block: 'nearest' });
-        } else if (e.key === 'Enter') {
-            e.preventDefault();
-            navigateToSelected();
-        } else if (e.key === 'Escape') {
-            e.preventDefault();
-            close();
-        }
-    });
-    overlay.addEventListener('click', e => {
-        if (e.target === overlay)
-            close();
-    });
-    invalidation.then(() => overlay.remove());
-    overlay._openPalette = open;
-    overlay._closePalette = close;
-    overlay._isOpen = () => !overlay.hidden;
-    return overlay;
+  }
+  function open() {
+    overlay.hidden = false;
+    input.value = '';
+    results = [];
+    selectedIdx = 0;
+    render();
+    requestAnimationFrame(() => input.focus());
+  }
+  function close() {
+    overlay.hidden = true;
+    input.blur();
+  }
+  function navigateToSelected() {
+    if (results[selectedIdx]) {
+      const r = results[selectedIdx];
+      close();
+      window.location.href = r.href || '#';
+    }
+  }
+  input.addEventListener('input', () => {
+    results = search(input.value);
+    selectedIdx = 0;
+    render();
+  });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIdx = Math.min(selectedIdx + 1, results.length - 1);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIdx = Math.max(selectedIdx - 1, 0);
+      render();
+      const sel = resultsContainer.querySelector('.selected');
+      if (sel)
+        sel.scrollIntoView({ block: 'nearest' });
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      navigateToSelected();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay)
+      close();
+  });
+  invalidation.then(() => overlay.remove());
+  overlay._openPalette = open;
+  overlay._closePalette = close;
+  overlay._isOpen = () => !overlay.hidden;
+  // Stable setter fed by command_provider_sync; re-searches live if the palette is open.
+  overlay._setProviders = arr => {
+    providers = arr || [];
+    if (!overlay.hidden) {
+      results = search(input.value);
+      selectedIdx = 0;
+      render();
+    }
+  };
+  return overlay;
 };
-const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,commandPaletteOverlay,invalidation)
+const _1vuj6tn = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinderPlugin,command_provider_sync,commandPaletteOverlay,invalidation)
 {
   cellSearchPlugin;
   moduleFinderPlugin;
-  const handler = (e) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+  command_provider_sync;
+  const handler = e => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
       e.stopPropagation();
       if (commandPaletteOverlay._isOpen()) {
@@ -4755,24 +7296,23 @@ const _mqy6k9 = function _commandPaletteKeybinding(cellSearchPlugin,moduleFinder
       }
     }
   };
-  document.addEventListener("keydown", handler, true);
-  invalidation.then(() =>
-    document.removeEventListener("keydown", handler, true)
-  );
+  document.addEventListener('keydown', handler, true);
+  invalidation.then(() => document.removeEventListener('keydown', handler, true));
   return null;
 };
-const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
+const _104tbig = function _cellSearchPlugin(searchIndex,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
     for (const entry of searchIndex) {
       let score = 0;
       let nameMatch = false;
       let sourceMatch = false;
-      const name = String(entry.name ?? "").toLowerCase();
-      const mod = String(entry.module ?? "").toLowerCase();
+      const name = String(entry.name ?? '').toLowerCase();
+      const mod = String(entry.module ?? '').toLowerCase();
       if (name.length && name.startsWith(q)) {
         score += 150;
         nameMatch = true;
@@ -4787,50 +7327,42 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
         score += 10;
         sourceMatch = true;
       }
-      if (score === 0) continue;
-      const nameStr = String(entry.name ?? "");
-      const modStr = String(entry.module ?? "");
-      const href = linkTo(nameStr ? modStr + "#" + nameStr : modStr);
+      if (score === 0)
+        continue;
+      const nameStr = String(entry.name ?? '');
+      const modStr = String(entry.module ?? '');
+      const href = linkTo(nameStr ? modStr + '#' + nameStr : modStr);
       let snippet = null;
       if (entry.source) {
         const src = String(entry.source);
         const idx = src.toLowerCase().indexOf(q);
         const frag = document.createDocumentFragment();
         if (idx >= 0) {
-          const start = Math.max(
-            0,
-            src.lastIndexOf("\n", Math.max(0, idx - 40)) + 1
-          );
-          const endNL = src.indexOf("\n", idx + query.length + 40);
-          const lineEnd =
-            endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
+          const start = Math.max(0, src.lastIndexOf('\n', Math.max(0, idx - 40)) + 1);
+          const endNL = src.indexOf('\n', idx + query.length + 40);
+          const lineEnd = endNL < 0 ? Math.min(src.length, idx + query.length + 80) : endNL;
           const before = src.slice(start, idx);
           const match = src.slice(idx, idx + query.length);
           const after = src.slice(idx + query.length, lineEnd);
           if (start > 0)
-            frag.appendChild(document.createTextNode("\u2026" + before));
-          else frag.appendChild(document.createTextNode(before));
-          const mark = document.createElement("mark");
+            frag.appendChild(document.createTextNode('\u2026' + before));
+          else
+            frag.appendChild(document.createTextNode(before));
+          const mark = document.createElement('mark');
           mark.textContent = match;
           frag.appendChild(mark);
-          frag.appendChild(
-            document.createTextNode(
-              after + (lineEnd < src.length ? "\u2026" : "")
-            )
-          );
+          frag.appendChild(document.createTextNode(after + (lineEnd < src.length ? '\u2026' : '')));
         } else {
-          const firstLine = src.slice(0, src.indexOf("\n", 0));
-          frag.appendChild(
-            document.createTextNode((firstLine || src).slice(0, 120))
-          );
+          const firstLine = src.slice(0, src.indexOf('\n', 0));
+          frag.appendChild(document.createTextNode((firstLine || src).slice(0, 120)));
         }
         snippet = frag;
       }
       out.push({
-        label: nameStr || "(anonymous)",
+        label: nameStr || '(anonymous)',
         module: modStr,
-        badge: entry.type && entry.type !== "simple" ? entry.type : null,
-        hint: sourceMatch && !nameMatch ? "source" : null,
+        badge: entry.type && entry.type !== 'simple' ? entry.type : null,
+        hint: sourceMatch && !nameMatch ? 'source' : null,
         snippet,
         href,
         score
@@ -4838,37 +7370,69 @@ const _k261kj = function _cellSearchPlugin(searchIndex,linkTo,$0,invalidation)
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "cell-search plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'cell-search plugin registered';
 };
-const _lq3msy = function _moduleFinderPlugin(modules,linkTo,$0,invalidation)
+const _1opf5e1 = function _moduleFinderPlugin(currentModules,linkTo,plugins,invalidation)
 {
-  const plugin = (query) => {
-    if (!query || query.length < 1) return [];
+  // Use the REACTIVE module set (module-map currentModules), not cell-map's one-shot `modules` snapshot,
+  // so modules created live (e.g. by robocoop-4) are immediately findable. This cell recomputes whenever
+  // currentModules changes; the old plugin is unregistered via invalidation before the new one registers.
+  const plugin = query => {
+    if (!query || query.length < 1)
+      return [];
     const q = query.toLowerCase();
     const out = [];
-    for (const [, info] of modules.entries()) {
-      const name = info?.name ?? "";
-      if (!name) continue;
+    for (const [, info] of currentModules.entries()) {
+      const name = info?.name ?? '';
+      if (!name)
+        continue;
       const lower = name.toLowerCase();
       let score = 0;
-      if (lower === q) score = 1000;
-      else if (lower.startsWith(q)) score = 800;
-      else if (lower.includes(q)) score = 600;
-      if (score === 0) continue;
+      if (lower === q)
+        score = 1000;
+      else if (lower.startsWith(q))
+        score = 800;
+      else if (lower.includes(q))
+        score = 600;
+      if (score === 0)
+        continue;
       out.push({
         label: name,
         href: linkTo(name),
-        hint: "open module",
+        hint: 'open module',
         score
       });
     }
     return out;
   };
-  const unregister = $0.addCommand(plugin);
-  invalidation.then(unregister);
-  return "module-finder plugin registered";
+  plugins.add('lopecode_commands', plugin, { invalidation });
+  return 'module-finder plugin registered';
+};
+const _1seh1ei = function _cp_menu_register(plugins,commandPaletteOverlay,invalidation)
+{
+  // Surface the palette in the lopepage-2 burger menu so it's discoverable without knowing the
+  // Cmd/Ctrl+K shortcut. Registers straight onto the shared plugin-registry "lp2-menu" set — no
+  // import of lopepage-2; a notebook opts in by adding both modules to its bootconf mains.
+  const isMac = /Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent || '');
+  plugins.add('lp2-menu', {
+    id: 'command-palette',
+    order: 3,
+    label: 'Command palette  ' + (isMac ? '\u2318K' : 'Ctrl+K'),
+    svg: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3"><circle cx="7" cy="7" r="4.2"/><path d="M10.2 10.2 14 14"/></svg>',
+    action: () => commandPaletteOverlay._openPalette()
+  }, { invalidation });
+  return 'registered: command-palette menu item';
+};
+const _7c6wp9 = function _commandProviders(plugins){return(
+plugins.get('lopecode_commands')
+)};
+const _13y9cxb = function _command_provider_sync(commandPaletteOverlay,commandProviders)
+{
+  // Push the current provider set (from the "lopecode_commands" bus) into the stable overlay,
+  // so the overlay is built once yet always searches the live set. Recomputes on every add/remove.
+  commandPaletteOverlay._setProviders(commandProviders);
+  return `command providers: ${ commandProviders.length }`;
 };
 
 export default function define(runtime, observer) {
@@ -4880,20 +7444,25 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
-  $def("_13upker", null, ["md"], _13upker);  
-  $def("_1eng7wy", "viewof commands", ["Inputs","Event"], _1eng7wy);  
-  $def("_7bve6u", "commands", ["Generators","viewof commands"], _7bve6u);  
-  $def("_bpk8h7", "searchIndex", ["liveCellMap","modules"], _bpk8h7);  
-  $def("_1ptnr90", "commandPaletteStyles", ["theme_assets","htl"], _1ptnr90);  
-  $def("_fomuvm", "commandPaletteOverlay", ["viewof commands","Node","invalidation"], _fomuvm);  
-  $def("_mqy6k9", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","commandPaletteOverlay","invalidation"], _mqy6k9);  
-  $def("_k261kj", "cellSearchPlugin", ["searchIndex","linkTo","viewof commands","invalidation"], _k261kj);  
-  $def("_lq3msy", "moduleFinderPlugin", ["modules","linkTo","viewof commands","invalidation"], _lq3msy);  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
+  $def("_tku1if", null, ["md"], _tku1if);  
+  $def("_yavx6b", "searchIndex", ["liveCellMap","modules"], _yavx6b);  
+  $def("_rmjyys", "commandPaletteStyles", ["theme_assets","htl"], _rmjyys);  
+  $def("_1q8grv4", "commandPaletteOverlay", ["Node","invalidation"], _1q8grv4);  
+  $def("_1vuj6tn", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","command_provider_sync","commandPaletteOverlay","invalidation"], _1vuj6tn);  
+  $def("_104tbig", "cellSearchPlugin", ["searchIndex","linkTo","plugins","invalidation"], _104tbig);  
+  $def("_1opf5e1", "moduleFinderPlugin", ["currentModules","linkTo","plugins","invalidation"], _1opf5e1);  
   main.define("viewof liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("viewof liveCellMap", _));  
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
   main.define("modules", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("modules", _));  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));
+  main.define("theme_assets", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("theme_assets", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
+  $def("_1seh1ei", "cp_menu_register", ["plugins","commandPaletteOverlay","invalidation"], _1seh1ei);  
+  $def("_7c6wp9", "commandProviders", ["plugins"], _7c6wp9);  
+  $def("_13y9cxb", "command_provider_sync", ["commandPaletteOverlay","commandProviders"], _13y9cxb);
   return main;
 }</script>
 <script id="@tomlarkworthy/dataflow-templating/dataflow_templating%401.svg" 
@@ -5387,768 +7956,6 @@ export default function define(runtime, observer) {
   $def("_ngavq7", null, ["viewof example","html"], _ngavq7);
   return main;
 }</script>
-
-<script id="@tomlarkworthy/editable-md" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _qfpqvm = function _title(control,md){return(
-md`# Inline editable \`md\` 
-
-A drop in replacement for the existing markdown renderer function \`md\`. Clicking markdown *content* will now switch to editing mode, so you can edit text in-place. This provides a more natural, Notion-like, document editing experience, and avoids scrolling to the code when correcting larger texts. 
-
-To adopt it you just need to import it, which naturally shadows the \`stdlib\` implementation.
-
-~~~js
-import {md} from "@tomlarkworthy/editable-md"
-~~~
-
-Template interpolation works! You can bring other notebook values into the text with \`\${<expr>}\`. For example, the value of the slider is: ${control}
-
-GFM tables are editable too — click a cell, TAB moves to the next one:
-
-| feature | editable | notes |
-| :--- | :---: | ---: |
-| paragraphs | yes | since v1 |
-| tables | yes | alignment survives |
-
-After an update (keyboard shortcut SHIFT + ENTER), the markdown is parsed back into the tagged template representation and pushed back into the runtime. Runtime serializers like [exporter](https://observablehq.com/@tomlarkworthy/exporter-3) and [Lopecode](https://github.com/tomlarkworthy/lopecode) will pick up the changes next export.`
-)};
-const _1drzw1m = function _control(Inputs){return(
-Inputs.range(undefined, {
-  label: "value is bound to markdown document"
-})
-)};
-const _t64jgr = (G, _) => G.input(_);
-const _t5sezz = function _3(md){return(
-md`## Value access to the markdown 
-
-Access to the raw markdown is sometimes useful, the response is a HTML document for display, but on the root element is the property "markdown" which returns a promise to the markdown document, so you can now use \`md\` as an input.`
-)};
-const _1lfncpk = function _4(title){return(
-title.markdown
-)};
-const _u4o7gp = function _5(md){return(
-md`## Known Issues
-
-- escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
-)};
-const _1z4iyw = function _md(editor_theme_css,prosemirror,editableSchema,Element,randstr,originalMd,editableMarkdownSerializer,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,editableMarkdownParser,linkifyPastedUrl,invalidation)
-{
-  // Force the theme override stylesheet to be evaluated and inserted.
-  editor_theme_css;
-  // Rebuild the prosemirror menubar so the broken "Insert image" item is gone.
-  // TODO: re-enable image insertion once we wire it through
-  //       @tomlarkworthy/fileattachments. The default exampleSetup item prompts
-  //       for a URL/data URL which isn't reachable from inside a lopecode
-  //       notebook; a working version would attach the picked image as a
-  //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
-  const menuItems = prosemirror.buildMenuItems(editableSchema);
-  const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
-  const menuContent = menuItems.inlineMenu.concat([[
-      insertMenu,
-      menuItems.typeMenu
-    ]]).concat([[
-      prosemirror.undoItem,
-      prosemirror.redoItem
-    ]]).concat(menuItems.blockMenu);
-  // Copied and adjusted from exampleSetup.
-  const blockQuoteRule = type => prosemirror.wrappingInputRule(/^\s*>\s$/, type);
-  const orderedListRule = type => prosemirror.wrappingInputRule(/^(\d+)\.\s$/, type, m => ({ order: +m[1] }), (m, n) => n.childCount + n.attrs.order == +m[1]);
-  const bulletListRule = type => prosemirror.wrappingInputRule(/^\s*([-+*])\s$/, type);
-  const codeBlockRule = type => prosemirror.textblockTypeInputRule(/^```$/, type);
-  const headingRule = (type, maxLevel) => prosemirror.textblockTypeInputRule(new RegExp('^(#{1,' + maxLevel + '})\\s$'), type, m => ({ level: m[1].length }));
-  const buildEditorInputRules = schema => {
-    const rules = [
-      prosemirror.ellipsis,
-      prosemirror.emDash
-    ];
-    let type;
-    if (type = schema.nodes.blockquote)
-      rules.push(blockQuoteRule(type));
-    if (type = schema.nodes.ordered_list)
-      rules.push(orderedListRule(type));
-    if (type = schema.nodes.bullet_list)
-      rules.push(bulletListRule(type));
-    if (type = schema.nodes.code_block)
-      rules.push(codeBlockRule(type));
-    if (type = schema.nodes.heading)
-      rules.push(headingRule(type, 6));
-    return prosemirror.inputRules({ rules });
-  };
-  const editorPlugins = [
-    // Table cell navigation must beat baseKeymap, so it goes first.
-    prosemirror.keymap({
-      Tab: prosemirror.goToNextCell(1),
-      'Shift-Tab': prosemirror.goToNextCell(-1)
-    }),
-    buildEditorInputRules(editableSchema),
-    prosemirror.keymap(prosemirror.buildKeymap(editableSchema)),
-    prosemirror.keymap(prosemirror.baseKeymap),
-    prosemirror.dropCursor(),
-    prosemirror.gapCursor(),
-    prosemirror.menuBar({
-      floating: true,
-      content: menuContent
-    }),
-    prosemirror.history(),
-    prosemirror.tableEditing(),
-    new prosemirror.Plugin({ props: { attributes: { class: 'ProseMirror-example-setup-style' } } })
-  ];
-  const isInteractiveTarget = (event, root) => {
-    if (!event || !root)
-      return false;
-    if (event.defaultPrevented)
-      return true;
-    if (event.button != null && event.button !== 0)
-      return true;
-    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
-      return true;
-    const t = event.target;
-    if (!(t instanceof Element))
-      return false;
-    const interactiveSelector = [
-      'a[href]',
-      'button',
-      'input',
-      'select',
-      'textarea',
-      'label',
-      'summary',
-      'details',
-      '[contenteditable=\'true\']',
-      '[data-md-noedit]',
-      '[data-noedit]'
-    ].join(',');
-    const hit = t.closest(interactiveSelector);
-    return !!(hit && root.contains(hit));
-  };
-  return (template, ...values) => {
-    const id = randstr();
-    const dom = originalMd(template, ...values);
-    dom.id = id;
-    // Scope the theme CSS overrides to our editor instances without
-    // bumping specificity via !important.
-    dom.classList.add('lope-editable-md');
-    let view;
-    let self;
-    function saveAndRender() {
-      const markdown = editableMarkdownSerializer.serialize(view.state.doc);
-      const template = markdownToMdTagged(markdown);
-      const variables = compile(template);
-      self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
-      let _fn;
-      eval('_fn = ' + variables[0]._definition.toString());
-      self.define(self._name, variables[0]._inputs, _fn);
-    }
-    const selfPromise = new Promise(resolve => {
-      setTimeout(() => {
-        self = [...runtime._variables].find(v => v?._value?.id == id);
-        if (!self)
-          return;
-        resolve(self);
-        const listener = async event => {
-          if (isInteractiveTarget(event, dom))
-            return;
-          // A click ending a drag-select would otherwise wipe the highlight.
-          const sel = dom.ownerDocument && dom.ownerDocument.getSelection && dom.ownerDocument.getSelection();
-          if (sel && !sel.isCollapsed && sel.anchorNode && sel.focusNode && dom.contains(sel.anchorNode) && dom.contains(sel.focusNode))
-            return;
-          dom.removeEventListener('click', listener);
-          dom.addEventListener('focusout', lostFocus);
-          const ojs_source = await decompile([self]);
-          const markdown = mdCellSourceToMarkdown(ojs_source);
-          const doc = editableMarkdownParser.parse(markdown);
-          const state = prosemirror.EditorState.create({
-            doc,
-            schema: editableSchema,
-            plugins: editorPlugins
-          });
-          dom.innerHTML = '';
-          view = new prosemirror.EditorView(dom, {
-            state,
-            handleKeyDown(viewInstance, event) {
-              if (event.key === 'Enter' && event.shiftKey) {
-                event.preventDefault();
-                lostFocus();
-                return true;
-              }
-              return false;
-            },
-            handlePaste(viewInstance, event) {
-              return linkifyPastedUrl(viewInstance, event);
-            }
-          });
-          view.focus();
-        };
-        // prosemirror appends its prompts (link URL, image) to document.body, outside
-        // dom, so focus entering one looks identical to the user leaving the editor.
-        // Saving there tears down the view the prompt's callback still holds.
-        const promptHasFocus = event => {
-          const to = event && event.relatedTarget;
-          if (to && to.closest && to.closest('.ProseMirror-prompt'))
-            return true;
-          return !!dom.ownerDocument.querySelector('.ProseMirror-prompt');
-        };
-        const lostFocus = event => {
-          if (promptHasFocus(event))
-            return;
-          dom.removeEventListener('focusout', lostFocus);
-          dom.addEventListener('click', listener);
-          saveAndRender();
-        };
-        dom.addEventListener('click', listener);
-        invalidation.then(() => {
-          dom.removeEventListener('click', listener);
-          dom.removeEventListener('focusout', lostFocus);
-        });
-      }, 0);
-    });
-    Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
-    return dom;
-  };
-};
-const _1t782yk = function _editableSchema(prosemirror){return(
-new prosemirror.Schema({
-  nodes: prosemirror.schema.spec.nodes.append(
-    prosemirror.tableNodes({
-      tableGroup: "block",
-      cellContent: "inline*",
-      cellAttributes: {
-        align: {
-          default: null,
-          getFromDOM: (dom) => dom.style.textAlign || null,
-          setDOMAttr: (value, attrs) => {
-            if (value) attrs.style = "text-align:" + value;
-          }
-        }
-      }
-    })
-  ),
-  marks: prosemirror.schema.spec.marks
-})
-)};
-const _ug01ne = function _editableMarkdownParser(prosemirror,editableSchema)
-{
-  // The default parser runs markdown-it's commonmark preset, which has no table
-  // rule, so a GFM pipe table collapses into one paragraph of softbreaks.
-  const MarkdownIt = prosemirror.defaultMarkdownParser.tokenizer.constructor;
-  const tokenizer = new MarkdownIt("commonmark", { html: false }).enable("table");
-  const alignOf = (tok) => {
-    const style = tok.attrGet && tok.attrGet("style");
-    const m = style && /text-align\s*:\s*(left|center|right)/.exec(style);
-    return m ? m[1] : null;
-  };
-  const tokens = Object.assign({}, prosemirror.defaultMarkdownParser.tokens, {
-    table: { block: "table" },
-    thead: { ignore: true },
-    tbody: { ignore: true },
-    tr: { block: "table_row" },
-    th: { block: "table_header", getAttrs: (tok) => ({ align: alignOf(tok) }) },
-    td: { block: "table_cell", getAttrs: (tok) => ({ align: alignOf(tok) }) }
-  });
-  return new prosemirror.MarkdownParser(editableSchema, tokenizer, tokens);
-};
-const _o4sxix = function _editableMarkdownSerializer(prosemirror)
-{
-  // Render a cell's inline content to a string by borrowing the live state's
-  // output buffer, then rewinding it. delim is suppressed so a table nested in a
-  // blockquote/list does not pick up the "> " prefix mid-cell.
-  const cellText = (state, cell) => {
-    const delim = state.delim;
-    state.delim = "";
-    const start = state.out.length;
-    state.renderInline(cell);
-    const text = state.out.slice(start);
-    state.out = state.out.slice(0, start);
-    state.delim = delim;
-    return text.replace(/\n/g, " ").replace(/\|/g, "\\|").trim();
-  };
-  const nodes = Object.assign({}, prosemirror.defaultMarkdownSerializer.nodes, {
-    table(state, node) {
-      // Flush the pending block separator before measuring cells, otherwise it
-      // lands inside the first cell's text and is rewound away.
-      state.flushClose();
-      const rows = [];
-      node.forEach((row) => {
-        const cells = [];
-        row.forEach((cell) =>
-          cells.push({ text: cellText(state, cell), align: cell.attrs.align })
-        );
-        rows.push(cells);
-      });
-      if (!rows.length) return;
-      const width = Math.max(...rows.map((r) => r.length));
-      const line = (cells) =>
-        "| " +
-        Array.from({ length: width }, (_, i) => (cells[i] && cells[i].text) || " ").join(" | ") +
-        " |";
-      const rule = Array.from({ length: width }, (_, i) => {
-        const a = rows[0][i] && rows[0][i].align;
-        return a === "center" ? ":---:" : a === "right" ? "---:" : a === "left" ? ":---" : "---";
-      });
-      const lines = [line(rows[0]), "| " + rule.join(" | ") + " |"].concat(
-        rows.slice(1).map(line)
-      );
-      // Write line by line so a nested table picks up the block delimiter on
-      // each row; no trailing newline, closeBlock owns the block separation.
-      lines.forEach((l, i) => state.write(i < lines.length - 1 ? l + "\n" : l));
-      state.closeBlock(node);
-    },
-    table_row() {},
-    table_cell() {},
-    table_header() {}
-  });
-  return new prosemirror.MarkdownSerializer(nodes, prosemirror.defaultMarkdownSerializer.marks);
-};
-const _etlb83 = function _irToEditableText(){return(
-function irToEditableText(ir) {
-  let s = "";
-  for (const p of ir.parts) {
-    if (p.kind === "text") {
-      s += p.text;
-    } else {
-      s += "${" + p.source + "}";
-    }
-  }
-  return s;
-}
-)};
-const _bpew19 = function _replaceArgPlaceholders()
-{
-  const argPlaceholderRegex = /\$\{ARG\$(\d+)\}/g;
-
-  return (text, replacer) =>
-    text.replace(argPlaceholderRegex, (_, index) => replacer(Number(index)));
-};
-const _n2jvwt = function _10(md){return(
-md`## Source to markdown`
-)};
-const _vbx9g2 = function _test_mdCellSourceToMarkdown(mdCellSourceToMarkdown){return(
-mdCellSourceToMarkdown(
-  "title = md`foo ${'cool'}`"
-)
-)};
-const _196gc4w = function _mdCellSourceToMarkdown(acorn,acorn_walk,escapeMarkdownInline){return(
-function mdCellSourceToMarkdown(source) {
-  const ast = acorn.parse(source, {
-    ecmaVersion: "latest",
-    sourceType: "module"
-  });
-
-  let mdNode = null;
-
-  acorn_walk.simple(ast, {
-    TaggedTemplateExpression(node) {
-      if (mdNode) return;
-      if (node.tag.type === "Identifier" && node.tag.name === "md") {
-        mdNode = node;
-      }
-    }
-  });
-
-  if (!mdNode) return null;
-
-  const tpl = mdNode.quasi;
-  const { quasis, expressions } = tpl;
-
-  let out = "";
-
-  for (let i = 0; i < quasis.length; i++) {
-    const q = quasis[i];
-
-    // 1. literal markdown chunk: use cooked text as-is
-    const text =
-      q.value && typeof q.value.cooked === "string" ? q.value.cooked : "";
-    out += text.replaceAll("${", "\\${");
-
-    // 2. interleaved JS expression as `${ ... }`
-    // Markdown-escape the JS so a round trip through prosemirror's parser
-    // (which strips escapes) hands back the exact source. tokenizeMarkdownTemplate unescapes.
-    if (i < expressions.length) {
-      const expr = expressions[i];
-      const exprSource = source.slice(expr.start, expr.end);
-      out += "${" + escapeMarkdownInline(exprSource) + "}";
-    }
-  }
-
-  return out;
-}
-)};
-const _1ubvqzm = function _13(md){return(
-md`## Markdown to Source`
-)};
-const _1x56dhi = function _markdownToMdTagged(tokenizeMarkdownTemplate,escapeTemplateChunk){return(
-function markdownToMdTagged(editableMarkdown) {
-  const parts = tokenizeMarkdownTemplate(editableMarkdown);
-
-  let out = "md`";
-
-  for (const p of parts) {
-    if (p.kind === "text") {
-      out += escapeTemplateChunk(p.text);
-    } else {
-      out += "${" + p.source + "}";
-    }
-  }
-
-  out += "`";
-  return out;
-}
-)};
-const _1060b9b = function _tokenizeMarkdownTemplate(unescapeMarkdownInline){return(
-function tokenizeMarkdownTemplate(input) {
-  const parts = [];
-  let i = 0;
-  let buf = "";
-  while (i < input.length) {
-    if (
-      input[i] === "$" &&
-      input[i + 1] === "{" &&
-      (i === 0 || input[i - 1] !== "\\")
-    ) {
-      if (buf) {
-        parts.push({ kind: "text", text: buf });
-        buf = "";
-      }
-      i += 2;
-      let depth = 1;
-      const start = i;
-      while (i < input.length && depth > 0) {
-        const ch = input[i];
-        if (ch === "{") depth++;
-        else if (ch === "}") depth--;
-        i++;
-      }
-      if (depth !== 0) {
-        throw new Error("Unbalanced ${...} in markdown template");
-      }
-      // The markdown serializer escapes its specials ([, ], *, ~, `, \) inside the
-      // placeholder too, which would otherwise emit invalid JS into the tagged template.
-      const exprSource = input.slice(start, i - 1);
-      parts.push({ kind: "expr", source: unescapeMarkdownInline(exprSource.trim()) });
-    } else {
-      buf += input[i++];
-    }
-  }
-  if (buf) {
-    parts.push({ kind: "text", text: buf });
-  }
-  return parts;
-}
-)};
-const _8wivof = function _escapeTemplateChunk(){return(
-function escapeTemplateChunk(text) {
-  let out = "";
-  let i = 0;
-
-  while (i < text.length) {
-    // already-escaped placeholder \${...}
-    if (text[i] === "\\" && text[i + 1] === "$" && text[i + 2] === "{") {
-      out += "\\${";
-      i += 3;
-      continue;
-    }
-
-    // unescaped ${...} in text -> escape it so it stays literal
-    if (text[i] === "$" && text[i + 1] === "{") {
-      out += "\\${";
-      i += 2;
-      continue;
-    }
-
-    const ch = text[i++];
-    if (ch === "\\") {
-      out += "\\\\";
-    } else if (ch === "`") {
-      out += "\\`";
-    } else {
-      out += ch;
-    }
-  }
-
-  return out;
-}
-)};
-const _7pk3xw = function _isPasteableUrl(){return(
-function isPasteableUrl(text) {
-  if (typeof text !== "string") return false;
-  const s = text.trim();
-  if (!s || /\s/.test(s)) return false;
-  return /^(https?:\/\/|mailto:)\S+$/i.test(s);
-}
-)};
-const _2mqz8v = function _linkifyPastedUrl(isPasteableUrl){return(
-function linkifyPastedUrl(view, event) {
-  // Pasting a URL over a selection links the selection instead of replacing it.
-  // Returns true when handled, so prosemirror skips its default paste.
-  // Mark types are per-schema, so take it from the view's own schema.
-  const linkType = view.state.schema.marks.link;
-  if (!linkType) return false;
-  const text = event.clipboardData && event.clipboardData.getData("text/plain");
-  if (!isPasteableUrl(text)) return false;
-  const { from, to, empty } = view.state.selection;
-  if (empty) return false;
-  view.dispatch(
-    view.state.tr
-      .addMark(from, to, linkType.create({ href: text.trim(), title: null }))
-      .scrollIntoView()
-  );
-  return true;
-}
-)};
-const _3kmqp1 = function _escapeMarkdownInline(){return(
-function escapeMarkdownInline(text) {
-  // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
-  // so escape/unescape are exact inverses across a parse+serialize round trip.
-  // `|` is included so a placeholder inside a table cell is not split at a pipe.
-  return text.replace(/[\\`*~\[\]_|]/g, (c) => "\\" + c);
-}
-)};
-const _9wq3vz = function _unescapeMarkdownInline(){return(
-function unescapeMarkdownInline(text) {
-  // Reverses a markdown backslash escape of any ASCII punctuation (CommonMark rule),
-  // a superset of escapeMarkdownInline so serializer-added escapes are also removed.
-  return text.replace(/\\([!-\/:-@\[-`{-~])/g, "$1");
-}
-)};
-const _150iump = function _randstr(){return(
-function randstr(prefix)
-{
-    return Math.random().toString(36).replace('0.',prefix || '');
-}
-)};
-const _2gy6uf = function _18(md){return(
-md`## Tests`
-)};
-const _186tklp = function _escaped_code_block_ojs(){return(
-"md`\\${...}`"
-)};
-const _pn6w19 = function _escaped_code_block_markdown(mdCellSourceToMarkdown,escaped_code_block_ojs){return(
-mdCellSourceToMarkdown(escaped_code_block_ojs)
-)};
-const _upbu6g = function _test_mdCellSourceToMarkdown_escaped_placeholder(expect,mdCellSourceToMarkdown){return(
-expect(
-  mdCellSourceToMarkdown("md`\\${...}`")
-).toBe("\\${...}")
-)};
-const _12yt2tt = function _test_markdownToMdTagged_escaped_placeholder(expect,markdownToMdTagged,compile)
-{
-  const MARKDOWN = "\\${...}";
-  const EXPECTED_TEMPLATE = "md`\\${...}`";
-  expect(markdownToMdTagged(MARKDOWN)).toBe(EXPECTED_TEMPLATE);
-  compile(EXPECTED_TEMPLATE);
-};
-const _ina30a = function _test_escaped_placeholder_round_trip(mdCellSourceToMarkdown,expect,markdownToMdTagged)
-{
-  const cell = "title = md`\\${...}`";
-  const markdown = mdCellSourceToMarkdown(cell);
-  expect(markdown).toBe("\\${...}"); // runtime: "\${...}"
-
-  const template = markdownToMdTagged(markdown);
-  expect(template).toBe("md`\\${...}`"); // same as original tag
-};
-const _7bxk2q = function _test_placeholder_brackets_survive_editing(prosemirror,expect,mdCellSourceToMarkdown,markdownToMdTagged,compile)
-{
-  // The reported bug: markdown-special chars inside a ${...} placeholder were escaped
-  // by the serializer and copied verbatim into the tagged template, yielding invalid JS.
-  const CELL = "title = md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`";
-  const markdown = mdCellSourceToMarkdown(CELL);
-  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
-  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
-  const template = markdownToMdTagged(serialized);
-  expect(template).toBe("md`See ${aside('editable-md', ['@tomlarkworthy/editable-md'])} here`");
-  // compile swallows a syntax error into a cell with no inputs whose definition just
-  // throws, so assert the placeholder was really parsed as an expression.
-  const variables = compile(template);
-  expect(variables[0]._inputs).toContain("aside");
-};
-const _4tzn8m = function _test_placeholder_round_trip_preserves_js(prosemirror,expect,escapeMarkdownInline,tokenizeMarkdownTemplate)
-{
-  const EXPRS = [
-    "arr[0]",
-    "a * b",
-    "obj['key']",
-    "x.replace(/\\[/g, '')",   // backslashes must not be eaten
-    "d3.range(10).map(i => i ** 2)",
-    "f(a, [b, c], {d})"
-  ];
-  for (const expr of EXPRS) {
-    const markdown = "Text ${" + escapeMarkdownInline(expr) + "} end";
-    const doc = prosemirror.defaultMarkdownParser.parse(markdown);
-    const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
-    const recovered = tokenizeMarkdownTemplate(serialized).find(p => p.kind === "expr").source;
-    expect(recovered).toBe(expr);
-  }
-  return EXPRS.length + " expressions round trip";
-};
-const _5vqw7d = function _test_escapeMarkdownInline_inverse(expect,escapeMarkdownInline,unescapeMarkdownInline){return(
-expect(unescapeMarkdownInline(escapeMarkdownInline("a[0] * b~c `d` \\e"))).toBe("a[0] * b~c `d` \\e")
-)};
-const _9lnk1a = function _test_isPasteableUrl(expect,isPasteableUrl)
-{
-  for (const ok of ["https://x.dev", "http://a.b/c?d=1", "mailto:a@b.c", "  https://x.dev  "])
-    expect(isPasteableUrl(ok)).toBe(true);
-  for (const no of ["", "not a url", "hello world", "https://a b", "ftp://x.dev", null, undefined, 42])
-    expect(isPasteableUrl(no)).toBe(false);
-  return "url predicate ok";
-};
-const _9lnk2b = function _test_link_survives_round_trip(expect,mdCellSourceToMarkdown,prosemirror,markdownToMdTagged,compile)
-{
-  // A link is only useful if it survives serialize -> tagged template -> compile.
-  const CELL = "title = md`see [the docs](https://example.com/a_b) here`";
-  const markdown = mdCellSourceToMarkdown(CELL);
-  const doc = prosemirror.defaultMarkdownParser.parse(markdown);
-  const serialized = prosemirror.defaultMarkdownSerializer.serialize(doc);
-  const template = markdownToMdTagged(serialized);
-  expect(template).toBe("md`see [the docs](https://example.com/a_b) here`");
-  expect(compile(template)[0]._inputs).toContain("md");
-};
-const _1g67rxt = function _test_table_round_trip(mdCellSourceToMarkdown,editableMarkdownParser,expect,editableMarkdownSerializer,markdownToMdTagged)
-{
-  // The reported bug: a GFM table came back as a single paragraph of pipes
-  // because the default parser has no table rule, destroying the table.
-  const CELL = "t = md`Before\n\n| a | b |\n| :-- | --: |\n| 1 | *x* |\n\nAfter`";
-  const markdown = mdCellSourceToMarkdown(CELL);
-  const doc = editableMarkdownParser.parse(markdown);
-  expect(doc.content.content.map((n) => n.type.name)).toEqual(["paragraph", "table", "paragraph"]);
-  const serialized = editableMarkdownSerializer.serialize(doc);
-  expect(serialized).toBe("Before\n\n| a | b |\n| :--- | ---: |\n| 1 | *x* |\n\nAfter");
-  // Stable under a second round trip, so repeated edits do not drift.
-  expect(editableMarkdownSerializer.serialize(editableMarkdownParser.parse(serialized))).toBe(serialized);
-  expect(markdownToMdTagged(serialized)).toBe("md`" + serialized + "`");
-};
-const _5f1lir = function _test_table_placeholder_round_trip(mdCellSourceToMarkdown,editableMarkdownSerializer,editableMarkdownParser,markdownToMdTagged,expect,compile)
-{
-  // A `${...}` placeholder inside a table cell must survive, pipes and all.
-  const CELL = "t = md`| v | expr |\n| --- | --- |\n| ${a || b} | ${f(x, [y])} |`";
-  const markdown = mdCellSourceToMarkdown(CELL);
-  const serialized = editableMarkdownSerializer.serialize(editableMarkdownParser.parse(markdown));
-  const template = markdownToMdTagged(serialized);
-  expect(template).toBe("md`| v | expr |\n| --- | --- |\n| ${a || b} | ${f(x, [y])} |`");
-  expect(compile(template)[0]._inputs).toContain("a");
-  expect(compile(template)[0]._inputs).toContain("f");
-};
-const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
-{
-  const result = prosemirror.defaultMarkdownParser.parse("\\${}");
-  expect(result.content.content[0].content.content[0]).toEqual({
-    text: "\\${}",
-    type: "text"
-  });
-  return result;
-};
-const _mr4g6d = function _editor_theme_css(htl){return(
-htl.html`<style>
-/* Override prosemirror's bundled fixed-color CSS with theme variables so the
-   inline editor's menubar follows the active lopecode theme.
-   We win on specificity (.lope-editable-md .ProseMirror-menubar = 2 classes
-   beats prosemirror's bundled .ProseMirror-menubar = 1 class), so no
-   !important needed. --theme-background-raised may be empty in some themes
-   (which kills the var() chain), so we use --theme-background as the
-   primary token.
-   TODO: .ProseMirror-prompt (link URL dialog) is appended to document.body
-         and isn't reachable from our wrapper — leave it default for now. */
-.lope-editable-md .ProseMirror-menubar {
-  background: var(--theme-background, #fff);
-  color: var(--theme-foreground-muted, #666);
-  border-bottom-color: var(--theme-foreground-faintest, #c0c0c0);
-}
-.lope-editable-md .ProseMirror-menubar .ProseMirror-icon {
-  color: var(--theme-foreground-muted, #666);
-}
-.lope-editable-md .ProseMirror-menubar .ProseMirror-icon:hover {
-  background: var(--theme-foreground-faintest, #eee);
-  color: var(--theme-foreground, currentColor);
-}
-.lope-editable-md .ProseMirror-menuseparator {
-  border-right-color: var(--theme-foreground-faintest, #c0c0c0);
-}
-.lope-editable-md .ProseMirror-menu-disabled {
-  color: var(--theme-foreground-faint, #ccc);
-}
-.lope-editable-md .ProseMirror-menu-active {
-  background: var(--theme-foreground-faintest, #eee);
-  color: var(--theme-foreground, currentColor);
-}
-.lope-editable-md .ProseMirror-menu-dropdown,
-.lope-editable-md .ProseMirror-menu-submenu-label {
-  color: var(--theme-foreground-muted, #666);
-}
-.lope-editable-md .ProseMirror-menu-dropdown-menu,
-.lope-editable-md .ProseMirror-menu-submenu {
-  background: var(--theme-background, #fff);
-  border-color: var(--theme-foreground-faintest, #c0c0c0);
-  color: var(--theme-foreground, inherit);
-}
-.lope-editable-md .ProseMirror-menu-dropdown-item:hover {
-  background: var(--theme-foreground-faintest, #eee);
-}
-</style>`
-)};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/prosemirror", async () => runtime.module((await import("/@tomlarkworthy/prosemirror.js?v=4")).default));  
-  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  $def("_qfpqvm", "title", ["control","md"], _qfpqvm);  
-  $def("_1drzw1m", "viewof control", ["Inputs"], _1drzw1m);  
-  $def("_t64jgr", "control", ["Generators","viewof control"], _t64jgr);  
-  $def("_t5sezz", null, ["md"], _t5sezz);  
-  $def("_1lfncpk", null, ["title"], _1lfncpk);  
-  $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","editableSchema","Element","randstr","originalMd","editableMarkdownSerializer","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","editableMarkdownParser","linkifyPastedUrl","invalidation"], _1z4iyw);
-  $def("_1t782yk", "editableSchema", ["prosemirror"], _1t782yk);
-  $def("_ug01ne", "editableMarkdownParser", ["prosemirror","editableSchema"], _ug01ne);
-  $def("_o4sxix", "editableMarkdownSerializer", ["prosemirror"], _o4sxix);
-  $def("_etlb83", "irToEditableText", [], _etlb83);
-  $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
-  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  $def("_n2jvwt", null, ["md"], _n2jvwt);  
-  $def("_vbx9g2", "test_mdCellSourceToMarkdown", ["mdCellSourceToMarkdown"], _vbx9g2);  
-  $def("_196gc4w", "mdCellSourceToMarkdown", ["acorn","acorn_walk","escapeMarkdownInline"], _196gc4w);
-  $def("_1ubvqzm", null, ["md"], _1ubvqzm);  
-  $def("_1x56dhi", "markdownToMdTagged", ["tokenizeMarkdownTemplate","escapeTemplateChunk"], _1x56dhi);  
-  $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
-  $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
-  $def("_7pk3xw", "isPasteableUrl", [], _7pk3xw);
-  $def("_2mqz8v", "linkifyPastedUrl", ["isPasteableUrl"], _2mqz8v);
-  $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
-  $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
-  $def("_150iump", "randstr", [], _150iump);
-  $def("_2gy6uf", null, ["md"], _2gy6uf);  
-  $def("_186tklp", "escaped_code_block_ojs", [], _186tklp);  
-  $def("_pn6w19", "escaped_code_block_markdown", ["mdCellSourceToMarkdown","escaped_code_block_ojs"], _pn6w19);  
-  $def("_upbu6g", "test_mdCellSourceToMarkdown_escaped_placeholder", ["expect","mdCellSourceToMarkdown"], _upbu6g);  
-  $def("_12yt2tt", "test_markdownToMdTagged_escaped_placeholder", ["expect","markdownToMdTagged","compile"], _12yt2tt);  
-  $def("_ina30a", "test_escaped_placeholder_round_trip", ["mdCellSourceToMarkdown","expect","markdownToMdTagged"], _ina30a);  
-  $def("_7bxk2q", "test_placeholder_brackets_survive_editing", ["prosemirror","expect","mdCellSourceToMarkdown","markdownToMdTagged","compile"], _7bxk2q);
-  $def("_4tzn8m", "test_placeholder_round_trip_preserves_js", ["prosemirror","expect","escapeMarkdownInline","tokenizeMarkdownTemplate"], _4tzn8m);
-  $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
-  $def("_9lnk1a", "test_isPasteableUrl", ["expect","isPasteableUrl"], _9lnk1a);
-  $def("_9lnk2b", "test_link_survives_round_trip", ["expect","mdCellSourceToMarkdown","prosemirror","markdownToMdTagged","compile"], _9lnk2b);
-  $def("_1g67rxt", "test_table_round_trip", ["mdCellSourceToMarkdown","editableMarkdownParser","expect","editableMarkdownSerializer","markdownToMdTagged"], _1g67rxt);
-  $def("_5f1lir", "test_table_placeholder_round_trip", ["mdCellSourceToMarkdown","editableMarkdownSerializer","editableMarkdownParser","markdownToMdTagged","expect","compile"], _5f1lir);
-  $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  
-  main.define("decompile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompile", _));  
-  main.define("compile", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("compile", _));  
-  main.define("acorn_walk", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn_walk", _));  
-  main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("prosemirror", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("prosemirror", _));  
-  main.define("hide_menu_css", ["module @tomlarkworthy/prosemirror", "@variable"], (_, v) => v.import("hide_menu_css", _));  
-  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_mr4g6d", "editor_theme_css", ["htl"], _mr4g6d);
-  return main;
-}</script>
 <script id="@tomlarkworthy/editor-5/cell_options.json" 
   type="text/plain"
   data-encoding="base64"
@@ -6260,10 +8067,10 @@ function divToVar(runtime, div) {
   }
 }
 )};
-const _1usw8c2 = function _attachContextManu(Inputs,isOnObservableCom){return(
+const _8yv93h = async function _attachContextManu(Inputs,optionsFile,isOnObservableCom){return(
 Inputs.toggle({
-  label: "attach menu",
-  value: !isOnObservableCom()
+  label: 'attach menu',
+  value: (await optionsFile.json())?.__attachMenu ?? !isOnObservableCom()
 })
 )};
 const _1oaz8r1 = (G, _) => G.input(_);
@@ -6300,7 +8107,7 @@ lookupVariable(
   editorModule
 )
 )};
-const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate){return(
+const _1p2yypw = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,createCell,findCell,dragReorder,pinOnCreate,getOption,Event,setOption){return(
 (variable, {
     pinned = undefined
 } = {}) => {
@@ -6389,6 +8196,20 @@ const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate
                             createCell({ cell: findCell(variable) });
                         });
                         hotbar.prepend(add);
+                    }
+                    // Drag the whole hotbar to reorder this cell (alternative to up/down arrows).
+                    if (hotbar && !hotbar.dataset.reorderable) {
+                        hotbar.dataset.reorderable = '1';
+                        hotbar.style.cursor = 'grab';
+                        const grip = document.createElement('span');
+                        grip.className = 'reorder-grip';
+                        grip.textContent = '⠿'; // ⠿ drag handle
+                        grip.title = 'Drag to reorder cell';
+                        // Float left so the grip sits at the far edge of the full-width
+                        // bar, while ➕/edit stay right-aligned via the shell's text-align.
+                        grip.style.cssText = 'float: left; margin-left: 4px; opacity: 0.55;';
+                        hotbar.prepend(grip);
+                        dragReorder(variable, hotbar);
                     }
                     if (body)
                         syncOpen();
@@ -6882,9 +8703,6 @@ async (cell, amount) =>
     }
   })
 )};
-const _pinoncr = function _pinOnCreate(){return(
-new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
-)};
 const _19znal9 = function _createCell($0){return(
 async ({cell, source = "{}" } = {}) =>
   $0.send({
@@ -6946,7 +8764,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate)
+const _g08ji8 = async function _command_processor(command,$0,compile_and_update,pinOnCreate,selectVariable,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,findCell,$2)
 {
     if (command.processed)
         return;
@@ -7002,6 +8820,35 @@ const _2pkmxz = async function _command_processor(command,$0,compile_and_update,
                     });
                 }
             }
+        }
+        result = true;
+    } else if (command.command == 'moveCellBeside') {
+        // Drag-drop reorder: place cell's variables immediately before (or, with
+        // placeAfter, after) the anchor cell that `target` belongs to. Repositions by
+        // variable identity, not cell index, so hidden/import/template variables
+        // between visible cells don't skew the destination. The anchor is resolved to
+        // its whole cell so multi-variable cells (viewof/mutable) aren't split, and a
+        // drop past the last visible cell anchors to it (placeAfter) rather than to the
+        // module's far-off last dynamic variable.
+        const { cell, target, placeAfter } = command.args;
+        const anchorCell = findCell(target);
+        const arr = Array.from(runtime._variables);
+        const groupSet = new Set(cell.variables);
+        const group = arr.filter(v => groupSet.has(v));
+        const without = arr.filter(v => !groupSet.has(v));
+        let insertAt = -1;
+        if (anchorCell?.variables?.length) {
+            const idxs = anchorCell.variables
+                .map(v => without.indexOf(v))
+                .filter(i => i >= 0);
+            if (idxs.length)
+                insertAt = placeAfter ? Math.max(...idxs) + 1 : Math.min(...idxs);
+        }
+        if (insertAt >= 0 && group.length) {
+            without.splice(insertAt, 0, ...group);
+            runtime._variables.clear();
+            without.forEach(v => runtime._variables.add(v));
+            await selectVariable(cell.variables[0], cell.dom);
         }
         result = true;
     }
@@ -7676,13 +9523,14 @@ const _w5q3yf = function _editorModule(thisModule){return(
 thisModule()
 )};
 const _18kaj2p = (G, _) => G.input(_);
-const _yn5gyd = function _editor_jobs(command_processor,submit_summary,save_options)
+const _yeikvo = function _editor_jobs(command_processor,submit_summary,save_options,persist_attach_menu)
 {
   //editedCell;
   command_processor;
   submit_summary;
   save_options;
-  return "editor_jobs";
+  persist_attach_menu;
+  return 'editor_jobs';
 };
 const _1whoy5n = function _91(md){return(
 md`### Apply Update`
@@ -7990,6 +9838,197 @@ const _bz6mai = function _test_completion_identifier_deferred(completionFixture)
     throw new Error('bare identifier (no dot) must defer');
   return 'identifier / no-dot bases deferred to the identifier-chain path';
 };
+const _y8yyf = function _pinOnCreate()
+{
+  return new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
+;
+};
+const _y040tx = function _persist_attach_menu($0,attachContextManu,Event)
+{
+  // Bake the global edit-mode flag into cell_options.json so it survives export/fork.
+  // Depends on `viewof options` (element, stable), not `options` (value), so this
+  // write does not re-trigger itself; save_options then persists the attachment.
+  $0.value.__attachMenu = attachContextManu;
+  $0.dispatchEvent(new Event('input'));
+  return 'persist_attach_menu';
+};
+const _1jn7thk = function _moveCellBeside($0){return(
+async (cell, target, placeAfter = false) =>
+  $0.send({
+    command: "moveCellBeside",
+    args: {
+      cell,
+      target,
+      placeAfter
+    }
+  })
+)};
+const _2rhl00 = function _dragReorder(divToVar,runtime,moveCellBeside,findCell){return(
+(variable, handle) => {
+  if (!document.getElementById('lope-reorder-style')) {
+    const s = document.createElement('style');
+    s.id = 'lope-reorder-style';
+    s.textContent =
+      'body.lope-reordering, body.lope-reordering * { user-select: none !important; cursor: grabbing !important; }';
+    document.head.appendChild(s);
+  }
+
+  const THRESH = 5;
+  let pointerId = null, dragging = false, startX = 0, startY = 0;
+  let cells = null, ownIndex = -1, scroller = null, indicator = null;
+  const blockSelect = (ev) => ev.preventDefault();
+
+  // Same-module visible cells in DOM order; one entry per rendered .observablehq div.
+  const getModuleCells = () => {
+    const mod = variable._module;
+    const out = [];
+    for (const div of document.querySelectorAll('.observablehq')) {
+      const v = divToVar(runtime, div);
+      if (v && v._module === mod) out.push({ div, v });
+    }
+    return out;
+  };
+
+  const ensureIndicator = () => {
+    if (indicator) return indicator;
+    indicator = document.createElement('div');
+    indicator.style.cssText =
+      'position: fixed; height: 0; z-index: 2147483646; pointer-events: none;' +
+      'border-top: 2px solid var(--theme-foreground-focus, #3b5bdb);';
+    document.body.appendChild(indicator);
+    return indicator;
+  };
+  const removeIndicator = () => { if (indicator) { indicator.remove(); indicator = null; } };
+
+  // gap 0..N: how many cells sit above pointer Y (by their vertical midpoint).
+  const gapAt = (y) => {
+    for (let i = 0; i < cells.length; i++) {
+      const r = cells[i].div.getBoundingClientRect();
+      if (y < r.top + r.height / 2) return i;
+    }
+    return cells.length;
+  };
+
+  const drawIndicator = (g) => {
+    const ind = ensureIndicator();
+    const ref = cells[Math.min(ownIndex, cells.length - 1)].div.getBoundingClientRect();
+    const y = g < cells.length
+      ? cells[g].div.getBoundingClientRect().top
+      : cells[cells.length - 1].div.getBoundingClientRect().bottom;
+    ind.style.left = ref.left + 'px';
+    ind.style.width = ref.width + 'px';
+    ind.style.top = (y - 1) + 'px';
+  };
+
+  const autoScroll = (y) => {
+    if (!scroller) return;
+    const r = scroller.getBoundingClientRect
+      ? scroller.getBoundingClientRect()
+      : { top: 0, bottom: window.innerHeight };
+    const M = 36;
+    let dy = 0;
+    if (y < r.top + M) dy = -Math.ceil((r.top + M - y) / 3);
+    else if (y > r.bottom - M) dy = Math.ceil((y - (r.bottom - M)) / 3);
+    if (dy && scroller.scrollBy) scroller.scrollBy({ top: dy });
+  };
+
+  const beginDrag = () => {
+    cells = getModuleCells();
+    ownIndex = cells.findIndex(c => c.v === variable);
+    if (ownIndex < 0) return false;
+    dragging = true;
+    scroller = cells[ownIndex].div.closest('.lm_content')
+      || document.scrollingElement || document.documentElement;
+    document.body.classList.add('lope-reordering');
+    handle.style.cursor = 'grabbing';
+    // Drop any selection the gesture already started and block new ones for the drag.
+    const sel = window.getSelection && window.getSelection();
+    if (sel && sel.removeAllRanges) sel.removeAllRanges();
+    document.addEventListener('selectstart', blockSelect, true);
+    return true;
+  };
+
+  const onMove = (e) => {
+    if (pointerId == null) return;
+    if (!dragging) {
+      if (Math.abs(e.clientX - startX) < THRESH && Math.abs(e.clientY - startY) < THRESH) return;
+      if (!beginDrag()) return;
+    }
+    e.preventDefault();
+    drawIndicator(gapAt(e.clientY));
+    autoScroll(e.clientY);
+  };
+
+  const teardown = () => {
+    if (pointerId != null && handle.releasePointerCapture) {
+      try { handle.releasePointerCapture(pointerId); } catch (_) {}
+    }
+    handle.removeEventListener('pointermove', onMove);
+    handle.removeEventListener('pointerup', onUp);
+    handle.removeEventListener('pointercancel', onCancel);
+    document.removeEventListener('selectstart', blockSelect, true);
+    handle.style.cursor = '';
+    document.body.classList.remove('lope-reordering');
+    removeIndicator();
+  };
+
+  const onUp = (e) => {
+    const wasDragging = dragging;
+    let target, placeAfter = false, ownDiv = null, doMove = false;
+    if (wasDragging) {
+      ownDiv = cells[ownIndex].div;
+      const g = gapAt(e.clientY);
+      // Drop in own slot (just above or below self) is a no-op.
+      if (g !== ownIndex && g !== ownIndex + 1) {
+        doMove = true;
+        if (g < cells.length) {
+          target = cells[g].v;         // insert before the cell now at the gap
+        } else {
+          target = cells[cells.length - 1].v;  // dropped past the last visible cell
+          placeAfter = true;
+        }
+      }
+    }
+    teardown();
+    pointerId = null; dragging = false; cells = null; ownIndex = -1; scroller = null;
+    if (wasDragging) {
+      // Suppress the click that would otherwise toggle the editor open/closed.
+      const stop = (ev) => { ev.stopPropagation(); ev.preventDefault(); };
+      handle.addEventListener('click', stop, { capture: true, once: true });
+      setTimeout(() => handle.removeEventListener('click', stop, { capture: true }), 0);
+      if (doMove) moveCellBeside(findCell(variable, ownDiv), target, placeAfter);
+    }
+  };
+
+  const onCancel = () => {
+    teardown();
+    pointerId = null; dragging = false; cells = null; ownIndex = -1; scroller = null;
+  };
+
+  const onDown = (e) => {
+    if (e.button != null && e.button !== 0) return;
+    if (e.target && e.target.closest && e.target.closest('.add-cell-btn')) return;
+    pointerId = e.pointerId;
+    startX = e.clientX; startY = e.clientY;
+    dragging = false;
+    if (handle.setPointerCapture) { try { handle.setPointerCapture(e.pointerId); } catch (_) {} }
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onCancel);
+  };
+
+  handle.addEventListener('pointerdown', onDown);
+  // Suppress the native text-selection drag that would otherwise start on press.
+  // mousedown-preventDefault leaves `click` intact (same trick as the add button).
+  handle.addEventListener('mousedown', e => {
+    if (!(e.target && e.target.closest && e.target.closest('.add-cell-btn'))) e.preventDefault();
+  });
+  handle.addEventListener('selectstart', blockSelect);
+  handle.style.touchAction = 'none';
+  handle.style.userSelect = 'none';
+  return () => handle.removeEventListener('pointerdown', onDown);
+}
+)};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -8005,6 +10044,7 @@ export default function define(runtime, observer) {
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
 
   main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
   main.define("module @tomlarkworthy/reversible-attachment", async () => runtime.module((await import("/@tomlarkworthy/reversible-attachment.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
@@ -8029,11 +10069,11 @@ export default function define(runtime, observer) {
   $def("_hdieof", "editors", [], _hdieof);  
   $def("_ipx6cz", "auto_attach", ["keepalive","editorModule","syncers","attachContextManu","divToVar","runtime","editors","cellEditor"], _ipx6cz);  
   $def("_1iwobxt", "divToVar", [], _1iwobxt);  
-  $def("_1usw8c2", "viewof attachContextManu", ["Inputs","isOnObservableCom"], _1usw8c2);  
+  $def("_8yv93h", "viewof attachContextManu", ["Inputs","optionsFile","isOnObservableCom"], _8yv93h);  
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
-  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate"], _1q95xt6);
+  $def("_1p2yypw", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","createCell","findCell","dragReorder","pinOnCreate","getOption","Event","setOption"], _1p2yypw);  
   $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
   $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
   $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
@@ -8078,8 +10118,7 @@ export default function define(runtime, observer) {
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
   $def("_1imarq2", null, ["md"], _1imarq2);  
   $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
-  $def("_pinoncr", "pinOnCreate", [], _pinoncr);
-  $def("_19znal9", "createCell", ["viewof command"], _19znal9);
+  $def("_19znal9", "createCell", ["viewof command"], _19znal9);  
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
   $def("_1toku21", null, ["md"], _1toku21);  
   $def("_d7ouqx", "viewof command", ["flowQueue"], _d7ouqx);  
@@ -8089,7 +10128,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate"], _2pkmxz);  
+  $def("_g08ji8", "command_processor", ["command","viewof edit","compile_and_update","pinOnCreate","selectVariable","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","findCell","viewof command"], _g08ji8);  
   $def("_8iz5z2", null, ["md"], _8iz5z2);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  
@@ -8119,11 +10158,12 @@ export default function define(runtime, observer) {
   $def("_1mfm13h", "normalizeObservableClipboardCell", ["inferCellGroupNameFromOJS","escapeTemplateLiteral"], _1mfm13h);  
   $def("_1pa2xc8", "readObservableClipboardCells", ["globalThis"], _1pa2xc8);  
   $def("_1w99cbu", "pasteObservableCellsIntoModule", ["viewof liveCellMap","normalizeObservableClipboardCell","findCell","compile_and_update"], _1w99cbu);  
-  $def("_z9vacx", null, ["md"], _z9vacx);
-  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);
+  $def("_z9vacx", null, ["md"], _z9vacx);  
+  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));  
+  $def("_gbuhyc", "decompiled", ["editedCell","decompile"], _gbuhyc);  
   $def("_w5q3yf", "viewof editorModule", ["thisModule"], _w5q3yf);  
   $def("_18kaj2p", "editorModule", ["Generators","viewof editorModule"], _18kaj2p);  
-  $def("_yn5gyd", "editor_jobs", ["command_processor","submit_summary","save_options"], _yn5gyd);  
+  $def("_yeikvo", "editor_jobs", ["command_processor","submit_summary","save_options","persist_attach_menu"], _yeikvo);  
   $def("_1whoy5n", null, ["md"], _1whoy5n);  
   $def("_gk83fp", "compile_and_update", ["compile","runtime","realize","repositionSetElement","decompile"], _gk83fp);  
   $def("_1g3bdxp", null, ["md"], _1g3bdxp);  
@@ -8178,9 +10218,7 @@ export default function define(runtime, observer) {
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
   main.define("submit_summary", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("submit_summary", _));  
   main.define("forcePeek", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("forcePeek", _));  
-  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));
-  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));
-  main.define("modules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", "modules", _));
+  main.define("observe", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("observe", _));  
   $def("_lbftlp", "literalCompletions", ["codemirror"], _lbftlp);  
   $def("_scoiwp", "completionFixture", ["EditorState","observableJS_language","literalCompletions"], _scoiwp);  
   $def("_160qhf1", "test_completion_string_literal", ["completionFixture"], _160qhf1);  
@@ -8190,7 +10228,11 @@ export default function define(runtime, observer) {
   $def("_quyccp", "test_completion_bool_template_regexp", ["completionFixture"], _quyccp);  
   $def("_1cn3ucr", "test_completion_parenthesised_unwrap", ["completionFixture"], _1cn3ucr);  
   $def("_15vxhca", "test_completion_never_evaluates", ["completionFixture"], _15vxhca);  
-  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);
+  $def("_bz6mai", "test_completion_identifier_deferred", ["completionFixture"], _bz6mai);  
+  $def("_y8yyf", "pinOnCreate", [], _y8yyf);  
+  $def("_y040tx", "persist_attach_menu", ["viewof options","attachContextManu","Event"], _y040tx);  
+  $def("_1jn7thk", "moveCellBeside", ["viewof command"], _1jn7thk);  
+  $def("_2rhl00", "dragReorder", ["divToVar","runtime","moveCellBeside","findCell"], _2rhl00);
   return main;
 }</script>
 <script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
@@ -10536,7 +12578,7 @@ const _yqx7l8 = function _syncEnabled(notebookId,htl)
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
+const _1nuhj4u = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, $0) {
     const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
@@ -11126,7 +13168,7 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
+const _19e6n4y = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
     if (!directory)
         return 'Waiting for directory...';
     if (!syncArmed || !syncArmed.armed)
@@ -11290,7 +13332,7 @@ const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, 
                         const blob = new window.Blob([diskText], { type: 'text/javascript' });
                         const url = window.URL.createObjectURL(blob);
                         try {
-                            const mod = await window.importShim(url, 'file://@tomlarkworthy/file-sync');
+                            const mod = await import(url);
                             if (typeof mod.default === 'function') {
                                 applyModule(moduleId, mod.default);
                                 console.log('[file-sync] applied ' + moduleId + ' from disk');
@@ -11397,7 +13439,7 @@ const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, 
                 const blob = new window.Blob([diskText], { type: 'text/javascript' });
                 const url = window.URL.createObjectURL(blob);
                 try {
-                    const imported = await window.importShim(url, 'file://@tomlarkworthy/file-sync');
+                    const imported = await import(url);
                     if (typeof imported.default === 'function') {
                         const newMod = runtime.module(imported.default, () => null);
                         runtime.mains.set(moduleId, newMod);
@@ -11509,6 +13551,196 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
+const _qq3v7b = function _jbApply(importShim) {
+    let pidSeq = 0;
+    const genPid = () => '_jb' + (pidSeq++).toString(36) + Math.floor(Math.random() * 1000000).toString(36);
+    const hasVarInput = inputs => (inputs || []).some(iv => (typeof iv === 'string' ? iv : iv && iv._name) === '@variable');
+    const importPath = defn => {
+        const m = (defn ? defn.toString() : '').match(/import\(\s*["'`]([^"'`]+)["'`]/);
+        return m ? m[1] : null;
+    };
+    return function makeApply({currentModules, runtime, probeDefine, createModule, obj_observer} = {}) {
+        const resolveModule = moduleId => {
+            if (currentModules)
+                for (const [, info] of currentModules)
+                    if (info.name === moduleId)
+                        return info.module;
+            const r = runtime;
+            if (r.mains && r.mains.has(moduleId))
+                return r.mains.get(moduleId);
+            if (typeof createModule === 'function') {
+                try {
+                    return createModule(moduleId, r);
+                } catch (e) {
+                    return null;
+                }
+            }
+            return null;
+        };
+        const obsFactory = (() => {
+            if (typeof obj_observer === 'function')
+                return obj_observer;
+            try {
+                const f = runtime && runtime._builtin && runtime._builtin._scope.get('__ojs_observer');
+                return f && typeof f._value === 'function' ? f._value : null;
+            } catch (e) {
+                return null;
+            }
+        })();
+        return function applyModule(moduleId, defineFn) {
+            const mod = resolveModule(moduleId);
+            if (!mod)
+                return {
+                    applied: false,
+                    reason: 'module not loaded and cannot create: ' + moduleId
+                };
+            const existingByName = new Map();
+            const existingByPid = new Map();
+            for (const v of runtime._variables) {
+                if (v._module !== mod)
+                    continue;
+                if (v._name)
+                    existingByName.set(v._name, v);
+                if (v.pid)
+                    existingByPid.set(v.pid, v);
+            }
+            const cells = probeDefine(defineFn);
+            const seenPids = new Set();
+            const seenNames = new Set();
+            let changes = 0;
+            for (const cell of cells) {
+                if (cell.name === '@variable')
+                    continue;
+                const upsertLoader = (loaderName, defn) => {
+                    seenNames.add(loaderName);
+                    const spec = loaderName.slice('module '.length);
+                    const child = resolveModule(spec);
+                    const path = importPath(defn);
+                    const key = child ? 'live:' + spec : path ? 'path:' + path : null;
+                    if (key == null)
+                        return;
+                    const make = child ? () => child : async () => runtime.module((await import(path)).default);
+                    const existing = existingByName.get(loaderName);
+                    if (existing) {
+                        if (existing._jbKey !== undefined && existing._jbKey !== key) {
+                            existing.define(loaderName, [], make);
+                            existing._jbKey = key;
+                            changes++;
+                        }
+                        return;
+                    }
+                    const v = mod.variable(null);
+                    v.define(loaderName, [], make);
+                    v._jbKey = key;
+                    existingByName.set(loaderName, v);
+                    changes++;
+                };
+                const upsertBinding = (name, inputs, defn) => {
+                    seenNames.add(name);
+                    const existing = existingByName.get(name);
+                    if (!existing) {
+                        const v = mod.variable(null);
+                        v.define(name, inputs, defn);
+                        existingByName.set(name, v);
+                        changes++;
+                        return;
+                    }
+                    const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(inputs);
+                    const defnMatch = existing._definition && existing._definition.toString() === (defn ? defn.toString() : '');
+                    if (!(inputsMatch && defnMatch)) {
+                        existing.define(name, inputs, defn);
+                        changes++;
+                    }
+                };
+                if (cell.type === 'import') {
+                    const spec = cell.from;
+                    const child = spec && resolveModule(spec);
+                    if (!child)
+                        continue;
+                    const loaderName = 'module ' + spec;
+                    seenNames.add(loaderName);
+                    if (!existingByName.has(loaderName)) {
+                        const lv = mod.variable(null);
+                        lv.define(loaderName, [], () => child);
+                        lv._jbKey = 'live:' + spec;
+                        existingByName.set(loaderName, lv);
+                        changes++;
+                    }
+                    const alias = cell.alias || cell.remote;
+                    upsertBinding(alias, [
+                        loaderName,
+                        '@variable'
+                    ], (_, vv) => vv.import(cell.remote, _));
+                    continue;
+                }
+                if (cell.name && cell.name.startsWith('module ')) {
+                    upsertLoader(cell.name, cell.definition);
+                    continue;
+                }
+                if (hasVarInput(cell.inputs)) {
+                    if (cell.name)
+                        upsertBinding(cell.name, cell.inputs, cell.definition);
+                    continue;
+                }
+                let pid = cell.pid;
+                if (!pid) {
+                    const byName = cell.name && existingByName.get(cell.name);
+                    pid = byName && byName.pid || genPid();
+                }
+                seenPids.add(pid);
+                if (cell.name)
+                    seenNames.add(cell.name);
+                const existing = existingByPid.get(pid) || cell.name && existingByName.get(cell.name);
+                if (!existing) {
+                    const v = mod.variable({});
+                    v.define(cell.name, cell.inputs, cell.definition);
+                    v.pid = pid;
+                    existingByPid.set(pid, v);
+                    if (cell.name)
+                        existingByName.set(cell.name, v);
+                    changes++;
+                    continue;
+                }
+                const existingInputNames = (existing._inputs || []).map(iv => typeof iv === 'string' ? iv : iv._name);
+                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+                const defnMatch = existing._definition && existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+                if (inputsMatch && defnMatch) {
+                    if (!existing.pid)
+                        existing.pid = pid;
+                    continue;
+                }
+                existing.define(cell.name, cell.inputs, cell.definition).pid = pid;
+                changes++;
+            }
+            for (const v of [...runtime._variables]) {
+                if (v._module !== mod)
+                    continue;
+                const name = v._name;
+                if (name === '@variable')
+                    continue;
+                if (name && seenNames.has(name))
+                    continue;
+                if (name && name.startsWith('module ') || hasVarInput(v._inputs)) {
+                    if (name) {
+                        v.delete();
+                        changes++;
+                    }
+                    continue;
+                }
+                if (!v.pid || seenPids.has(v.pid))
+                    continue;
+                v.delete();
+                changes++;
+            }
+            return {
+                applied: true,
+                moduleId,
+                changes
+            };
+        };
+    };
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -11526,7 +13758,7 @@ export default function define(runtime, observer) {
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
   $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11543,7 +13775,7 @@ export default function define(runtime, observer) {
   $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_19e6n4y", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _19e6n4y);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11553,7 +13785,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 
@@ -12929,6 +15162,146 @@ export default function define(runtime, observer) {
   $def("_b5ui8y", "isnode", ["Element","Text"], _b5ui8y);
   return main;
 }</script>
+
+<script id="@tomlarkworthy/invoke-variable" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _zkje0r = function _1(md){return(
+md`# \`invokeVariable(<name>, <module>, overrides = {})\`
+
+Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
+)};
+const _swiym2 = function _invokeVariable(lookupVariable)
+{
+  return async function invokeVariable(name, module, overrides = {}) {
+    if (overrides == null || typeof overrides !== 'object')
+      throw new TypeError('invokeVariable(name, module, {overrides}): overrides must be an object');
+    // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
+    // the caller already holds it); otherwise resolve by (name, module).
+    let variable;
+    if (name && typeof name === 'object' && typeof name._definition !== 'undefined') {
+      variable = name;
+      module = module ?? variable._module;
+    } else {
+      if (typeof name !== 'string' || !name.length)
+        throw new TypeError('invokeVariable(name, module, \u2026): name must be a non-empty string');
+      if (!module)
+        throw new TypeError('invokeVariable(name, module, \u2026): module is required');
+      variable = await lookupVariable(name, module);
+      if (!variable)
+        throw new Error(`invokeVariable: variable "${ name }" not found in module`);
+    }
+    module = module ?? variable._module;
+    const label = variable._name ?? (typeof name === 'string' ? name : '(anonymous)');
+    const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
+    const inputNames = inputs.map(v => v?._name);
+    for (const k of Object.keys(overrides)) {
+      if (!inputNames.includes(k)) {
+        throw new Error(`invokeVariable("${ label }"): override "${ k }" was provided but is not a declared dependency. Declared dependencies: ${ inputNames.filter(Boolean).join(', ') }`);
+      }
+    }
+    const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+    const resolveDependency = async depName => {
+      if (hasOwn(overrides, depName))
+        return overrides[depName];
+      const scopeVar = module?._scope?.get?.(depName) ?? module?._runtime?._builtin?._scope?.get?.(depName);
+      if (scopeVar) {
+        if (scopeVar._value !== undefined)
+          return scopeVar._value;
+        if (scopeVar._promise && typeof scopeVar._promise?.then === 'function')
+          return await scopeVar._promise;
+      }
+      if (typeof module?.value === 'function') {
+        try {
+          return await module.value(depName);
+        } catch (e) {
+        }
+      }
+      if (module?._runtime && typeof module._runtime._global === 'function') {
+        try {
+          const g = module._runtime._global(depName);
+          if (g !== undefined)
+            return g;
+        } catch (e) {
+        }
+      }
+      throw new Error(`invokeVariable("${ label }"): could not resolve dependency "${ depName }" (no override and not found in module/builtins/global)`);
+    };
+    const args = [];
+    for (const dep of inputs) {
+      const depName = dep?._name;
+      if (!depName) {
+        args.push(undefined);
+        continue;
+      }
+      args.push(await resolveDependency(depName));
+    }
+    const def = variable._definition;
+    if (typeof def !== 'function') {
+      throw new Error(`invokeVariable("${ label }"): target variable does not have an invokable function definition`);
+    }
+    return def(...args);
+  };
+};
+const _jtrr9m = function _3(md){return(
+md`### Example
+
+let c = a + b`
+)};
+const _1v2c0s1 = function _a(){return(
+1
+)};
+const _ywl8oh = function _b(){return(
+3
+)};
+const _1mc3tpl = function _c(a,b){return(
+a + b
+)};
+const _o5e50u = function _7(md){return(
+md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
+)};
+const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule)
+)};
+const _smh5by = function _9(md){return(
+md`But we can set b to 20, and then we get the answer 21.`
+)};
+const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule, { b: 20 })
+)};
+const _qh0yhm = function _11(md){return(
+md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
+)};
+const _1hy0qcz = function _invokeVariableModule(thisModule){return(
+thisModule()
+)};
+const _jno7wc = (G, _) => G.input(_);
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_zkje0r", null, ["md"], _zkje0r);  
+  $def("_swiym2", "invokeVariable", ["lookupVariable"], _swiym2);  
+  $def("_jtrr9m", null, ["md"], _jtrr9m);  
+  $def("_1v2c0s1", "a", [], _1v2c0s1);  
+  $def("_ywl8oh", "b", [], _ywl8oh);  
+  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
+  $def("_o5e50u", null, ["md"], _o5e50u);  
+  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
+  $def("_smh5by", null, ["md"], _smh5by);  
+  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
+  $def("_qh0yhm", null, ["md"], _qh0yhm);  
+  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
+  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
+  return main;
+}</script>
 <script id="@tomlarkworthy/isomorphic-git-1-30-1/isomorphic-git-1%401.30.1.bundle.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -14222,7 +16595,7 @@ async function listBranches({repo} = {}) {
   }
 }
 )};
-const _1bvisll = function _listFiles(ensure_branch,git,fs){return(
+const _bvp3oz = function _listFiles(ensure_branch,git,fs){return(
 async function listFiles({repo, branch, ref} = {}) {
   if (!repo)
     throw new Error('repo is required');
@@ -14241,7 +16614,6 @@ async function listFiles({repo, branch, ref} = {}) {
     });
   } catch (err) {
     console.error(err);
-    debugger;
     return [];
   }
 }
@@ -14399,91 +16771,105 @@ function read(def) {
 const _1l4hr6l = function _49(md){return(
 md`## History API Functions`
 )};
-const _zanj5n = function _revertVariables(getVariableByPersistentId,runtime,realize){return(
-async entries => {
-  const out = [];
-  for (const e of entries ?? []) {
-    const pid = e?.pid ?? null;
-    if (!pid)
-      continue;
-    const variable = getVariableByPersistentId(pid, runtime) || null;
-    if (!variable) {
-      out.push({
-        pid,
-        ok: false,
-        reason: 'no runtime variable'
-      });
-      continue;
-    }
-    const prev = e?.previous ?? null;
-    if (!prev) {
-      if (e?.op === 'new') {
-        try {
-          variable.delete?.();
-          out.push({
-            pid,
-            ok: true,
-            action: 'delete'
-          });
-        } catch (err) {
-          out.push({
-            pid,
-            ok: false,
-            action: 'delete',
-            reason: String(err?.message ?? err)
-          });
-        }
-      } else {
+const _1hhkam2 = function _revertVariables(getVariableByPersistentId,runtime,history,initial_state,realize)
+{
+  return async entries => {
+    const out = [];
+    // For each selected change, restore its variable to the state it had
+    // immediately BEFORE that change. Reconstructed from the history log +
+    // initial_state, since entries carry no `previous` field.
+    for (const e of entries ?? []) {
+      const pid = e?.pid ?? null;
+      if (!pid)
+        continue;
+      const variable = getVariableByPersistentId(pid, runtime) || null;
+      if (!variable) {
         out.push({
           pid,
           ok: false,
-          reason: 'no previous snapshot'
+          reason: 'no runtime variable'
+        });
+        continue;
+      }
+      // find the prior snapshot for this pid: the last same-pid entry before `e`
+      const at = history.indexOf(e);
+      const upTo = at === -1 ? history.length - 1 : at - 1;
+      let prev = null, firstForPid = null;
+      for (let idx = 0; idx <= upTo; idx++) {
+        const h = history[idx];
+        if (h?.pid !== pid)
+          continue;
+        if (firstForPid === null)
+          firstForPid = h;
+        prev = h;
+      }
+      if (!prev) {
+        // nothing earlier for this pid — either it existed before recording,
+        // or this change first created it (op 'new') so reverting deletes it
+        const base = initial_state instanceof Map ? initial_state.get(pid) ?? null : null;
+        if (e?.op === 'new' || !base) {
+          try {
+            variable.delete?.();
+            out.push({
+              pid,
+              ok: true,
+              action: 'delete'
+            });
+          } catch (err) {
+            out.push({
+              pid,
+              ok: false,
+              action: 'delete',
+              reason: String(err?.message ?? err)
+            });
+          }
+          continue;
+        }
+        prev = base;
+      }
+      const def = (await realize([prev._definition ?? ''], runtime))[0];
+      if (!def) {
+        out.push({
+          pid,
+          ok: false,
+          reason: 'could not realize previous definition'
+        });
+        continue;
+      }
+      const name = ((typeof prev._name === 'string' && prev._name.length) ? prev._name : null) ?? ((typeof variable._name === 'string' && variable._name.length) ? variable._name : null) ?? pid;
+      try {
+        variable.define(name, Array.isArray(prev._inputs) ? prev._inputs : [], def);
+        out.push({
+          pid,
+          ok: true,
+          action: 'define'
+        });
+      } catch (err) {
+        out.push({
+          pid,
+          ok: false,
+          action: 'define',
+          reason: String(err?.message ?? err)
         });
       }
-      continue;
     }
-    const def = (await realize([prev._definition ?? ''], runtime))[0];
-    if (!def) {
-      out.push({
-        pid,
-        ok: false,
-        reason: 'could not realize previous definition'
-      });
-      continue;
+    return out;
+  };
+};
+const _41vg0h = function _rewindToTime(history,applyHistoryState)
+{
+  return function rewindToTime(time) {
+    // history is sorted ascending by t; index = number of changes at or before `time`
+    let index = 0;
+    for (const entry of history) {
+      if ((entry?.t ?? 0) <= time)
+        index++;
+      else
+        break;
     }
-    const name = ((typeof prev._name === 'string' && prev._name.length) ? prev._name : null) ?? ((typeof variable._name === 'string' && variable._name.length) ? variable._name : null) ?? pid;
-    try {
-      variable.define(name, Array.isArray(prev._inputs) ? prev._inputs : [], def);
-      out.push({
-        pid,
-        ok: true,
-        action: 'define'
-      });
-    } catch (err) {
-      out.push({
-        pid,
-        ok: false,
-        action: 'define',
-        reason: String(err?.message ?? err)
-      });
-    }
-  }
-  return out;
-}
-)};
-const _1cvp8ui = function _rewindToTime(history,revertVariables){return(
-function (time) {
-  const byPid = new Map();
-  for (const entry of history) {
-    if (entry?.t > time) {
-      const pid = entry?.pid;
-      if (pid && !byPid.has(pid))
-        byPid.set(pid, entry);
-    }
-  }
-  revertVariables(Array.from(byPid.values()));
-}
-)};
+    return applyHistoryState(index);
+  };
+};
 const _1rfq6xd = function _52(md){return(
 md`## State`
 )};
@@ -14529,7 +16915,7 @@ const _qu2y2k = function _historyUtils(){return(
   }
 }
 )};
-const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$1,read,onCodeChange,identity,modules,$2,Event,invalidation)
+const _5czkc4 = function _change_listener(runtime,$0,persistentId,historyUtils,$1,read,onCodeChange,playback_suspend,identity,modules,$2,Event,invalidation)
 {
   // scan the runtime for things that were loaded before we attached the hook
   if (!this) {
@@ -14545,6 +16931,9 @@ const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$
     return read(currDef) ?? read(prevDef) ?? null;
   };
   const stop = onCodeChange(({variable, previous, t}) => {
+    // playback drives defines/deletes; suppress recording while it runs
+    if (playback_suspend && Date.now() < playback_suspend.until)
+      return;
     let v = variable || previous.variable;
     // lazyImport
     // Suprised the do not referentially match
@@ -14559,6 +16948,9 @@ const _84fm9q = function _change_listener(runtime,$0,persistentId,historyUtils,$
     const moduleName = modules.get(module)?.name || 'unknown';
     const prov = inferProvenance(variable, previous);
     const source = prov?.source ?? 'runtime';
+    // playback replays existing history; never record it as a fresh change
+    if (source === 'playback')
+      return;
     if (variable && !previous) {
       // new variable
       // record it as a base state
@@ -14992,6 +17384,120 @@ const _1tpet0t = function _historyModule(thisModule){return(
 thisModule()
 )};
 const _1ryokzy = (G, _) => G.input(_);
+const _sjnusq = function _playback(history,html,applyHistoryState,Event,invalidation)
+{
+  const n = history.length;
+  const form = html`<form style="display:flex;gap:.4em;align-items:center;font:13px system-ui,sans-serif;flex-wrap:wrap">
+    <button type=button name=first title="start">⏮</button>
+    <button type=button name=prev title="previous change">◀</button>
+    <button type=button name=play title="play / pause">▶ play</button>
+    <button type=button name=next title="next change">▶</button>
+    <button type=button name=last title="latest">⏭</button>
+    <input type=range name=range min=0 max=${ n } step=1 value=${ n } style="flex:1;min-width:120px">
+    <output name=out style="font:12px monospace">${ n } / ${ n }</output>
+  </form>`;
+  let value = n, timer = null;
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+      form.play.textContent = '\u25B6 play';
+    }
+  };
+  const go = async v => {
+    value = Math.max(0, Math.min(n, v | 0));
+    form.range.value = value;
+    form.out.value = `${ value } / ${ n }`;
+    form.value = value;
+    await applyHistoryState(value);
+    form.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+  form.range.oninput = () => go(+form.range.value);
+  form.first.onclick = () => go(0);
+  form.prev.onclick = () => go(value - 1);
+  form.next.onclick = () => go(value + 1);
+  form.last.onclick = () => go(n);
+  form.play.onclick = () => {
+    if (timer)
+      return stop();
+    form.play.textContent = '\u23F8 pause';
+    timer = setInterval(() => go(value >= n ? 0 : value + 1), 700);
+  };
+  invalidation.then(stop);
+  form.value = value;
+  return form;
+};
+const _x7pc8l = (G, _) => G.input(_);
+const _ncb8n9 = function _applyHistoryState(modules,playback_suspend,history,initial_state,getVariableByPersistentId,runtime,replay_pid_map,realize,tag)
+{
+  const moduleByName = new Map();
+  if (modules instanceof Map)
+    for (const [m, meta] of modules)
+      if (meta?.name)
+        moduleByName.set(meta.name, m);
+  const defaultMod = moduleByName.get('main') ?? (modules instanceof Map ? modules.keys().next().value : null) ?? null;
+  // Reconstruct notebook state after the first `index` recorded changes, from the
+  // history log + initial_state base snapshots. Entries carry no `previous` field,
+  // so this also drives git-replayed history.
+  return async function applyHistoryState(index) {
+    // Suspend recording for the apply + a grace window: playback's redefines/deletes
+    // fire onCodeChange asynchronously and must not be logged as fresh changes.
+    playback_suspend.until = Date.now() + 4000;
+    const i = Math.max(0, Math.min(index | 0, history.length));
+    const byPid = new Map();
+    history.forEach((h, idx) => {
+      if (!h?.pid)
+        return;
+      let g = byPid.get(h.pid);
+      if (!g)
+        byPid.set(h.pid, g = {
+          first: h,
+          last: null
+        });
+      if (idx < i)
+        g.last = h;
+    });
+    for (const [pid, {first, last}] of byPid) {
+      const del = last ? last.op === 'del' : first.op === 'new';
+      const snap = del ? null : last ?? initial_state.get(pid) ?? null;
+      let v = getVariableByPersistentId(pid, runtime) ?? replay_pid_map.get(pid) ?? null;
+      if (del) {
+        if (v) {
+          try {
+            v.delete?.();
+          } catch {
+          }
+          replay_pid_map.delete(pid);
+        }
+        continue;
+      }
+      if (!snap)
+        continue;
+      if (!v) {
+        const mod = moduleByName.get((last ?? first)?.module ?? 'main') ?? defaultMod;
+        if (!mod)
+          continue;
+        replay_pid_map.set(pid, v = mod.variable());
+      }
+      let def = null;
+      try {
+        def = (await realize([snap._definition ?? ''], runtime))[0] ?? null;
+      } catch {
+      }
+      if (!def)
+        continue;
+      v.define(snap._name || pid, Array.isArray(snap._inputs) ? snap._inputs : [], tag(def, {
+        source: 'playback',
+        pid
+      }));
+    }
+    playback_suspend.until = Date.now() + 500;
+    return i;
+  };
+};
+const _v5cr66 = function _playback_suspend(){return(
+{ until: 0 }
+)};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
@@ -15048,7 +17554,7 @@ export default function define(runtime, observer) {
   $def("_1c4d7y5", "setFilesAndCommit", ["ensure_branch","git","fs","ensure_dir"], _1c4d7y5);  
   $def("_veyumo", "listRepos", ["fs"], _veyumo);  
   $def("_1rusr2m", "listBranches", ["ensure_repo","git","fs"], _1rusr2m);  
-  $def("_1bvisll", "listFiles", ["ensure_branch","git","fs"], _1bvisll);  
+  $def("_bvp3oz", "listFiles", ["ensure_branch","git","fs"], _bvp3oz);  
   $def("_xl9zth", "listCommits", ["ensure_branch","git","fs"], _xl9zth);  
   $def("_h6ylpe", "getCommitChanges", ["git","fs"], _h6ylpe);  
   $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
@@ -15057,12 +17563,12 @@ export default function define(runtime, observer) {
   $def("_1intaie", "tag", [], _1intaie);  
   $def("_ziwv9c", "read", [], _ziwv9c);  
   $def("_1l4hr6l", null, ["md"], _1l4hr6l);  
-  $def("_zanj5n", "revertVariables", ["getVariableByPersistentId","runtime","realize"], _zanj5n);  
-  $def("_1cvp8ui", "rewindToTime", ["history","revertVariables"], _1cvp8ui);  
+  $def("_1hhkam2", "revertVariables", ["getVariableByPersistentId","runtime","history","initial_state","realize"], _1hhkam2);  
+  $def("_41vg0h", "rewindToTime", ["history","applyHistoryState"], _41vg0h);  
   $def("_1rfq6xd", null, ["md"], _1rfq6xd);  
   $def("_lh9ssh", "config", ["notebook_title","ensure_branch"], _lh9ssh);  
   $def("_qu2y2k", "historyUtils", [], _qu2y2k);  
-  $def("_84fm9q", "change_listener", ["runtime","viewof initial_state","persistentId","historyUtils","viewof module_load_time","read","onCodeChange","identity","modules","viewof history","Event","invalidation"], _84fm9q);  
+  $def("_5czkc4", "change_listener", ["runtime","viewof initial_state","persistentId","historyUtils","viewof module_load_time","read","onCodeChange","playback_suspend","identity","modules","viewof history","Event","invalidation"], _5czkc4);  
   $def("_1gmcocx", null, ["Inputs","history"], _1gmcocx);  
   $def("_ztvqq8", null, ["md"], _ztvqq8);  
   $def("_1klmxot", "commit_watermarks", [], _1klmxot);  
@@ -15101,7 +17607,11 @@ export default function define(runtime, observer) {
   main.define("http", ["module @tomlarkworthy/isomorphic-git-1-30-1", "@variable"], (_, v) => v.import("http", _));  
   main.define("JSZip", ["module @tomlarkworthy/jszip-3-10-1", "@variable"], (_, v) => v.import("JSZip", _));  
   main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));
+  main.define("notebook_title", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("notebook_title", _));  
+  $def("_sjnusq", "viewof playback", ["history","html","applyHistoryState","Event","invalidation"], _sjnusq);  
+  $def("_x7pc8l", "playback", ["Generators","viewof playback"], _x7pc8l);  
+  $def("_ncb8n9", "applyHistoryState", ["modules","playback_suspend","history","initial_state","getVariableByPersistentId","runtime","replay_pid_map","realize","tag"], _ncb8n9);  
+  $def("_v5cr66", "playback_suspend", [], _v5cr66);
   return main;
 }</script>
 
@@ -15293,1640 +17803,6 @@ export default function define(runtime, observer) {
   $def("_1vldl4e", "viewof example3", ["Inputs","localStorageView"], _1vldl4e);  
   $def("_fyim03", "example3", ["Generators","viewof example3"], _fyim03);  
   main.define("inspect", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("inspect", _));
-  return main;
-}</script>
-
-<script id="@tomlarkworthy/lopepage" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1xyxga0 = function _page(htl,isOnObservableCom,lopeviz_handle_css,base_css,light_theme_css,commandPaletteStyles,commandPaletteOverlay,linkTo){return(
-htl.html`<div id="lopepage" style="height: ${
-  isOnObservableCom() ? "800px" : "100vh"
-}">
-  ${lopeviz_handle_css}
-  ${base_css}
-  ${light_theme_css}
-  ${commandPaletteStyles}
-${commandPaletteOverlay}
-  <style>
-    html body {
-      max-width: 100vw;
-    }
-    html {
-      padding: 0px !important;
-      margin: 0px !important;
-    }
-    #lopepage:has(.observablehq-root) > .module-explorer {
-      display: none;
-    }
-  </style>
-  <h1 style="display:none;">Lopepage</h1>
-  <div class="module-explorer">
-    <p>Lost? Open the <a href="${linkTo("@tomlarkworthy/module-selection", {
-      onObservable: false
-    })}">module explorer</a> or press CMD + K to open the command palatte.
-  </div>
-</div>`
-)};
-const _1ujnhdh = function _append_to_body(page)
-{
-    // If exported in headless mode, this will attach the page
-    if (!page.isConnected) {
-        document.body.appendChild(page);
-    }
-};
-const _1nv51s8 = function _testNavigation(htl,linkTo){return(
-htl.html`<h2>Manual Testing links</h2>
-<ul>
-<li><a href="https://observablehq.com/@tomlarkworthy/lopepage#testNavigation">refresh page</a></li>
-<li><a href="#testNavigation">reset view</a></li>
-<li><a href="${ linkTo('@tomlarkworthy/stream-operators', { onObservable: false }) }">stream-operators</a> module</li>
-<li><a href="${ linkTo('@tomlarkworthy/stream-operators#combineLatest', { onObservable: false }) }">stream-operators#combineLatest</a> 
-<li><a href="${ linkTo('@tomlarkworthy/runtime-sdk#observe', { onObservable: false }) }">runtime-sdk#observe</a> cell</li>
-</ul>`
-)};
-const _ydvyos = function _reload(Inputs){return(
-Inputs.button('reload')
-)};
-const _1we0ggl = (G, _) => G.input(_);
-const _plefwg = function _onLoadConfig(parseGoldenDSL,URLSearchParams,location)
-{
-    try {
-        return parseGoldenDSL(new URLSearchParams(location.hash.substring(1)).get('view'));
-    } catch (err) {
-        return undefined;
-    }
-};
-const _1nzpnqy = function _visualizer_cache(reload)
-{
-    reload;
-    return new Map();
-};
-const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
-{
-  return function (container, component) {
-    appendScrollLog('modulePanel:enter', {
-      title: container?.title ?? null,
-      componentCell: component?.cell ?? null
-    });
-    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
-    if (!moduleInfo) {
-      // Fall through to file attachment: titles like @user/notebook/path.ext
-      // resolve via the lopecode bootloader's contentSync DOM lookup.
-      const title = container?.title ?? null;
-      if (title) {
-        let node = file_attachment_cache.get(title);
-        if (!node) {
-          const r = window.lopecode?.contentSync?.(title);
-          if (r && r.status === 200 && r.bytes) {
-            node = renderFileAttachment(r.mime, r.bytes);
-            file_attachment_cache.set(title, node);
-            appendScrollLog('modulePanel:file_attachment_create', {
-              title,
-              mime: r.mime
-            });
-          }
-        }
-        if (node) {
-          const c_element = container.getElement();
-          if (node.parentNode !== c_element)
-            c_element.appendChild(node);
-          appendScrollLog('modulePanel:file_attachment_mount', { title });
-          return;
-        }
-      }
-      appendScrollLog('modulePanel:missing_moduleInfo', { title });
-      return;
-    }
-    const module = moduleInfo.module;
-    let node;
-    if (!visualizer_cache.has(module)) {
-      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
-      node = visualizer(runtime, {
-        invalidation: new Promise(r => {
-        }),
-        module,
-        detachNodes: isOnObservableCom(),
-        filter: (cell_name, variables) => {
-          if (variables[0]._type !== 1)
-            return false;
-          if (typeof cell_name == 'string') {
-            if (cell_name.startsWith('dynamic '))
-              return false;
-          }
-          return true;
-        }
-      });
-      visualizer_cache.set(module, node);
-    } else {
-      node = visualizer_cache.get(module);
-      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
-    }
-    const cell = module._scope.get(component.cell);
-    const scrollKey = scrollKeyFor(container);
-    fix_scroll(container, node, cell, scrollKey);
-    const el = container.getElement();
-    if (!el.__lope_scroll_bound) {
-      el.__lope_scroll_bound = true;
-      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
-      const markUserScroll = () => {
-        el.__lope_user_scroll_at = Date.now();
-      };
-      el.addEventListener('wheel', markUserScroll, { passive: true });
-      el.addEventListener('touchmove', markUserScroll, { passive: true });
-      el.addEventListener('keydown', markUserScroll, { passive: true });
-      el.addEventListener('scroll', () => {
-        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
-          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
-          return;
-        }
-        // Only cache scrolls following a genuine user gesture; reflow-induced
-        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
-        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
-          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
-          return;
-        }
-        const k = scrollKeyFor(container);
-        const scrollTop = el.scrollTop;
-        const scrollLeft = el.scrollLeft;
-        if (scrollTop == 0) {
-          appendScrollLog('modulePanel:skip 0 scroll', {
-            title: container?.title ?? null,
-            scrollKey
-          });
-          return;
-        }
-        scroll_cache.set(k, {
-          scrollTop,
-          scrollLeft,
-          t: Date.now()
-        });
-        appendScrollLog('scroll:event', {
-          k,
-          title: container?.title ?? null,
-          scrollTop,
-          scrollLeft
-        });
-      }, { passive: true });
-    }
-    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
-    if (!container.__lope_destroy_bound) {
-      container.__lope_destroy_bound = true;
-      container.on('destroy', () => {
-        try {
-          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
-            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
-            return;
-          }
-          const k = scrollKeyFor(container);
-          const scrollTop = el?.scrollTop;
-          const scrollLeft = el?.scrollLeft;
-          if (scrollTop == 0) {
-            appendScrollLog('scroll:skip 0 scroll', {
-              k,
-              key: container?.title ?? null,
-              scrollKey
-            });
-            return;
-          }
-          // do not skip 0 here: if the user is at top, preserve that state
-          scroll_cache.set(k, {
-            scrollTop,
-            scrollLeft,
-            t: Date.now()
-          });
-          appendScrollLog('scroll:destroy_capture', {
-            k,
-            title: container?.title ?? null,
-            scrollTop,
-            scrollLeft
-          });
-        } catch (e) {
-          appendScrollLog('scroll:destroy_capture:error', {
-            title: container?.title ?? null,
-            error: String(e)
-          });
-        }
-      });
-    }
-    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
-    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
-    if (!container.__lope_resize_bound) {
-      container.__lope_resize_bound = true;
-      container.on('resize', () => {
-        const rk = scrollKeyFor(container);
-        const cached = scroll_cache.get(rk);
-        if (!cached || cached.scrollTop == null)
-          return;
-        const c_el = container.getElement();
-        const at = Date.now();
-        scroll_cache.__reflowUntil = at + 800;
-        // The reflow can shift scrollTop in several passes (content relayout
-        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
-        const apply = () => {
-          if ((c_el.__lope_user_scroll_at || 0) > at)
-            return;
-          if (c_el.scrollTop !== cached.scrollTop)
-            c_el.scrollTop = cached.scrollTop;
-          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
-            c_el.scrollLeft = cached.scrollLeft;
-        };
-        requestAnimationFrame(apply);
-        for (const d of [
-            60,
-            150,
-            300,
-            450,
-            600
-          ])
-          setTimeout(apply, d);
-        appendScrollLog('scroll:resize_restore', {
-          k: rk,
-          title: container?.title ?? null,
-          scrollTop: cached.scrollTop
-        });
-      });
-    }
-    appendScrollLog('modulePanel:exit', {
-      title: container?.title ?? null,
-      scrollKey
-    });
-  };
-};
-const _1gm4gbf = function _blobPanel(){return(
-function (container, component) {
-    const node = document.createElement('iframe');
-    node.src = component.url;
-    const c_element = container.getElement();
-    const element = c_element.appendChild(node);
-}
-)};
-const _lxv2e2 = function _settings(){return(
-{
-    showMaximiseIcon: false,
-    showPopoutIcon: false,
-    showCloseIcon: true,
-    hasHeaders: true
-}
-)};
-const _lp1ggk = function _is_mobile(width){return(
-width < 800
-)};
-const _qbghwu = function _config(onLoadConfig,settings)
-{
-    if (onLoadConfig) {
-        return {
-            settings: settings,
-            content: [onLoadConfig]
-        };
-    }
-    return { settings: settings };
-};
-const _15lk82w = (M, _) => new M(_);
-const _1bki6eh = _ => _.generator;
-const _14z0bay = function _resize(Generators,addEventListener,invalidation,removeEventListener){return(
-Generators.observe(notify => {
-    notify(undefined);
-    addEventListener('resize', notify);
-    invalidation.then(() => removeEventListener('resize', notify));
-})
-)};
-const _18jv72h = function _layout(resize,gl,$0,page,modulePanel,blobPanel)
-{
-    // Removed resizing re-laying out because it causes problems with components that watch focus
-    // when the the layout is redone, the components are killed and removed, damaging focus state.
-    // mobile keyboards cause a resize, breaking the component that has focus
-    resize;
-    let layout = this;
-    if (!layout) {
-        layout = new gl.GoldenLayout($0.value, page);
-        layout.registerComponent('module', modulePanel);
-        layout.registerComponent('blob', blobPanel);
-        layout.init();
-    } else {
-        layout.updateSize();
-    }
-    // TODO layout destroy is destructive
-    // invalidation.then(() => {
-    //   // avoid layouts stacking up
-    //   layout.destroy();
-    // });
-    return layout;
-};
-const _tsjb2x = function _layout_state(appendScrollLog,layout,gl,$0)
-{
-    appendScrollLog('layout_state:bind', { hasLayout: !!layout });
-    return layout.on('stateChanged', () => {
-        appendScrollLog('layout:stateChanged', {});
-        const state = gl.LayoutConfig.fromResolved(layout.toConfig());
-        $0.value = state;
-        appendScrollLog('layout:stateChanged:config_updated', { rootType: state?.root?.type ?? null });
-    });
-};
-const _11nrwvj = function _lopepageModule(thisModule){return(
-thisModule()
-)};
-const _r97569 = (G, _) => G.input(_);
-const _1sp5wo4 = function _16(md){return(
-md`## Scrolling
-
-Scrolling has been a mess to develop. The thing that finally fixed it was \`scroll_fix_sync_layout\`. I suspect fix_scroll is over-complex.`
-)};
-const _1ts23ma = function _scrollDebug(Inputs){return(
-Inputs.toggle({
-    label: 'enable debug scroll?',
-    value: true
-})
-)};
-const _7jxivy = (G, _) => G.input(_);
-const _1f2wuqm = function _appendScrollLog($0,$1){return(
-(type, detail = {}) => {
-    if (!$0.value)
-        return null;
-    const evt = {
-        t: Date.now(),
-        type: String(type),
-        ...detail
-    };
-    $1.value = ($1.value || []).concat([evt]);
-    return evt;
-}
-)};
-const _1nbnzwx = function _scrollLog(scrollDebug){return(
-scrollDebug ? [] : []
-)};
-const _1f7xtz1 = (M, _) => new M(_);
-const _1dyz4o0 = _ => _.generator;
-const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
-{
-    return container => {
-        // can return undefined if the container is loading still
-        const key = container?.title;
-        appendScrollLog('scrollKeyFor:', { key });
-        return key;
-    };
-};
-const _tb217h = function _scroll_cache(){return(
-new Map()
-)};
-const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
-{
-  return function (container, node, cell_variable, key) {
-    scroll_cache.__reflowUntil = Date.now() + 600;
-    // suppress reflow-induced scroll events that clobber the cache
-    const c_element = container.getElement();
-    let k = scrollKeyFor(container);
-    appendScrollLog('fix_scroll:enter', {
-      title: container?.title ?? null,
-      k,
-      cell: cell_variable?._name ?? null
-    });
-    if (node && node.parentNode !== c_element) {
-      c_element.appendChild(node);
-      appendScrollLog('fix_scroll:append_node', {
-        title: container?.title ?? null,
-        k
-      });
-    }
-    const writeCache = (scrollTop, scrollLeft, why) => {
-      scroll_cache.set(k, {
-        scrollTop,
-        scrollLeft,
-        t: Date.now()
-      });
-      appendScrollLog('scroll_cache:write', {
-        k,
-        scrollTop,
-        scrollLeft,
-        why
-      });
-    };
-    const scrollToCellIfPossible = why => {
-      if (!cell_variable)
-        return false;
-      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
-      if (!dom) {
-        appendScrollLog('scroll:cell_dom_not_found', {
-          k,
-          why,
-          cell: cell_variable?._name ?? null
-        });
-        return false;
-      }
-      const top = dom.offsetTop - c_element.offsetTop;
-      const left = c_element.scrollLeft;
-      c_element.scrollTop = top;
-      appendScrollLog('scroll:set', {
-        k,
-        why: `${ why }:cell`,
-        scrollTop: top,
-        scrollLeft: left,
-        cell: cell_variable?._name ?? null
-      });
-      writeCache(top, left, `${ why }:cell`);
-      return true;
-    };
-    const restoreFromCache = why => {
-      k = scrollKeyFor(container);
-      const cached = scroll_cache.get(k);
-      appendScrollLog('scroll:restore_attempt', {
-        k,
-        why,
-        cachedScrollTop: cached?.scrollTop ?? null,
-        cachedScrollLeft: cached?.scrollLeft ?? null
-      });
-      if (!cached) {
-        appendScrollLog('scroll:restore_no_scroll', {
-          k,
-          why
-        });
-        return;
-      }
-      if (cached.scrollTop != null)
-        c_element.scrollTop = cached.scrollTop;
-      if (cached.scrollLeft != null)
-        c_element.scrollLeft = cached.scrollLeft;
-      appendScrollLog('scroll:restore_applied', {
-        k,
-        why,
-        scrollTop: cached.scrollTop ?? null,
-        scrollLeft: cached.scrollLeft ?? null,
-        scrollTopFinal: c_element.scrollTop,
-        scrollLeftFinal: c_element.scrollLeft
-      });
-    };
-    const setScroll = (why = 'setScroll') => {
-      if (scrollToCellIfPossible(why))
-        return;
-      restoreFromCache(why);
-    };
-    const retryFrames = 6;
-    for (let i = 0; i < retryFrames; i++) {
-      requestAnimationFrame(() => {
-        k = scrollKeyFor(container);
-        appendScrollLog('fix_scroll:raf_retry', {
-          i,
-          k,
-          title: container?.title ?? null
-        });
-        setScroll(`raf:${ i }`);
-      });
-    }
-    appendScrollLog('fix_scroll:exit', {
-      k,
-      title: container?.title ?? null
-    });
-  };
-};
-const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
-{
-    sync_layout_to_url;
-    let timeout = null;
-    const listComponentItems = () => {
-        const out = [];
-        const walk = item => {
-            if (!item)
-                return;
-            if (item.isComponent || item.type === 'component')
-                out.push(item);
-            const kids = item.contentItems || item.content || [];
-            for (const k of kids)
-                walk(k);
-        };
-        walk(layout.root);
-        return out;
-    };
-    const items = listComponentItems();
-    appendScrollLog('scroll:reapply_all:begin', { count: items.length });
-    for (const it of items) {
-        try {
-            const container = it.container;
-            const title = container?.title ?? it.title ?? null;
-            if (!container || !title)
-                continue;
-            const st = it.componentState ?? it.config?.componentState ?? it._config?.componentState ?? it._state ?? {};
-            modulePanel(container, { cell: st?.cell });
-        } catch (e) {
-            appendScrollLog('scroll:reapply_all:error', { error: String(e) });
-        }
-    }
-    return true;
-};
-const _3nwpp4 = function _URLrouting(md){return(
-md`## URL Sync
-
-### Goals
-1. **Non-destructive navigation:** mutate an existing GoldenLayout (GL) instance (add/remove/reorder items) rather than rebuilding.
-2. **Refresh restores what you see:** the URL eventually contains the full serialized GL tree in **\`view=\`**.
-3. **Links are “intents”:** in-app links should not rewrite \`view=\` at click time.
-
----
-
-## State model
-
-### Canonical, persistent state
-- **\`view=<DSL>\`** is the canonical serialized GL layout (single source of truth after boot).
-
-### One-shot intent params (cleared after commit)
-- \`open=<moduleOrModule#cell>\`
-- \`close=<...>\` (reserved)
-- \`focus=<...>\` (reserved)
-- \`from=<module>\` (optional placement hint)
-
----
-
-## Dataflow
-
-### 1) URL → desired layout (intent overlay)
-- Parse \`view\` with \`parseGoldenDSL\` to get the desired root config.
-- If \`open=\` exists, **overlay** it into the parsed config by inserting the target module into the *first stack* (and optional \`componentState.cell\`).
-
-Implemented in: **\`sync_layout_from_url\`**.
-
-### 2) Desired layout → live GL (non-destructive when possible)
-- Try **\`treeSyncGolden(layout, desiredRoot)\`** to:
-  - add missing module tabs
-  - remove extra module tabs
-  - reorder tabs to match the DSL
-  - ensure container shapes (row/column/stack) match where possible
-- If tree sync can’t reconcile safely, **fallback to \`layout.loadLayout(...)\`**.
-
-Implemented in: **\`treeSyncGolden\`** + \`sync_layout_from_url\`.
-
-### 3) Live GL → URL persistence (“commit then clear”)
-- GL emits \`stateChanged\` → update \`mutable config\` from \`layout.toConfig()\`.
-- Serialize \`config.root\` with \`serializeGoldenDSL\` and write it to **\`view=\`**.
-- Clear one-shot intent params (\`open/close/focus/from\`) so they are not re-applied on refresh.
-
-Implemented in: **\`sync_layout_to_url\`** via \`history.replaceState(...)\`.
-
----
-
-## Unit test gate (safety check)
-Before \`sync_layout_to_url\` is allowed to persist \`view=\`, a **roundtrip invariant** must hold:
-
-- Compute an expected “pre” DSL:
-  - normalize weights (e.g. S100/R100/C100)
-  - apply the same \`open=\` overlay used by \`sync_layout_from_url\`
-- Compare it to the “post” DSL obtained after applying the URL to the live layout and re-serializing.
-
-If **\`test_url_roundtrip\`** throws or returns non-\`true\`, **\`sync_layout_to_url\`** exits early (no canonical \`view=\` writes). This prevents committing a drifting/incorrect \`view=\` during development and makes URL persistence self-checking.
-
-Implemented in: **\`test_url_roundtrip\`** and enforced at the top of **\`sync_layout_to_url\`**.
-`
-)};
-const _14te9pl = function _sync_layout_from_url(reload,resize,URLSearchParams,hash,appendScrollLog,parseGoldenDSL,gl,layout,serializeGoldenDSL,treeSyncGolden,invalidation)
-{
-  reload;
-  resize;
-  const params = new URLSearchParams(String(hash || '').replace(/^#/, ''));
-  const view = params.get('view');
-  const open = params.get('open');
-  appendScrollLog('url:sync_from:begin', {
-    hash: String(hash || ''),
-    view,
-    open
-  });
-  const diag = {
-    preURL: view ?? null,
-    postURL: null,
-    method: null,
-    status: 'skipped',
-    reason: '',
-    error: null,
-    open: null,
-    openApplied: false
-  };
-  let desiredRoot;
-  try {
-    desiredRoot = parseGoldenDSL(view);
-  } catch (e) {
-    diag.method = 'parse';
-    diag.status = 'error';
-    diag.reason = 'parseGoldenDSL failed';
-    diag.error = String(e);
-    appendScrollLog('url:sync_from:error', {
-      where: 'parse',
-      error: diag.error
-    });
-    return diag;
-  }
-  if (!view && open) {
-    try {
-      const resolved = gl.LayoutConfig.fromResolved(layout.toConfig());
-      desiredRoot = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
-      if (desiredRoot) {
-        diag.preURL = serializeGoldenDSL(desiredRoot);
-        appendScrollLog('url:sync_from:fallback_to_current_layout', {
-          preURL: diag.preURL,
-          open
-        });
-      }
-    } catch (e) {
-      appendScrollLog('url:sync_from:fallback_to_current_layout:error', { error: String(e) });
-    }
-    if (!desiredRoot) {
-      // Lazily synthesize an empty stack so the open overlay below can populate it.
-      desiredRoot = {
-        type: 'stack',
-        content: []
-      };
-      try {
-        diag.preURL = serializeGoldenDSL(desiredRoot);
-      } catch {
-        diag.preURL = 'S100()';
-      }
-      appendScrollLog('url:sync_from:synthesize_empty_stack', {
-        preURL: diag.preURL,
-        open
-      });
-    }
-  }
-  if (!desiredRoot) {
-    diag.method = 'parse';
-    diag.status = 'error';
-    diag.reason = 'parseGoldenDSL returned falsy';
-    appendScrollLog('url:sync_from:error', {
-      where: 'parse',
-      error: diag.reason
-    });
-    return diag;
-  }
-  const findFirstStack = node => {
-    if (!node)
-      return null;
-    if (node.type === 'stack')
-      return node;
-    for (const c of node.content || []) {
-      const f = findFirstStack(c);
-      if (f)
-        return f;
-    }
-    return null;
-  };
-  const findExistingModule = (node, title) => {
-    if (!node)
-      return null;
-    if (node.type === 'component' && (node.componentType === 'module' || node.componentName === 'module') && node.title === title) {
-      return node;
-    }
-    for (const c of node.content || []) {
-      const f = findExistingModule(c, title);
-      if (f)
-        return f;
-    }
-    return null;
-  };
-  if (open) {
-    const [moduleTitleRaw, cellRaw] = String(open).split('#');
-    const moduleTitle = (moduleTitleRaw || '').trim();
-    const cell = (cellRaw || '').trim() || null;
-    if (moduleTitle) {
-      diag.open = {
-        moduleTitle,
-        cell
-      };
-      const existingAnywhere = findExistingModule(desiredRoot, moduleTitle);
-      if (existingAnywhere) {
-        existingAnywhere.componentState = existingAnywhere.componentState || {};
-        if (cell)
-          existingAnywhere.componentState.cell = cell;
-        appendScrollLog('url:sync_from:overlay_open:update_existing', {
-          moduleTitle,
-          cell
-        });
-        diag.openApplied = true;
-      } else {
-        const stack = findFirstStack(desiredRoot);
-        if (stack) {
-          stack.content = stack.content || [];
-          stack.content.push({
-            type: 'component',
-            title: moduleTitle,
-            componentType: 'module',
-            componentName: 'module',
-            componentState: cell ? { cell } : {}
-          });
-          appendScrollLog('url:sync_from:overlay_open:add', {
-            moduleTitle,
-            cell
-          });
-          diag.openApplied = true;
-        } else {
-          appendScrollLog('url:sync_from:overlay_open:no_stack_found', {
-            moduleTitle,
-            cell
-          });
-        }
-      }
-    }
-  }
-  const doLoadLayout = () => {
-    if (typeof layout?.loadLayout !== 'function')
-      throw new Error('layout.loadLayout not available');
-    appendScrollLog('layout:loadLayout:call', {
-      desiredType: desiredRoot?.type ?? null,
-      open: diag.open?.moduleTitle ?? null
-    });
-    layout.loadLayout({
-      settings: {},
-      content: [desiredRoot]
-    });
-  };
-  try {
-    const res = treeSyncGolden(layout, desiredRoot);
-    if (res?.status === 'fallback') {
-      diag.method = 'loadLayout';
-      diag.status = 'fallback';
-      diag.reason = res.reason || 'treeSync requested fallback';
-      appendScrollLog('url:sync_from:treesync_fallback', { reason: diag.reason });
-      try {
-        doLoadLayout();
-      } catch (e2) {
-        diag.status = 'error';
-        diag.reason = 'loadLayout failed after treeSync fallback';
-        diag.error = String(e2);
-        appendScrollLog('url:sync_from:error', {
-          where: 'loadLayout_after_fallback',
-          error: diag.error
-        });
-      }
-    } else {
-      diag.method = 'treeSync';
-      diag.status = 'synced';
-      appendScrollLog('url:sync_from:treesync_ok', {});
-    }
-  } catch (e) {
-    diag.method = 'loadLayout';
-    diag.status = 'fallback';
-    diag.reason = 'exception during treeSync';
-    diag.error = String(e);
-    appendScrollLog('url:sync_from:treesync_exception', { error: diag.error });
-    try {
-      doLoadLayout();
-    } catch (e2) {
-      diag.status = 'error';
-      diag.reason = 'loadLayout failed after treeSync exception';
-      diag.error = `${ String(e) }; loadLayout: ${ String(e2) }`;
-      appendScrollLog('url:sync_from:error', {
-        where: 'loadLayout_after_exception',
-        error: diag.error
-      });
-    }
-  }
-  try {
-    const resolved = gl?.LayoutConfig?.fromResolved ? gl.LayoutConfig.fromResolved(layout.toConfig()) : null;
-    const root = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
-    diag.postURL = root ? serializeGoldenDSL(root) : null;
-  } catch (e) {
-    diag.postURL = null;
-    if (!diag.error)
-      diag.error = `serialize failed: ${ String(e) }`;
-    appendScrollLog('url:sync_from:serialize_failed', { error: String(e) });
-  }
-  appendScrollLog('url:sync_from:end', {
-    status: diag.status,
-    method: diag.method,
-    reason: diag.reason || null,
-    preURL: diag.preURL,
-    postURL: diag.postURL
-  });
-  invalidation.then(() => {
-  });
-  return diag;
-};
-const _1l50a0d = function _sync_layout_to_url(appendScrollLog,sync_layout_from_url,config,test_url_roundtrip,serializeGoldenDSL,location,setHashURL)
-{
-    appendScrollLog('url:sync_to:tick', {
-        fromStatus: sync_layout_from_url?.status ?? null,
-        hasRoot: !!config?.root
-    });
-    if (test_url_roundtrip !== true) {
-        appendScrollLog('url:sync_to:blocked', { reason: 'test_url_roundtrip != true' });
-        return;
-    }
-    if (sync_layout_from_url?.status === 'error') {
-        appendScrollLog('url:sync_to:blocked', { reason: 'sync_layout_from_url status=error' });
-        return;
-    }
-    if (!config?.root) {
-        appendScrollLog('url:sync_to:blocked', { reason: 'config.root missing' });
-        return;
-    }
-    let dsl;
-    try {
-        dsl = serializeGoldenDSL(config.root);
-    } catch (e) {
-        appendScrollLog('url:sync_to:serialize_failed', { error: String(e) });
-        return;
-    }
-    // Parse hash manually to avoid URLSearchParams percent-encoding view= values
-    // like R100(S50(@tomlarkworthy/lopepage)) → R100%28S50%28%40tomlarkworthy%2Flopepage%29%29
-    const rawHash = String(location.hash || '').replace(/^#/, '');
-    const knownIntents = new Set([
-        'open',
-        'close',
-        'focus',
-        'from'
-    ]);
-    // Split into key=value pairs, preserving original encoding
-    const parts = rawHash.split('&').filter(Boolean);
-    const extra = [];
-    // unknown params to preserve (e.g. cc=TOKEN)
-    let currentView = null;
-    let hasIntent = false;
-    for (const part of parts) {
-        const eq = part.indexOf('=');
-        const key = eq >= 0 ? part.slice(0, eq) : part;
-        const val = eq >= 0 ? part.slice(eq + 1) : '';
-        if (key === 'view') {
-            currentView = decodeURIComponent(val);
-        } else if (knownIntents.has(key)) {
-            hasIntent = true;
-        } else {
-            extra.push(part);    // preserve verbatim
-        }
-    }
-    if (currentView === dsl) {
-        appendScrollLog('url:sync_to:no_change', { hasIntent });
-        if (hasIntent) {
-            // Rebuild without intents, keep view + extras
-            const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
-            const res = setHashURL(newHash);
-            appendScrollLog('url:sync_to:clear_intents', { result: res });
-        }
-        return;
-    }
-    const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
-    appendScrollLog('url:sync_to:write_view', {
-        oldHash: String(location.hash || ''),
-        newHash,
-        dsl
-    });
-    if (newHash !== location.hash) {
-        const res = setHashURL(newHash);
-        appendScrollLog('url:sync_to:setHashURL_result', { result: res });
-    }
-};
-const _jcy1xg = function _test_url_roundtrip(sync_layout_from_url)
-{
-    const d = sync_layout_from_url;
-    if (!d || d.status === 'skipped')
-        return true;
-    if (d.status === 'error')
-        throw new Error(d.error || d.reason || 'sync error');
-    if (d.postURL == null)
-        throw new Error(d.error || 'postURL missing');
-    const normalize = dsl => {
-        if (dsl == null)
-            return dsl;
-        let s = String(dsl);
-        s = s.replace(/S\d+(?=\()/g, 'S100').replace(/R\d+(?=\()/g, 'R100').replace(/C\d+(?=\()/g, 'C100');
-        s = s.replace(/S(?=\()/g, 'S100').replace(/R(?=\()/g, 'R100').replace(/C(?=\()/g, 'C100');
-        return s;
-    };
-    const overlayOpen = (dsl, openTarget) => {
-        if (!openTarget?.moduleTitle)
-            return dsl;
-        const title = String(openTarget.moduleTitle);
-        if (dsl && dsl.includes(title))
-            return dsl;
-        const s = String(dsl ?? '');
-        if (!/S100\(/.test(s)) {
-            return `S100(${ title })`;
-        }
-        return s.replace(/S100\(([^)]*)\)/, (m, inner) => {
-            const trimmed = String(inner || '').trim();
-            const next = trimmed ? `${ trimmed },${ title }` : title;
-            return `S100(${ next })`;
-        });
-    };
-    const preRaw = d.preURL ?? 'S()';
-    const preWithIntent = overlayOpen(normalize(preRaw), d.open);
-    const post = normalize(d.postURL);
-    if (preWithIntent !== post) {
-        throw new Error(`view URL drift: preURL != postURL\n` + `preURL=${ String(preRaw) }\n` + `open=${ d.open?.moduleTitle || '' }\n` + `postURL=${ String(d.postURL) }\n` + `normalizedPreWithIntent=${ String(preWithIntent) }\n` + `normalizedPost=${ String(post) }\n` + `method=${ d.method } status=${ d.status } reason=${ d.reason || '' }`);
-    }
-    return true;
-};
-const _1yxu9kf = function _setHashURL(location,appendScrollLog,history){return(
-function setHashURL(newHash) {
-    const h = String(newHash ?? '');
-    const hash = h.startsWith('#') ? h : `#${ h }`;
-    const url = new URL(location.href);
-    url.hash = hash;
-    const href = url.toString();
-    appendScrollLog('url:setHashURL:attempt', {
-        hash,
-        href
-    });
-    try {
-        history.replaceState(null, '', href);
-        const res = {
-            ok: true,
-            method: 'replaceState',
-            href,
-            hash
-        };
-        appendScrollLog('url:setHashURL:success', res);
-        return res;
-    } catch (e) {
-        const a = document.createElement('a');
-        a.href = href;
-        a.rel = 'noreferrer';
-        a.style.display = 'none';
-        (document.body || document.documentElement).appendChild(a);
-        a.click();
-        a.remove();
-        const res = {
-            ok: false,
-            method: 'synthetic-click',
-            href,
-            hash,
-            error: String(e)
-        };
-        appendScrollLog('url:setHashURL:fallback', res);
-        return res;
-    }
-}
-)};
-const _1zkl8r = function _treeSyncGolden(appendScrollLog,gl){return(
-function treeSyncGoldenFactory(gl) {
-    const isCompCfg = n => n && n.type === 'component';
-    const isContCfg = n => n && (n.type === 'row' || n.type === 'column' || n.type === 'stack');
-    const desiredModuleKey = cfg => isCompCfg(cfg) && (cfg.componentType === 'module' || cfg.componentName === 'module') && cfg.title ? `module:${ cfg.title }` : null;
-    const liveModuleKey = item => {
-        if (!item)
-            return null;
-        if (!(item.isComponent || item.type === 'component'))
-            return null;
-        const t = item.componentType || item.componentName;
-        return t === 'module' && item.title ? `module:${ item.title }` : null;
-    };
-    const cloneCfg = cfg => {
-        const c = JSON.parse(JSON.stringify(cfg));
-        if (c.type === 'component' && (c.componentType === 'module' || c.componentName === 'module')) {
-            c.componentType = 'module';
-            c.componentName = 'module';
-            c.componentState = c.componentState || {};
-        }
-        return c;
-    };
-    function indexLiveModules(stackLive) {
-        const map = new Map();
-        for (const child of stackLive?.contentItems || []) {
-            const k = liveModuleKey(child);
-            if (k)
-                map.set(k, child);
-        }
-        return map;
-    }
-    function setLiveComponentStateCell(liveItem, cell) {
-        if (!liveItem || !cell)
-            return false;
-        let changed = false;
-        liveItem.componentState = liveItem.componentState || {};
-        if (liveItem.componentState.cell !== cell) {
-            liveItem.componentState.cell = cell;
-            changed = true;
-        }
-        const configs = [
-            liveItem.config,
-            liveItem._config,
-            liveItem._state
-        ].filter(Boolean);
-        for (const cfg of configs) {
-            cfg.componentState = cfg.componentState || {};
-            if (cfg.componentState.cell !== cell) {
-                cfg.componentState.cell = cell;
-                changed = true;
-            }
-        }
-        return changed;
-    }
-    function syncStack(stackLive, desiredStackCfg) {
-        appendScrollLog('treeSync:syncStack:enter', {
-            title: stackLive?.parent?.title ?? stackLive?.title ?? null,
-            desiredCount: (desiredStackCfg?.content || []).length,
-            liveCount: (stackLive?.contentItems || []).length
-        });
-        const desiredComps = (desiredStackCfg.content || []).filter(isCompCfg);
-        let liveByKey = indexLiveModules(stackLive);
-        for (let i = 0; i < desiredComps.length; i++) {
-            const d = desiredComps[i];
-            const k = desiredModuleKey(d);
-            if (!k)
-                continue;
-            if (!liveByKey.has(k)) {
-                let before = null;
-                for (let j = i + 1; j < desiredComps.length; j++) {
-                    const k2 = desiredModuleKey(desiredComps[j]);
-                    if (k2 && liveByKey.has(k2)) {
-                        before = liveByKey.get(k2);
-                        break;
-                    }
-                }
-                const idx = before ? (stackLive.contentItems || []).indexOf(before) : (stackLive.contentItems || []).length;
-                appendScrollLog('treeSync:stack:addItem', {
-                    key: k,
-                    title: d?.title ?? null,
-                    idx,
-                    beforeKey: before ? liveModuleKey(before) : null
-                });
-                if (typeof stackLive.addItem !== 'function')
-                    return {
-                        status: 'fallback',
-                        reason: 'stack missing addItem'
-                    };
-                stackLive.addItem(cloneCfg(d), idx);
-                liveByKey = indexLiveModules(stackLive);
-            }
-        }
-        const desiredKeys = new Set(desiredComps.map(desiredModuleKey).filter(Boolean));
-        for (const child of Array.from(stackLive?.contentItems || [])) {
-            const k = liveModuleKey(child);
-            if (k && !desiredKeys.has(k) && typeof child.remove === 'function') {
-                appendScrollLog('treeSync:stack:remove', {
-                    key: k,
-                    title: child?.title ?? null
-                });
-                child.remove();
-            }
-        }
-        const order = desiredComps.map(desiredModuleKey).filter(Boolean);
-        const byKey = indexLiveModules(stackLive);
-        for (let i = 0; i < order.length; i++) {
-            const item = byKey.get(order[i]);
-            if (!item)
-                continue;
-            const curIdx = (stackLive.contentItems || []).indexOf(item);
-            if (curIdx !== i && typeof stackLive.removeChild === 'function' && typeof stackLive.addChild === 'function') {
-                appendScrollLog('treeSync:stack:reorder', {
-                    key: order[i],
-                    from: curIdx,
-                    to: i
-                });
-                stackLive.removeChild(item, true);
-                stackLive.addChild(item, i, false);
-            }
-        }
-        {
-            const byKey2 = indexLiveModules(stackLive);
-            for (const d of desiredComps) {
-                const k = desiredModuleKey(d);
-                const desiredCell = d?.componentState?.cell ?? null;
-                if (!k || !desiredCell)
-                    continue;
-                const liveItem = byKey2.get(k);
-                if (!liveItem)
-                    continue;
-                const changed = setLiveComponentStateCell(liveItem, desiredCell);
-                if (changed) {
-                    appendScrollLog('treeSync:stack:sync_componentState_cell', {
-                        key: k,
-                        title: liveItem?.title ?? null,
-                        cell: desiredCell
-                    });
-                }
-            }
-        }
-        appendScrollLog('treeSync:syncStack:exit', { liveCount: (stackLive?.contentItems || []).length });
-        return { status: 'synced' };
-    }
-    function ensureContainerChild(parentLive, idx, desiredChildCfg) {
-        const liveChild = parentLive?.contentItems?.[idx];
-        if (liveChild && liveChild.type === desiredChildCfg.type)
-            return liveChild;
-        if (liveChild && typeof liveChild.remove === 'function') {
-            appendScrollLog('treeSync:container:remove_child_for_type_mismatch', {
-                idx,
-                liveType: liveChild?.type ?? null,
-                desiredType: desiredChildCfg?.type ?? null
-            });
-            liveChild.remove();
-        }
-        if (typeof parentLive?.addItem !== 'function')
-            return null;
-        appendScrollLog('treeSync:container:addItem', {
-            idx,
-            type: desiredChildCfg?.type ?? null
-        });
-        parentLive.addItem({
-            type: desiredChildCfg.type,
-            content: []
-        }, idx);
-        return parentLive?.contentItems?.[idx] || null;
-    }
-    function isContainerItem(item) {
-        if (!item)
-            return false;
-        if (item.isComponent)
-            return false;
-        return item.type === 'row' || item.type === 'column' || item.type === 'stack';
-    }
-    function syncContainer(containerLive, desiredCfg) {
-        if (!containerLive || !desiredCfg || !Array.isArray(desiredCfg.content))
-            return { status: 'synced' };
-        const desiredChildren = desiredCfg.content.filter(isContCfg);
-        for (let i = 0; i < desiredChildren.length; i++)
-            ensureContainerChild(containerLive, i, desiredChildren[i]);
-        const liveContainers = (containerLive.contentItems || []).filter(isContainerItem);
-        while (liveContainers.length > desiredChildren.length) {
-            const last = (containerLive.contentItems || []).slice().reverse().find(isContainerItem);
-            if (!last)
-                break;
-            appendScrollLog('treeSync:container:remove_extra_container', { type: last?.type ?? null });
-            if (typeof last.remove === 'function')
-                last.remove();
-            liveContainers.pop();
-        }
-        for (let i = 0; i < desiredChildren.length; i++) {
-            const d = desiredChildren[i];
-            const l = containerLive.contentItems?.[i];
-            if (!l)
-                continue;
-            if (l.type !== d.type)
-                return {
-                    status: 'fallback',
-                    reason: `child type mismatch @${ i } live=${ l.type } desired=${ d.type }`
-                };
-            if (d.type === 'stack') {
-                const r = syncStack(l, d);
-                if (r?.status === 'fallback')
-                    return r;
-            } else {
-                const r = syncContainer(l, d);
-                if (r?.status === 'fallback')
-                    return r;
-            }
-        }
-        return { status: 'synced' };
-    }
-    return function treeSync(layout, desiredRootCfg) {
-        appendScrollLog('treeSync:enter', {
-            desiredType: desiredRootCfg?.type ?? null,
-            hasRoot: !!layout?.root
-        });
-        if (!layout?.root || !desiredRootCfg)
-            return { status: 'noop' };
-        const liveTop = layout.root.contentItems?.[0];
-        if (!liveTop)
-            return {
-                status: 'fallback',
-                reason: 'no live top'
-            };
-        if (liveTop.type !== desiredRootCfg.type) {
-            const out = {
-                status: 'fallback',
-                reason: `top type mismatch live=${ liveTop.type } desired=${ desiredRootCfg.type }`
-            };
-            appendScrollLog('treeSync:fallback', out);
-            return out;
-        }
-        const out = desiredRootCfg.type === 'stack' ? syncStack(liveTop, desiredRootCfg) : syncContainer(liveTop, desiredRootCfg);
-        if (out?.status === 'fallback')
-            appendScrollLog('treeSync:fallback', out);
-        else
-            appendScrollLog('treeSync:synced', { status: out?.status ?? 'synced' });
-        return out;
-    };
-}(gl)
-)};
-const _133ahw5 = function _background_jobs(onLoadConfig,layout_state,sync_layout_from_url,test_url_roundtrip,sync_layout_to_url,runtime,navigator_jobs,commandPaletteKeybinding,auto_attach,scroll_fix_sync_layout,commit_history,replay_git,change_listener,cc_chat)
-{
-  onLoadConfig;
-  layout_state;
-  sync_layout_from_url;
-  test_url_roundtrip;
-  sync_layout_to_url;
-  runtime;
-  navigator_jobs;
-  commandPaletteKeybinding;
-  auto_attach;
-  scroll_fix_sync_layout;
-  // history
-  commit_history;
-  replay_git;
-  change_listener;
-  cc_chat;
-};
-const _1n78po6 = function _imports(md){return(
-md`## Imports`
-)};
-const _b2c0kp = function _32(exporter){return(
-exporter()
-)};
-const _1ey5aow = function _dragOutGrips(layout,invalidation)
-{
-    function readModuleSource(name) {
-        const r = window.lopecode?.contentSync?.(name);
-        if (!r || r.status !== 200 || !r.bytes)
-            return null;
-        return new TextDecoder().decode(r.bytes);
-    }
-    function filenameFor(name) {
-        let m = name.match(/^@([A-Za-z0-9-]+)\/([A-Za-z0-9-]+)$/);
-        if (m)
-            return `at_${ m[1] }_${ m[2] }.js`;
-        m = name.match(/^d\/([A-Za-z0-9]+)(@\d+)?$/);
-        if (m)
-            return `d_${ m[1] }${ m[2] ?? '' }.js`;
-        return name.replace(/[/]/g, '_') + '.js';
-    }
-    function flashGrip(grip) {
-        const prev = grip.style.opacity;
-        grip.style.opacity = '1';
-        setTimeout(() => {
-            grip.style.opacity = prev;
-        }, 350);
-    }
-    function hookTab(tabEl) {
-        if (tabEl.__lopepageGripHooked)
-            return;
-        tabEl.__lopepageGripHooked = true;
-        const grip = document.createElement('span');
-        grip.className = 'lm_drag_out_grip';
-        grip.title = 'Click to copy source \xB7 Drag out as .js';
-        grip.setAttribute('draggable', 'true');
-        grip.innerHTML = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="display:block"><rect x="5.5" y="5.5" width="9" height="9" rx="1.5"/><path d="M2.5 10.5V3a.5.5 0 01.5-.5h7.5"/></svg>`;
-        Object.assign(grip.style, {
-            display: 'inline-block',
-            width: '12px',
-            height: '12px',
-            verticalAlign: '3.5px',
-            marginLeft: '-7px',
-            marginRight: '2px',
-            cursor: 'pointer',
-            opacity: '0.55',
-            userSelect: 'none',
-            lineHeight: '0',
-            color: 'currentColor'
-        });
-        [
-            'pointerdown',
-            'mousedown',
-            'touchstart'
-        ].forEach(ev => {
-            grip.addEventListener(ev, e => e.stopPropagation(), { capture: true });
-        });
-        grip.addEventListener('click', e => {
-            e.stopPropagation();
-            const t = tabEl.querySelector('.lm_title')?.textContent || '';
-            if (!t)
-                return;
-            const source = readModuleSource(t);
-            if (!source) {
-                console.warn('[grip click] no source for:', t);
-                return;
-            }
-            navigator.clipboard?.writeText?.(source).then(() => {
-                console.log('[grip click] copied source for:', t, `(${ source.length } chars)`);
-                flashGrip(grip);
-            }).catch(err => console.warn('[grip click] clipboard failed:', err));
-        });
-        grip.addEventListener('dragstart', e => {
-            e.stopPropagation();
-            const title = tabEl.querySelector('.lm_title')?.textContent || '';
-            const source = readModuleSource(title);
-            if (!source) {
-                e.dataTransfer.setData('text/plain', `// no source for ${ title }`);
-                return;
-            }
-            const filename = filenameFor(title);
-            const dataUrl = 'data:text/javascript;base64,' + btoa(unescape(encodeURIComponent(source)));
-            e.dataTransfer.setData('DownloadURL', `text/javascript:${ filename }:${ dataUrl }`);
-            e.dataTransfer.setData('text/plain', source);
-            e.dataTransfer.effectAllowed = 'copyMove';
-        });
-        const titleEl = tabEl.querySelector('.lm_title');
-        if (titleEl?.parentNode === tabEl)
-            tabEl.insertBefore(grip, titleEl);
-        else
-            tabEl.prepend(grip);
-    }
-    document.querySelectorAll('.lm_drag_out_grip').forEach(g => g.remove());
-    document.querySelectorAll('.lm_tab').forEach(t => {
-        t.__lopepageGripHooked = false;
-    });
-    document.querySelectorAll('.lm_tab').forEach(hookTab);
-    const handler = tab => hookTab(tab.element);
-    layout.on('tabCreated', handler);
-    invalidation.then(() => {
-        try {
-            layout.off?.('tabCreated', handler);
-        } catch (e) {
-        }
-    });
-    return 'drag-out grips installed';
-};
-const _1gkn0mq = function _dropInHandler(location, setHashURL, runtime, page, invalidation) {
-    const STYLE_ID = 'lopepage-dropzone-style';
-    const oldStyle = document.getElementById(STYLE_ID);
-    if (oldStyle)
-        oldStyle.remove();
-    const s = document.createElement('style');
-    s.id = STYLE_ID;
-    s.textContent = `.lm_header.lopepage-drop-target { outline: 2px dashed currentColor; outline-offset: -2px; background: color-mix(in srgb, currentColor 14%, transparent); }`;
-    document.head.appendChild(s);
-    function parseModuleName(filename) {
-        let m = filename.match(/^at_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.js$/);
-        if (m)
-            return `@${ m[1] }/${ m[2] }`;
-        m = filename.match(/^d_([A-Za-z0-9]+)(@\d+)?\.js$/);
-        if (m)
-            return `d/${ m[1] }${ m[2] ?? '' }`;
-        return null;
-    }
-    function ensureDomScriptTag(name, source) {
-        let el = document.getElementById(name);
-        if (el?.tagName === 'SCRIPT' && el.getAttribute('type') === 'text/plain') {
-            el.textContent = source;
-            return el;
-        }
-        el = document.createElement('script');
-        el.type = 'text/plain';
-        el.id = name;
-        el.setAttribute('data-mime', 'application/javascript');
-        el.textContent = source;
-        document.body.appendChild(el);
-        return el;
-    }
-    function openModuleInHash(name) {
-        let h = location.hash.replace(/^#/, '');
-        if (/(^|&)open=[^&]*/.test(h)) {
-            h = h.replace(/(^|&)open=[^&]*/, `$1open=${ name }`);
-        } else {
-            h = h + (h ? '&' : '') + `open=${ name }`;
-        }
-        setHashURL(h);
-    }
-    function tearDownExistingModule(name) {
-        const existing = runtime.mains.get(name);
-        if (!existing)
-            return false;
-        try {
-            for (const v of Array.from(existing._scope.values())) {
-                try {
-                    v.delete();
-                } catch (e) {
-                }
-            }
-        } catch (e) {
-            console.warn('[lopepage drop-in] teardown scope:', e);
-        }
-        runtime.mains.delete(name);
-        return true;
-    }
-    async function installFromFile(file) {
-        const name = parseModuleName(file.name);
-        if (!name) {
-            console.warn('[lopepage drop-in] bad filename:', file.name);
-            return;
-        }
-        const src = await file.text();
-        const blob = new Blob([src], { type: 'text/javascript' });
-        const url = URL.createObjectURL(blob);
-        let imported;
-        try {
-            imported = await window.importShim(url, `file://${ name }`);
-        } catch (e) {
-            console.error('[lopepage drop-in] import failed:', e);
-            return;
-        }
-        if (typeof imported.default !== 'function') {
-            console.warn('[lopepage drop-in] default export not a function');
-            return;
-        }
-        const replaced = tearDownExistingModule(name);
-        const mod = runtime.module(imported.default);
-        runtime.mains.set(name, mod);
-        ensureDomScriptTag(name, src);
-        openModuleInHash(name);
-        console.log(`[lopepage drop-in] ${ replaced ? 'replaced' : 'installed' } + opened:`, name);
-    }
-    let activeHeader = null;
-    const clearHighlight = () => {
-        if (activeHeader) {
-            activeHeader.classList.remove('lopepage-drop-target');
-            activeHeader = null;
-        }
-    };
-    const isFilesDrag = e => [...e.dataTransfer?.types || []].includes('Files');
-    const onDragOver = e => {
-        if (!isFilesDrag(e))
-            return;
-        const header = e.target?.closest?.('.lm_header');
-        if (!header) {
-            clearHighlight();
-            return;
-        }
-        e.preventDefault();
-        e.dataTransfer.dropEffect = 'copy';
-        if (activeHeader !== header) {
-            activeHeader?.classList.remove('lopepage-drop-target');
-            header.classList.add('lopepage-drop-target');
-            activeHeader = header;
-        }
-    };
-    const onDragLeave = e => {
-        if (!page.contains(e.relatedTarget))
-            clearHighlight();
-    };
-    const onDrop = e => {
-        if (!isFilesDrag(e))
-            return;
-        const header = e.target?.closest?.('.lm_header');
-        if (!header)
-            return;
-        e.preventDefault();
-        clearHighlight();
-        const f = e.dataTransfer.files[0];
-        if (f)
-            installFromFile(f).catch(err => console.error('[lopepage drop-in] failed:', err));
-    };
-    page.addEventListener('dragover', onDragOver);
-    page.addEventListener('dragleave', onDragLeave);
-    page.addEventListener('drop', onDrop);
-    invalidation.then(() => {
-        page.removeEventListener('dragover', onDragOver);
-        page.removeEventListener('dragleave', onDragLeave);
-        page.removeEventListener('drop', onDrop);
-        clearHighlight();
-        document.getElementById(STYLE_ID)?.remove();
-    });
-    return 'drop-in handler installed';
-};
-const _1v605qi = function _file_attachment_cache(reload)
-{
-    reload;
-    return new Map();
-};
-const _1fgpmzl = function _renderFileAttachment()
-{
-    return function renderFileAttachment(mime, bytes) {
-        const m = String(mime || '').toLowerCase();
-        // HTML: srcdoc keeps the runtime same-origin-ish (opaque) but renders rich content
-        if (m === 'text/html' || m === 'application/xhtml+xml') {
-            const iframe = document.createElement('iframe');
-            iframe.setAttribute('srcdoc', new TextDecoder().decode(bytes));
-            Object.assign(iframe.style, {
-                width: '100%',
-                height: '100%',
-                border: '0',
-                display: 'block'
-            });
-            return iframe;
-        }
-        if (m.startsWith('image/')) {
-            const img = document.createElement('img');
-            img.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(img.style, {
-                maxWidth: '100%',
-                maxHeight: '100%',
-                display: 'block',
-                margin: 'auto'
-            });
-            return img;
-        }
-        if (m.startsWith('audio/')) {
-            const audio = document.createElement('audio');
-            audio.controls = true;
-            audio.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(audio.style, { width: '100%' });
-            return audio;
-        }
-        if (m.startsWith('video/')) {
-            const video = document.createElement('video');
-            video.controls = true;
-            video.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
-            Object.assign(video.style, {
-                width: '100%',
-                height: '100%'
-            });
-            return video;
-        }
-        if (m === 'text/plain' || m === 'text/markdown' || m === 'application/json' || m.startsWith('text/')) {
-            const pre = document.createElement('pre');
-            pre.textContent = new TextDecoder().decode(bytes);
-            Object.assign(pre.style, {
-                margin: '0',
-                padding: '8px',
-                whiteSpace: 'pre-wrap',
-                overflow: 'auto',
-                width: '100%',
-                height: '100%',
-                boxSizing: 'border-box'
-            });
-            return pre;
-        }
-        // application/pdf and unknown: blob: iframe — browser picks the viewer
-        const iframe = document.createElement('iframe');
-        iframe.src = URL.createObjectURL(new Blob([bytes], { type: mime || 'application/octet-stream' }));
-        Object.assign(iframe.style, {
-            width: '100%',
-            height: '100%',
-            border: '0',
-            display: 'block'
-        });
-        return iframe;
-    };
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/golden-layout-2-6-0", async () => runtime.module((await import("/@tomlarkworthy/golden-layout-2-6-0.js?v=4")).default));  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
-  main.define("module @tomlarkworthy/module-selection", async () => runtime.module((await import("/@tomlarkworthy/module-selection.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
-  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
-  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
-  main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
-  $def("_1xyxga0", "page", ["htl","isOnObservableCom","lopeviz_handle_css","base_css","light_theme_css","commandPaletteStyles","commandPaletteOverlay","linkTo"], _1xyxga0);  
-  $def("_1ujnhdh", "append_to_body", ["page"], _1ujnhdh);  
-  $def("_1nv51s8", "testNavigation", ["htl","linkTo"], _1nv51s8);  
-  $def("_ydvyos", "viewof reload", ["Inputs"], _ydvyos);  
-  $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
-  $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
-  $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
-  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
-  $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
-  $def("_lxv2e2", "settings", [], _lxv2e2);  
-  $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
-  $def("_qbghwu", "initial config", ["onLoadConfig","settings"], _qbghwu);  
-  $def("_15lk82w", "mutable config", ["Mutable","initial config"], _15lk82w);  
-  $def("_1bki6eh", "config", ["mutable config"], _1bki6eh);  
-  $def("_14z0bay", "resize", ["Generators","addEventListener","invalidation","removeEventListener"], _14z0bay);  
-  $def("_18jv72h", "layout", ["resize","gl","mutable config","page","modulePanel","blobPanel"], _18jv72h);  
-  $def("_tsjb2x", "layout_state", ["appendScrollLog","layout","gl","mutable config"], _tsjb2x);  
-  $def("_11nrwvj", "viewof lopepageModule", ["thisModule"], _11nrwvj);  
-  $def("_r97569", "lopepageModule", ["Generators","viewof lopepageModule"], _r97569);  
-  $def("_1sp5wo4", null, ["md"], _1sp5wo4);  
-  $def("_1ts23ma", "viewof scrollDebug", ["Inputs"], _1ts23ma);  
-  $def("_7jxivy", "scrollDebug", ["Generators","viewof scrollDebug"], _7jxivy);  
-  $def("_1f2wuqm", "appendScrollLog", ["viewof scrollDebug","mutable scrollLog"], _1f2wuqm);  
-  $def("_1nbnzwx", "initial scrollLog", ["scrollDebug"], _1nbnzwx);  
-  $def("_1f7xtz1", "mutable scrollLog", ["Mutable","initial scrollLog"], _1f7xtz1);  
-  $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
-  $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
-  $def("_tb217h", "scroll_cache", [], _tb217h);  
-  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
-  $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
-  $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
-  $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  
-  $def("_1l50a0d", "sync_layout_to_url", ["appendScrollLog","sync_layout_from_url","config","test_url_roundtrip","serializeGoldenDSL","location","setHashURL"], _1l50a0d);  
-  $def("_jcy1xg", "test_url_roundtrip", ["sync_layout_from_url"], _jcy1xg);  
-  $def("_1yxu9kf", "setHashURL", ["location","appendScrollLog","history"], _1yxu9kf);  
-  $def("_1zkl8r", "treeSyncGolden", ["appendScrollLog","gl"], _1zkl8r);  
-  $def("_133ahw5", "background_jobs", ["onLoadConfig","layout_state","sync_layout_from_url","test_url_roundtrip","sync_layout_to_url","runtime","navigator_jobs","commandPaletteKeybinding","auto_attach","scroll_fix_sync_layout","commit_history","replay_git","change_listener","cc_chat"], _133ahw5);  
-  $def("_1n78po6", "imports", ["md"], _1n78po6);  
-  $def("_b2c0kp", null, ["exporter"], _b2c0kp);  
-  $def("_1ey5aow", "dragOutGrips", ["layout","invalidation"], _1ey5aow);  
-  $def("_1gkn0mq", "dropInHandler", ["location","setHashURL","runtime","page","invalidation"], _1gkn0mq);  
-  main.define("gl", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("gl", _));  
-  main.define("base_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("base_css", _));  
-  main.define("light_theme_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("light_theme_css", _));  
-  main.define("unorderedSync", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("unorderedSync", _));  
-  main.define("runtime", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
-  main.define("Inspector", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("Inspector", _));  
-  main.define("lopeviz_handle_css", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("lopeviz_handle_css", _));  
-  main.define("viewof notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof notebookModule", _));  
-  main.define("notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("notebookModule", _));  
-  main.define("currentModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("currentModules", _));  
-  main.define("viewof selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof selected_modules", _));  
-  main.define("selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("selected_modules", _));  
-  main.define("navigator_jobs", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("navigator_jobs", _));  
-  main.define("serializeGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("serializeGoldenDSL", _));  
-  main.define("parseGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("parseGoldenDSL", _));  
-  main.define("linkTo", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("persistedAttachments", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("persistedAttachments", _));  
-  main.define("getHashModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("getHashModules", _));  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("getPromiseState", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getPromiseState", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
-  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
-  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
-  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
-  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
-  main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
-  main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
-  main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
-  main.define("commandPaletteStyles", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteStyles", _));  
-  main.define("commandPaletteKeybinding", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteKeybinding", _));  
-  main.define("commandPaletteOverlay", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteOverlay", _));  
-  $def("_1v605qi", "file_attachment_cache", ["reload"], _1v605qi);  
-  $def("_1fgpmzl", "renderFileAttachment", [], _1fgpmzl);
   return main;
 }</script>
 
@@ -17560,35 +18436,33 @@ module -> {
 }
 \`\`\``
 )};
-const _1798myt = function _moduleMap(runtime,keepalive,myModule,$0){return(
-async (
-  _runtime = runtime,
-  {
-    cache = new Map() // module -> {name}
-  } = {}
-) => {
-  if (!_runtime || !_runtime._variables)
-    throw "Invalid runtime passed to moduleMap";
-  keepalive(myModule, "submit_summary");
-  keepalive(myModule, "sync_modules");
-  keepalive(myModule, "currentModules");
-  return await $0.send({
-    runtime: _runtime,
-    cache: cache
-  });
-}
-)};
+const _1hn3uql = function _moduleMap(runtime,keepalive,myModule,$0)
+{
+  return async (_runtime = runtime, {
+    cache = new Map()  // module -> {name}
+  } = {}) => {
+    if (!_runtime || !_runtime._variables)
+      throw 'Invalid runtime passed to moduleMap';
+    keepalive(myModule, 'submit_summary');
+    keepalive(myModule, 'sync_modules');
+    keepalive(myModule, 'currentModules');
+    return await $0.send({
+      runtime: _runtime,
+      cache: cache
+    });
+  };
+};
 const _1yso65r = function _5(md){return(
 md`### \`currentModules\``
 )};
-const _1fcoh6x = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
+const _1e3kr85 = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
 {
   runtime_variables;
   const latest = await moduleMap();
   let dirty = !this || !_.isEqual(new Set(latest.keys()), new Set(this.keys()));
   if (dirty) {
     $0.value = latest;
-    $0.dispatchEvent(new Event("input"));
+    $0.dispatchEvent(new Event('input'));
   }
   return $0.value;
 };
@@ -17596,261 +18470,260 @@ const _wi39n0 = async function _currentModules(Inputs,moduleMap){return(
 Inputs.input(await moduleMap())
 )};
 const _1gxgyd6 = (G, _) => G.input(_);
-const _1qag34d = function _8(Inputs,currentModules){return(
+const _1kxoygl = function _8(Inputs,currentModules){return(
 Inputs.table([...currentModules.values()], {
   format: {
-    dom: (d) => d.innerHTML,
+    dom: d => d.innerHTML,
     specifiers: JSON.stringify,
-    variable: (v) => v._name
+    variable: v => v._name
   }
 })
 )};
 const _1xamz8j = function _9(md){return(
 md`### Visualization`
 )};
-const _1n4p4hn = function _tipTitle(){return(
-([k, c]) => 
-`${k}\ndependsOn: [\n  ${(c[3].dependsOn || []).join(
-  "\n  "
-)}\n]\ndependedBy: [\n  ${(c[3].dependedBy || []).join("\n  ")}\n]`
+const _1sglrv3 = function _tipTitle(){return(
+([k, c]) => `${ k }\ndependsOn: [\n  ${ (c[3].dependsOn || []).join('\n  ') }\n]\ndependedBy: [\n  ${ (c[3].dependedBy || []).join('\n  ') }\n]`
 )};
-const _1kdcb71 = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom)
-{
-  return ({ useSpectral = true } = {}) => {
-    const modules = [...currentModules.values()].filter((m) => m && m.name);
-    const n = modules.length;
-    if (n === 0) return htl.svg`<svg width="1" height="1"></svg>`;
-
-    const indexOf = new Map(modules.map((m, i) => [m.name, i]));
-
-    const undirectedEdges = [];
-    const seen = new Set();
+const _5zbe1k = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom){return(
+({
+  useSpectral = true
+} = {}) => {
+  const modules = [...currentModules.values()].filter(m => m && m.name);
+  const n = modules.length;
+  if (n === 0)
+    return htl.svg`<svg width="1" height="1"></svg>`;
+  const indexOf = new Map(modules.map((m, i) => [
+    m.name,
+    i
+  ]));
+  const undirectedEdges = [];
+  const seen = new Set();
+  for (let i = 0; i < n; i++) {
+    const from = modules[i];
+    for (const toName of from.dependsOn || []) {
+      const j = indexOf.get(toName);
+      if (j == null || j === i)
+        continue;
+      const a = Math.min(i, j), b = Math.max(i, j);
+      const k = `${ a },${ b }`;
+      if (seen.has(k))
+        continue;
+      seen.add(k);
+      undirectedEdges.push([
+        a,
+        b
+      ]);
+    }
+  }
+  const buildCSRLocal = (n, edges) => {
+    const adj = Array.from({ length: n }, () => []);
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      if (a < 0 || b < 0 || a >= n || b >= n)
+        continue;
+      adj[a].push(b);
+      adj[b].push(a);
+    }
+    const deg = new Float64Array(n);
+    let nnz = 0;
     for (let i = 0; i < n; i++) {
-      const from = modules[i];
-      for (const toName of from.dependsOn || []) {
-        const j = indexOf.get(toName);
-        if (j == null || j === i) continue;
-        const a = Math.min(i, j),
-          b = Math.max(i, j);
-        const k = `${a},${b}`;
-        if (seen.has(k)) continue;
-        seen.add(k);
-        undirectedEdges.push([a, b]);
+      const row = adj[i];
+      row.sort((x, y) => x - y);
+      let w = 0;
+      for (let j = 0; j < row.length; j++)
+        if (w === 0 || row[j] !== row[w - 1])
+          row[w++] = row[j];
+      row.length = w;
+      deg[i] = w;
+      nnz += w;
+    }
+    const rowPtr = new Int32Array(n + 1);
+    const colIdx = new Int32Array(nnz);
+    const val = new Float64Array(nnz);
+    let p = 0;
+    for (let i = 0; i < n; i++) {
+      rowPtr[i] = p;
+      const row = adj[i];
+      for (let j = 0; j < row.length; j++) {
+        colIdx[p] = row[j];
+        val[p] = 1;
+        p++;
       }
     }
-
-    const buildCSRLocal = (n, edges) => {
-      const adj = Array.from({ length: n }, () => []);
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        if (a < 0 || b < 0 || a >= n || b >= n) continue;
-        adj[a].push(b);
-        adj[b].push(a);
-      }
-      const deg = new Float64Array(n);
-      let nnz = 0;
-      for (let i = 0; i < n; i++) {
-        const row = adj[i];
-        row.sort((x, y) => x - y);
-        let w = 0;
-        for (let j = 0; j < row.length; j++)
-          if (w === 0 || row[j] !== row[w - 1]) row[w++] = row[j];
-        row.length = w;
-        deg[i] = w;
-        nnz += w;
-      }
-      const rowPtr = new Int32Array(n + 1);
-      const colIdx = new Int32Array(nnz);
-      const val = new Float64Array(nnz);
-      let p = 0;
-      for (let i = 0; i < n; i++) {
-        rowPtr[i] = p;
-        const row = adj[i];
-        for (let j = 0; j < row.length; j++) {
-          colIdx[p] = row[j];
-          val[p] = 1;
-          p++;
-        }
-      }
-      rowPtr[n] = p;
-      return { n, rowPtr, colIdx, val, deg };
+    rowPtr[n] = p;
+    return {
+      n,
+      rowPtr,
+      colIdx,
+      val,
+      deg
     };
-
-    const crossingsCountLocal = (n, edges, order) => {
-      const pos = new Int32Array(n);
-      for (let i = 0; i < n; i++) pos[order[i]] = i;
-
-      const intervals = [];
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        const i = pos[a],
-          j = pos[b];
-        const s = Math.min(i, j),
-          t = Math.max(i, j);
-        if (s === t) continue;
-        intervals.push([s, t]);
-      }
-
-      intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
-      const bit = new Int32Array(n + 1);
-      const add = (i) => {
-        for (let x = i + 1; x <= n; x += x & -x) bit[x]++;
-      };
-      const sum = (i) => {
-        let s = 0;
-        for (let x = i + 1; x > 0; x -= x & -x) s += bit[x];
-        return s;
-      };
-      const range = (l, r) => (r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0));
-
-      let crossings = 0;
-      let k = 0;
-      while (k < intervals.length) {
-        const s = intervals[k][0];
-        let k2 = k;
-        while (k2 < intervals.length && intervals[k2][0] === s) k2++;
-        for (let t = k; t < k2; t++)
-          crossings += range(s + 1, intervals[t][1] - 1);
-        for (let t = k; t < k2; t++) add(intervals[t][1]);
-        k = k2;
-      }
-      return crossings;
+  };
+  const crossingsCountLocal = (n, edges, order) => {
+    const pos = new Int32Array(n);
+    for (let i = 0; i < n; i++)
+      pos[order[i]] = i;
+    const intervals = [];
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      const i = pos[a], j = pos[b];
+      const s = Math.min(i, j), t = Math.max(i, j);
+      if (s === t)
+        continue;
+      intervals.push([
+        s,
+        t
+      ]);
+    }
+    intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
+    const bit = new Int32Array(n + 1);
+    const add = i => {
+      for (let x = i + 1; x <= n; x += x & -x)
+        bit[x]++;
     };
-
-    let orderIdx;
-    if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
-      orderIdx = Int32Array.from(d3.range(n));
-    } else {
-      const csr = buildCSRLocal(n, undirectedEdges);
-
-      const spectral = spectralCircleOrder(csr, {
-        alpha: 0.92,
-        maxIters: 80,
-        tol: 1e-4,
-        seed: 1,
-        passesOrtho: 1
-      });
-
-      const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
-        passes: 1,
-        vertexSequence: "order"
-      });
-
-      const baseline = bestOfRandomOrders(n, undirectedEdges, {
-        R: Math.min(n, 12),
-        seed: 1,
-        postSiftPasses: 0
-      });
-
-      const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
-      orderIdx =
-        baseline?.order && baseline.crossings < cSift
-          ? baseline.order
-          : sifted.order;
+    const sum = i => {
+      let s = 0;
+      for (let x = i + 1; x > 0; x -= x & -x)
+        s += bit[x];
+      return s;
+    };
+    const range = (l, r) => r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0);
+    let crossings = 0;
+    let k = 0;
+    while (k < intervals.length) {
+      const s = intervals[k][0];
+      let k2 = k;
+      while (k2 < intervals.length && intervals[k2][0] === s)
+        k2++;
+      for (let t = k; t < k2; t++)
+        crossings += range(s + 1, intervals[t][1] - 1);
+      for (let t = k; t < k2; t++)
+        add(intervals[t][1]);
+      k = k2;
     }
-
-    const R = 100;
-    const nodes = new Map();
-    for (let p = 0; p < n; p++) {
-      const vid = orderIdx[p] | 0;
-      const a = (p * 2 * Math.PI) / n;
-      const [x, y] = d3.pointRadial(a, R);
-      const deg = (p * 360) / n;
-      nodes.set(modules[vid].name, [x, y, deg, modules[vid]]);
-    }
-
-    const edges = modules.flatMap((from) =>
-      (from.dependsOn || [])
-        .filter((to) => nodes.has(to))
-        .map((to) => [
-          [from.name, nodes.get(from.name)],
-          [to, nodes.get(to)]
-        ])
-    );
-
-    const plot = Plot.plot({
-      inset: 180,
-      aspectRatio: 1,
-      axis: null,
-      marks: [
-        () => htl.svg`<defs>
+    return crossings;
+  };
+  let orderIdx;
+  if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
+    orderIdx = Int32Array.from(d3.range(n));
+  } else {
+    const csr = buildCSRLocal(n, undirectedEdges);
+    const spectral = spectralCircleOrder(csr, {
+      alpha: 0.92,
+      maxIters: 80,
+      tol: 0.0001,
+      seed: 1,
+      passesOrtho: 1
+    });
+    const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
+      passes: 1,
+      vertexSequence: 'order'
+    });
+    const baseline = bestOfRandomOrders(n, undirectedEdges, {
+      R: Math.min(n, 12),
+      seed: 1,
+      postSiftPasses: 0
+    });
+    const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
+    orderIdx = baseline?.order && baseline.crossings < cSift ? baseline.order : sifted.order;
+  }
+  const R = 100;
+  const nodes = new Map();
+  for (let p = 0; p < n; p++) {
+    const vid = orderIdx[p] | 0;
+    const a = p * 2 * Math.PI / n;
+    const [x, y] = d3.pointRadial(a, R);
+    const deg = p * 360 / n;
+    nodes.set(modules[vid].name, [
+      x,
+      y,
+      deg,
+      modules[vid]
+    ]);
+  }
+  const edges = modules.flatMap(from => (from.dependsOn || []).filter(to => nodes.has(to)).map(to => [
+    [
+      from.name,
+      nodes.get(from.name)
+    ],
+    [
+      to,
+      nodes.get(to)
+    ]
+  ]));
+  const plot = Plot.plot({
+    inset: 180,
+    aspectRatio: 1,
+    axis: null,
+    marks: [
+      () => htl.svg`<defs>
           <linearGradient id="gradient">
             <stop offset="15%" stop-color="red" />
             <stop offset="100%" stop-color="gold" />
           </linearGradient>
         </defs>`,
-        Plot.arrow(edges, {
-          x1: ([[, [x1]]]) => x1,
-          y1: ([[, [, y1]]]) => y1,
-          x2: ([, [, [x2]]]) => x2,
-          y2: ([, [, [, y2]]]) => y2,
-          bend: true,
-          stroke: "url(#gradient)",
-          strokeOpacity: 0.5,
-          strokeLinejoin: "miter",
-          headLength: 3,
-          inset: 5
-        }),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] > 180),
-          {
-            textAnchor: "end",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] <= 180),
-          {
-            fontSize: 12,
-            textAnchor: "start",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.tip(
-          nodes.entries(),
-          Plot.pointer({
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            title: tipTitle,
-            maxRadius: Infinity
-          })
-        )
-      ]
-    });
-
-    const xmlns = "http://www.w3.org/2000/svg";
-    const xlink = "http://www.w3.org/1999/xlink";
-    for (const text of plot.querySelectorAll("text")) {
-      const moduleName = text.textContent;
-      let url;
-      try {
-        url = linkTo(moduleName);
-      } catch {
-        continue;
-      }
-      const a = document.createElementNS(xmlns, "a");
-      a.setAttributeNS(null, "href", url);
-      a.setAttributeNS(xlink, "href", url);
-      text.parentNode.insertBefore(a, text);
-      if (isOnObservableCom()) {
-        a.setAttribute("target", "_blank");
-      }
-      a.appendChild(text);
+      Plot.arrow(edges, {
+        x1: ([[, [x1]]]) => x1,
+        y1: ([[, [, y1]]]) => y1,
+        x2: ([, [, [x2]]]) => x2,
+        y2: ([, [, [, y2]]]) => y2,
+        bend: true,
+        stroke: 'url(#gradient)',
+        strokeOpacity: 0.5,
+        strokeLinejoin: 'miter',
+        headLength: 3,
+        inset: 5
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] > 180), {
+        textAnchor: 'end',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] <= 180), {
+        fontSize: 12,
+        textAnchor: 'start',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.tip(nodes.entries(), Plot.pointer({
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        title: tipTitle,
+        maxRadius: Infinity
+      }))
+    ]
+  });
+  const xmlns = 'http://www.w3.org/2000/svg';
+  const xlink = 'http://www.w3.org/1999/xlink';
+  for (const text of plot.querySelectorAll('text')) {
+    const moduleName = text.textContent;
+    let url;
+    try {
+      url = linkTo(moduleName);
+    } catch {
+      continue;
     }
-
-    return plot;
-  };
-};
+    const a = document.createElementNS(xmlns, 'a');
+    a.setAttributeNS(null, 'href', url);
+    a.setAttributeNS(xlink, 'href', url);
+    text.parentNode.insertBefore(a, text);
+    if (isOnObservableCom()) {
+      a.setAttribute('target', '_blank');
+    }
+    a.appendChild(text);
+  }
+  return plot;
+}
+)};
 const _hgwvol = function _12(md){return(
 md`### Random helpers`
 )};
@@ -17861,88 +18734,85 @@ const _1cir47e = (G, _) => G.input(_);
 const _1nfaybn = function _tag(){return(
 Symbol()
 )};
-const _17qqkoj = function _forcePeek()
+const _1lkbrun = function _forcePeek()
 {
   //console.log("force peek");
-  return (variable, { forever = false } = {}) => {
-    if (variable._value) return variable._value;
+  return (variable, {
+    forever = false
+  } = {}) => {
+    if (variable._value)
+      return variable._value;
     let peeker;
     const promise = new Promise((fulfilled, rejected) => {
-      peeker = variable._module
-        .variable({
-          fulfilled,
-          rejected
-        })
-        .define([variable._name], (m) => m);
+      peeker = variable._module.variable({
+        fulfilled,
+        rejected
+      }).define([variable._name], m => m);
     });
-    if (!forever) promise.finally((v) => peeker.delete());
-    return Promise.race([promise, new Promise((_, r) => setTimeout(r, 1000))]);
+    if (!forever)
+      promise.finally(v => peeker.delete());
+    return Promise.race([
+      promise,
+      new Promise((_, r) => setTimeout(r, 1000))
+    ]);
   };
 };
-const _v9hg2i = function _observe(){return(
+const _1qva85d = function _observe(){return(
 (module, variable_name, observer) => {
-  const variable = module
-    .variable(observer)
-    .define(`dynamic observe ${variable_name}`, [variable_name], (m) => m);
+  const variable = module.variable(observer).define(`dynamic observe ${ variable_name }`, [variable_name], m => m);
   return () => variable.delete();
 }
 )};
 const _1bm642i = function _17(md){return(
 md`### Implementation`
 )};
-const _oothhq = function _queue(flowQueue){return(
-flowQueue({ timeout_ms: 15000, dedupe: true })
+const _1f31b1g = function _queue(flowQueue){return(
+flowQueue({
+  timeout_ms: 15000,
+  dedupe: true
+})
 )};
 const _648shl = (G, _) => G.input(_);
 const _1acbzli = function _19(md){return(
 md`We resolve what we can using variables named with prefix \`module\` that hold module values. We \`forcePeek\` the variables to make them resolve, which forces loading of the modules.`
 )};
-const _10dhunq = async function _module_definition_variables(notebookImports,queue)
+const _1g0cuj1 = async function _module_definition_variables(notebookImports,queue)
 {
-  console.log("module_definition_variables");
+  console.log('module_definition_variables');
   notebookImports;
   queue;
   let last_module_count = -1;
   let module_definition_variables = [];
   while (last_module_count < module_definition_variables.length) {
     last_module_count = module_definition_variables.length;
-    module_definition_variables = (
-      await Promise.all(
-        [...queue.runtime._variables]
-          .filter((v) => v._name && v._name.startsWith("module "))
-          .filter((v) => !v._name.startsWith("module <unknown"))
-          .map(async (v) => {
-            try {
-              v._value = await Promise.race([
-                v._definition(),
-                new Promise((_, reject) =>
-                  setTimeout(() => reject(new Error("timeout")), 1000)
-                )
-              ]);
-              return [v];
-            } catch (err) {
-              console.error("error loading module", v._name, err);
-              return [];
-            }
-          })
-      )
-    ).flat();
+    module_definition_variables = (await Promise.all([...queue.runtime._variables].filter(v => v._name && v._name.startsWith('module ')).filter(v => !v._name.startsWith('module <unknown')).map(async v => {
+      try {
+        v._value = await Promise.race([
+          v._definition(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1000))
+        ]);
+        return [v];
+      } catch (err) {
+        console.error('error loading module', v._name, err);
+        return [];
+      }
+    }))).flat();
   }
   return module_definition_variables;
 };
-const _dcxoxy = function _modules(module_definition_variables,queue)
+const _17frsyf = function _modules(module_definition_variables,queue)
 {
-  console.log("modules");
+  console.log('modules');
   module_definition_variables;
-  return [...new Set([...queue.runtime._variables].map((v) => v._module))];
+  return [...new Set([...queue.runtime._variables].map(v => v._module))];
 };
 const _1dqpbvy = function _builtin(queue){return(
 queue.runtime._builtin
 )};
-const _ir3ob0 = function _main_modules(queue,modules,builtin)
+const _13mmmk9 = function _main_modules(queue,modules,builtin)
 {
   const imports = new Set(queue.runtime._modules.values());
-  return modules.filter((m) => !imports.has(m) && m !== builtin);
+  return modules.filter(m => !imports.has(m) && m !== builtin);
 };
 const _yflsv5 = function _bootloaded_mains(queue){return(
 queue.runtime.mains || new Map()
@@ -17950,16 +18820,16 @@ queue.runtime.mains || new Map()
 const _ox2g3b = function _bootloader(queue){return(
 queue.runtime.bootloader
 )};
-const _1turw8j = function _resolve_modules(modules,module_definition_variables,findModuleName)
+const _10ufqkh = function _resolve_modules(modules,module_definition_variables,findModuleName)
 {
-  console.log("resolve_modules");
+  console.log('resolve_modules');
   const module_definitions = new Map();
   const unresolved = [];
-  modules.forEach((m) => {
-    const md = module_definition_variables.find((md) => md._value == m);
+  modules.forEach(m => {
+    const md = module_definition_variables.find(md => md._value == m);
     if (md) {
       module_definitions.set(m, {
-        type: "module variable",
+        type: 'module variable',
         name: findModuleName(md._module._scope, m),
         variable: md
       });
@@ -17967,239 +18837,218 @@ const _1turw8j = function _resolve_modules(modules,module_definition_variables,f
       unresolved.push(m);
     }
   });
-  return { module_definitions, unresolved };
+  return {
+    module_definitions,
+    unresolved
+  };
 };
 const _9fbvam = function _27(md){return(
 md`modules imported via notebook imports do not have module variables, so they are trickier to figure out. We can sniff the page DOM to find the import expressions, and try to map them to the modules we could to resolve earlier`
 )};
-const _1h0lryb = function _notebookImports(main,parser)
+const _1t4ga3d = function _notebookImports(main,parser)
 {
-  console.log("notebookImports");
+  console.log('notebookImports');
   main;
-  return new Map(
-    [...document.querySelectorAll(".observablehq--import")]
-      .map((dom) => [dom, parser.parseCell(dom.textContent)])
-      .map(([dom, node]) => [
-        dom.parentElement,
-        node.body.specifiers.map((s) => ({
-          name: node.body.source.value,
-          dom: dom.parentElement,
-          ast: s,
-          local: s.local.name,
-          imported: s.imported.name
-        }))
-      ])
-  );
+  return new Map([...document.querySelectorAll('.observablehq--import')].map(dom => [
+    dom,
+    parser.parseCell(dom.textContent)
+  ]).map(([dom, node]) => [
+    dom.parentElement,
+    node.body.specifiers.map(s => ({
+      name: node.body.source.value,
+      dom: dom.parentElement,
+      ast: s,
+      local: s.local.name,
+      imported: s.imported.name
+    }))
+  ]));
 };
-const _7t198q = function _notebookImportVariables(runtime,notebookImports)
+const _994hn4 = function _notebookImportVariables(runtime,notebookImports)
 {
-  console.log("notebookImportVariables");
+  console.log('notebookImportVariables');
   return [
-    ...[...runtime._variables] // Observable DOM nodes are referenced in runtime variables
-      .filter(
-        (v) =>
-          v._observer &&
-          v._observer._node &&
-          notebookImports.get(v._observer._node)
-      )
-      .map((v) => ({
-        variable: v,
-        notebookImports: notebookImports.get(v._observer._node)
-      })),
-    ...[
-      ...[...notebookImports.entries()] // visualizer DOM nodes have the variable attached
-        .filter(([pi, vars]) => pi.variable)
-        .map(([pi, vars]) => ({
-          variable: pi.variable,
-          notebookImports: vars
-        }))
-    ]
-  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length); // sort by complexity
+    ...[...runtime._variables]  // Observable DOM nodes are referenced in runtime variables
+.filter(v => v._observer && v._observer._node && notebookImports.get(v._observer._node)).map(v => ({
+      variable: v,
+      notebookImports: notebookImports.get(v._observer._node)
+    })),
+    ...[...[...notebookImports.entries()]  // visualizer DOM nodes have the variable attached
+.filter(([pi, vars]) => pi.variable).map(([pi, vars]) => ({
+        variable: pi.variable,
+        notebookImports: vars
+      }))]
+  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length);  // sort by complexity
 };
-const _1lyens8 = function _pageImportMatch(){return(
-async (notebookImportVariables, modules) => {
-  console.log("pageImportMatch");
-  const backupHas = Map.prototype.has; // Save the original `has` method on Map.prototype
-
-  let currentImport = undefined;
-  const matches = new Map();
-  // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
-  Map.prototype.has = function (...args) {
-    const module = modules.find((m) => m._scope == this);
-    if (currentImport && module) {
-      matches.set(module, {
-        name: currentImport.notebookImports[0].name,
-        type: "notebook import",
-        module: module,
-        dependsOn: [],
-        dependedBy: [],
-        dom: currentImport.notebookImports[0].dom,
-        specifiers: currentImport.notebookImports.map((pi) => ({
-          local: pi.local,
-          imported: pi.imported,
-          variable: pi.variable
-        }))
-      });
-    }
-    return backupHas.call(this, ...args); // Call the original `has` method
-  };
-
-  // Iterate through the notebook imports and define them while capturing `has` calls
-
-  await notebookImportVariables.reduce((chain, pageImportVariable) => {
-    // Call the definition chain
-    return chain.then(async () => {
-      currentImport = pageImportVariable;
-      try {
-        await pageImportVariable.variable._definition();
-      } catch (err) {
-        console.warn(err);
-      }
-      currentImport = undefined;
-    });
-  }, Promise.resolve());
-
-  // Restore the original `has` method after the operations are done
-  Map.prototype.has = backupHas;
-
-  return matches;
-}
-)};
-const _1akt4kz = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+const _xanizk = function _pageImportMatch()
 {
-  console.log("notebookImportMatches");
+  return async (notebookImportVariables, modules) => {
+    console.log('pageImportMatch');
+    const backupHas = Map.prototype.has;
+    // Save the original `has` method on Map.prototype
+    let currentImport = undefined;
+    const matches = new Map();
+    // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
+    Map.prototype.has = function (...args) {
+      const module = modules.find(m => m._scope == this);
+      if (currentImport && module) {
+        matches.set(module, {
+          name: currentImport.notebookImports[0].name,
+          type: 'notebook import',
+          module: module,
+          dependsOn: [],
+          dependedBy: [],
+          dom: currentImport.notebookImports[0].dom,
+          specifiers: currentImport.notebookImports.map(pi => ({
+            local: pi.local,
+            imported: pi.imported,
+            variable: pi.variable
+          }))
+        });
+      }
+      return backupHas.call(this, ...args);  // Call the original `has` method
+    };
+    // Iterate through the notebook imports and define them while capturing `has` calls
+    await notebookImportVariables.reduce((chain, pageImportVariable) => {
+      // Call the definition chain
+      return chain.then(async () => {
+        currentImport = pageImportVariable;
+        try {
+          await pageImportVariable.variable._definition();
+        } catch (err) {
+          console.warn(err);
+        }
+        currentImport = undefined;
+      });
+    }, Promise.resolve());
+    // Restore the original `has` method after the operations are done
+    Map.prototype.has = backupHas;
+    return matches;
+  };
+};
+const _1q5pc6n = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+{
+  console.log('notebookImportMatches');
   return pageImportMatch(notebookImportVariables, modules);
 };
-const _1ang0sg = function _moduleTitle(observeVariable){return(
-async function moduleTitle(module) {
-  const runtime = module._runtime;
-  const vars = [...runtime._variables].filter(
-    (v) => v && v._module === module && v._definition
-  );
-  const candidates = vars.filter((v) => {
-    const n = v._name;
-    if (v._type != 1) return false;
-    if (n == null) return true;
-    if (typeof n !== "string") return true;
-    if (n.startsWith("dynamic observe ")) return false;
-    if (n.startsWith("module ")) return false;
-    return true;
-  });
-
-  if (candidates.length === 0) return null;
-
-  const first = candidates.find(
-    (v) => typeof v._id === "number" && Number.isFinite(v._id)
-  )
-    ? candidates.reduce((a, b) =>
-        (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b
-      )
-    : candidates[0];
-
-  const extract = (v) => {
-    // instanceof cannot be used hear for cross realm
-    if (v == null) return null;
-    if (typeof v === "string") return v.trim() || null;
-    if (v.tagName) {
-      if (v.tagName == "H1") return v.textContent;
-      const h1 = v.querySelector?.("h1");
-      if (h1) return (h1.textContent ?? "").trim() || null;
+const _12o3fj5 = function _moduleTitle(observeVariable)
+{
+  return async function moduleTitle(module) {
+    const runtime = module._runtime;
+    const vars = [...runtime._variables].filter(v => v && v._module === module && v._definition);
+    const candidates = vars.filter(v => {
+      const n = v._name;
+      if (v._type != 1)
+        return false;
+      if (n == null)
+        return true;
+      if (typeof n !== 'string')
+        return true;
+      if (n.startsWith('dynamic observe '))
+        return false;
+      if (n.startsWith('module '))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0)
       return null;
-    }
-    if (v.textContent) return (v.textContent ?? "").trim() || null;
-    const maybeNode = v?.nodeType ? v : null;
-    if (maybeNode?.tagName) return extract(maybeNode);
-    return null;
-  };
-
-  // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
-  // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
-  // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
-  // base_css <style>) out of the live page, breaking the frame. Instead:
-  //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
-  //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
-  //     existing variable reachable and replays its value, adding no intermediate variable (no
-  //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
-  //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
-  if (first._value !== undefined) return extract(first._value);
-  const peekValue = (v) =>
-    new Promise((resolve, reject) => {
+    const first = candidates.find(v => typeof v._id === 'number' && Number.isFinite(v._id)) ? candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b) : candidates[0];
+    const extract = v => {
+      // instanceof cannot be used hear for cross realm
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      const maybeNode = v?.nodeType ? v : null;
+      if (maybeNode?.tagName)
+        return extract(maybeNode);
+      return null;
+    };
+    // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
+    // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
+    // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
+    // base_css <style>) out of the live page, breaking the frame. Instead:
+    //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
+    //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
+    //     existing variable reachable and replays its value, adding no intermediate variable (no
+    //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
+    //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
+    if (first._value !== undefined)
+      return extract(first._value);
+    const peekValue = v => new Promise((resolve, reject) => {
       let settled = false;
       let fireInvalidation;
-      const invalidation = new Promise((r) => (fireInvalidation = r));
+      const invalidation = new Promise(r => fireInvalidation = r);
       const finish = (fn, arg) => {
-        if (settled) return;
+        if (settled)
+          return;
         settled = true;
         fireInvalidation();
         fn(arg);
       };
-      observeVariable(
-        v,
-        {
-          fulfilled: (value) => finish(resolve, value),
-          rejected: (err) => finish(reject, err),
-          pending: () => {}
-        },
-        { invalidation }
-      );
+      observeVariable(v, {
+        fulfilled: value => finish(resolve, value),
+        rejected: err => finish(reject, err),
+        pending: () => {
+        }
+      }, { invalidation });
     });
-  try {
-    return extract(await peekValue(first));
-  } catch (err) {
-    return "Err";
-  }
-}
-)};
-const _197sgjt = async function _titles(modules,moduleTitle)
+    try {
+      return extract(await peekValue(first));
+    } catch (err) {
+      return 'Err';
+    }
+  };
+};
+const _ze3jk0 = async function _titles(modules,moduleTitle)
 {
-  const map = new Map(
-    await Promise.all(
-      [...modules].map(async (m) => [
-        m,
-        await Promise.race([
-          moduleTitle(m),
-          new Promise((resolve) =>
-            setTimeout(() => resolve("<TIMEOUT LOADING TITLE>"), 250)
-          )
-        ]).catch((e) => `err: ${e}`)
-      ])
-    )
-  );
+  const map = new Map(await Promise.all([...modules].map(async m => [
+    m,
+    await Promise.race([
+      moduleTitle(m),
+      new Promise(resolve => setTimeout(() => resolve('<TIMEOUT LOADING TITLE>'), 250))
+    ]).catch(e => `err: ${ e }`)
+  ])));
   return map;
 };
-const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
+const _pnpoh8 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
 {
-  console.log("generate summary");
+  console.log('generate summary');
   const modules = new Map([
-    ...main_modules.map((main_module) => [
+    ...main_modules.map(main_module => [
       main_module,
       {
-        name: "main",
+        name: 'main',
         module: main_module,
         title: titles.get(main_module),
         dependsOn: [],
         dependedBy: []
       }
     ]),
-    ...(bootloader
-      ? [
-          [
-            bootloader,
-            {
-              name: "bootloader",
-              title: "Bootloader",
-              module: bootloader,
-              dependsOn: [],
-              dependedBy: []
-            }
-          ]
-        ]
-      : []),
+    ...bootloader ? [[
+        bootloader,
+        {
+          name: 'bootloader',
+          title: 'Bootloader',
+          module: bootloader,
+          dependsOn: [],
+          dependedBy: []
+        }
+      ]] : [],
     [
       builtin,
       {
-        name: "builtin",
-        title: "Standard library",
+        name: 'builtin',
+        title: 'Standard library',
         module: builtin,
         dependsOn: [],
         dependedBy: []
@@ -18231,30 +19080,21 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   ]);
   // add cross links
   // notebookImportVariables[0].variable._module == main
-  [...notebookImportMatches.keys()].forEach((m) => {
+  [...notebookImportMatches.keys()].forEach(m => {
     const hostModule = modules.get(main_modules[0]);
     const importedModule = modules.get(m);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
     importedModule.dependedBy.push(main_modules[0].name);
   });
-
-  module_definition_variables.forEach((v) => {
+  module_definition_variables.forEach(v => {
     const hostModule = modules.get(v._module);
     const importedModule = modules.get(v._value);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
@@ -18262,11 +19102,11 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   });
   return modules;
 };
-const _1pou2g6 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
+const _hhecn4 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
 {
   resolve_modules;
   queue;
-  console.log("submit_summary");
+  console.log('submit_summary');
   notebookImports;
   $0.resolve(summary);
 };
@@ -18280,47 +19120,47 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
-  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));
-  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));  
+  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));  
   $def("_1w9yf3l", null, ["md"], _1w9yf3l);  
   $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
   $def("_1sznqfl", null, ["md"], _1sznqfl);  
-  $def("_1798myt", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1798myt);  
+  $def("_1hn3uql", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1hn3uql);  
   $def("_1yso65r", null, ["md"], _1yso65r);  
-  $def("_1fcoh6x", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1fcoh6x);  
+  $def("_1e3kr85", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1e3kr85);  
   $def("_wi39n0", "viewof currentModules", ["Inputs","moduleMap"], _wi39n0);  
   $def("_1gxgyd6", "currentModules", ["Generators","viewof currentModules"], _1gxgyd6);  
-  $def("_1qag34d", null, ["Inputs","currentModules"], _1qag34d);  
+  $def("_1kxoygl", null, ["Inputs","currentModules"], _1kxoygl);  
   $def("_1xamz8j", null, ["md"], _1xamz8j);  
-  $def("_1n4p4hn", "tipTitle", [], _1n4p4hn);  
-  $def("_1kdcb71", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _1kdcb71);  
+  $def("_1sglrv3", "tipTitle", [], _1sglrv3);  
+  $def("_5zbe1k", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _5zbe1k);  
   $def("_hgwvol", null, ["md"], _hgwvol);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
   $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_1nfaybn", "tag", [], _1nfaybn);  
-  $def("_17qqkoj", "forcePeek", [], _17qqkoj);  
-  $def("_v9hg2i", "observe", [], _v9hg2i);  
+  $def("_1lkbrun", "forcePeek", [], _1lkbrun);  
+  $def("_1qva85d", "observe", [], _1qva85d);  
   $def("_1bm642i", null, ["md"], _1bm642i);  
-  $def("_oothhq", "viewof queue", ["flowQueue"], _oothhq);  
+  $def("_1f31b1g", "viewof queue", ["flowQueue"], _1f31b1g);  
   $def("_648shl", "queue", ["Generators","viewof queue"], _648shl);  
   $def("_1acbzli", null, ["md"], _1acbzli);  
-  $def("_10dhunq", "module_definition_variables", ["notebookImports","queue"], _10dhunq);  
-  $def("_dcxoxy", "modules", ["module_definition_variables","queue"], _dcxoxy);  
+  $def("_1g0cuj1", "module_definition_variables", ["notebookImports","queue"], _1g0cuj1);  
+  $def("_17frsyf", "modules", ["module_definition_variables","queue"], _17frsyf);  
   $def("_1dqpbvy", "builtin", ["queue"], _1dqpbvy);  
-  $def("_ir3ob0", "main_modules", ["queue","modules","builtin"], _ir3ob0);  
+  $def("_13mmmk9", "main_modules", ["queue","modules","builtin"], _13mmmk9);  
   $def("_yflsv5", "bootloaded_mains", ["queue"], _yflsv5);  
   $def("_ox2g3b", "bootloader", ["queue"], _ox2g3b);  
-  $def("_1turw8j", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _1turw8j);  
+  $def("_10ufqkh", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _10ufqkh);  
   $def("_9fbvam", null, ["md"], _9fbvam);  
-  $def("_1h0lryb", "notebookImports", ["main","parser"], _1h0lryb);  
-  $def("_7t198q", "notebookImportVariables", ["runtime","notebookImports"], _7t198q);  
-  $def("_1lyens8", "pageImportMatch", [], _1lyens8);  
-  $def("_1akt4kz", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1akt4kz);  
-  $def("_1ang0sg", "moduleTitle", ["observeVariable"], _1ang0sg);
-  $def("_197sgjt", "titles", ["modules","moduleTitle"], _197sgjt);  
-  $def("_11z3pt0", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _11z3pt0);  
-  $def("_1pou2g6", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _1pou2g6);  
+  $def("_1t4ga3d", "notebookImports", ["main","parser"], _1t4ga3d);  
+  $def("_994hn4", "notebookImportVariables", ["runtime","notebookImports"], _994hn4);  
+  $def("_xanizk", "pageImportMatch", [], _xanizk);  
+  $def("_1q5pc6n", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1q5pc6n);  
+  $def("_12o3fj5", "moduleTitle", ["observeVariable"], _12o3fj5);  
+  $def("_ze3jk0", "titles", ["modules","moduleTitle"], _ze3jk0);  
+  $def("_pnpoh8", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _pnpoh8);  
+  $def("_hhecn4", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _hhecn4);  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
@@ -18334,8 +19174,8 @@ export default function define(runtime, observer) {
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
   main.define("viewof runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
-  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));
-  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));  
   main.define("spectralCircleOrder", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("spectralCircleOrder", _));  
   main.define("improveOrderSifting", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("improveOrderSifting", _));  
   main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));
@@ -18612,6 +19452,418 @@ export default function define(runtime, observer) {
   main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/modules" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _s7bl1p = function _1(md){return(
+md`# Modules
+
+\`modules(options?)\` is an async generator that yields a **cumulative \`Map\`** (module → \`{name, title, module, variable}\`) of every fully-formed record known so far, growing as modules resolve. 
+
+It's an effecient alternative to [moduleMap](https://observablehq.com/@tomlarkworthy/module-map) that blocks until all modules are loaded.
+`
+)};
+const _1eaa9lr = function _currentModules(modules){return(
+modules()
+)};
+const _dmem61 = function _modules(runtime, observeVariable, moduleTitle) {
+    const _runtime = runtime;
+    return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
+        if (!runtime || !runtime._variables)
+            throw 'Invalid runtime passed to modules';
+        return async function* () {
+            const records = new Map();
+            const watchers = new Map();
+            const peeking = new Map();
+            let pending = false, wake = null, dirty = true;
+            const bump = () => {
+                pending = true;
+                if (wake) {
+                    const w = wake;
+                    wake = null;
+                    w();
+                }
+            };
+            const touch = () => {
+                dirty = true;
+                bump();
+            };
+            const slugFromDef = v => {
+                const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
+                return m ? m[1].replace(/^\//, '') : null;
+            };
+            const scan = () => {
+                const out = new Map();
+                const put = (m, r) => {
+                    if (m && !out.has(m))
+                        out.set(m, r);
+                };
+                const builtin = runtime._builtin, bootloader = runtime.bootloader;
+                if (builtin)
+                    put(builtin, {
+                        name: 'builtin',
+                        title: 'Standard library'
+                    });
+                if (bootloader)
+                    put(bootloader, {
+                        name: 'bootloader',
+                        title: 'Bootloader'
+                    });
+                for (const [name, mod] of runtime.mains || new Map())
+                    put(mod, { name });
+                const imported = new Set((runtime._modules || new Map()).values());
+                const owners = new Set();
+                for (const v of runtime._variables)
+                    if (v._module)
+                        owners.add(v._module);
+                for (const m of owners)
+                    if (m !== builtin && m !== bootloader && !imported.has(m))
+                        put(m, { name: 'main' });
+                for (const v of runtime._variables) {
+                    if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+                        continue;
+                    const mod = v._value;
+                    if (mod && typeof mod === 'object')
+                        put(mod, {
+                            name: slugFromDef(v) || v._name.slice(7),
+                            variable: v
+                        });
+                    else if (load && !peeking.has(v))
+                        peeking.set(v, observeVariable(v, {
+                            fulfilled: bump,
+                            error: bump
+                        }));
+                }
+                return out;
+            };
+            const reconcile = () => {
+                const cand = scan();
+                for (const m of [...watchers.keys()]) {
+                    if (!cand.has(m)) {
+                        const cancel = watchers.get(m);
+                        watchers.delete(m);
+                        if (records.delete(m))
+                            touch();
+                        try {
+                            cancel();
+                        } catch (e) {
+                        }
+                    }
+                }
+                for (const [m, c] of cand) {
+                    if (watchers.has(m))
+                        continue;
+                    if (c.title != null) {
+                        records.set(m, {
+                            name: c.name,
+                            title: c.title,
+                            module: m,
+                            variable: c.variable
+                        });
+                        watchers.set(m, () => {
+                        });
+                        touch();
+                        continue;
+                    }
+                    const apply = title => {
+                        if (!watchers.has(m))
+                            return;
+                        const t = title ?? c.name;
+                        const prev = records.get(m);
+                        if (!prev) {
+                            records.set(m, {
+                                name: c.name,
+                                title: t,
+                                module: m,
+                                variable: c.variable
+                            });
+                            touch();
+                        } else if (prev.title !== t) {
+                            records.set(m, {
+                                ...prev,
+                                title: t
+                            });
+                            touch();
+                        }
+                    };
+                    const cancel = moduleTitle(m, apply);
+                    watchers.set(m, () => {
+                        try {
+                            cancel();
+                        } catch (e) {
+                        }
+                    });
+                    setTimeout(() => {
+                        if (watchers.has(m) && !records.has(m))
+                            apply(null);
+                    }, titleTimeoutMs);
+                }
+            };
+            let stopped = false;
+            (async () => {
+                while (!stopped) {
+                    try {
+                        reconcile();
+                    } catch (e) {
+                    }
+                    await new Promise(r => setTimeout(r, rescanMs));
+                }
+            })();
+            try {
+                while (true) {
+                    pending = false;
+                    if (dirty) {
+                        dirty = false;
+                        yield new Map(records);
+                    }
+                    if (!pending)
+                        await new Promise(resolve => {
+                            wake = resolve;
+                            if (pending) {
+                                wake = null;
+                                resolve();
+                            }
+                        });
+                }
+            } finally {
+                stopped = true;
+                for (const cancel of watchers.values()) {
+                    try {
+                        cancel();
+                    } catch (e) {
+                    }
+                }
+                for (const stop of peeking.values()) {
+                    try {
+                        stop();
+                    } catch (e) {
+                    }
+                }
+            }
+        }();
+    };
+};
+const _up9atj = function _moduleTitle(observeVariable)
+{
+  return function moduleTitle(module, onTitle) {
+    // Observes a module's title-defining cell and calls onTitle(title|null) on every change.
+    // Returns a cancel fn. The fixed observe() forces a lazy title cell to compute (and replays
+    // the current value on attach), so no in-module forcing helper is needed — works for named
+    // and anonymous cells alike, even in a fresh runtime nothing else observes.
+    const rt = module._runtime;
+    const candidates = [...rt._variables].filter(v => {
+      if (!v || v._module !== module || !v._definition || v._type != 1)
+        return false;
+      const n = v._name;
+      if (typeof n === 'string' && (n.startsWith('dynamic observe ') || n.startsWith('module ')))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0) {
+      onTitle(null);
+      return () => {
+      };
+    }
+    const first = candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b);
+    const extract = v => {
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      return null;
+    };
+    const stop = observeVariable(first, {
+      fulfilled: value => onTitle(extract(value)),
+      error: () => onTitle('Err')
+    });
+    return () => {
+      try {
+        stop();
+      } catch (e) {
+      }
+    };
+  };
+};
+const _qpensj = function _5(Inputs,currentModules){return(
+Inputs.table([...currentModules.values()], {
+  columns: [
+    'name',
+    'title'
+  ],
+  format: { name: x => x }
+})
+)};
+const _1x0q6zt = function _7(md){return(
+md`## Tests`
+)};
+const _e0sbyj = function _8(tests,modulesModule){return(
+tests({
+  filter: (t) => t.variable._module == modulesModule
+})
+)};
+const _p3rq3v = function _modulesModule(thisModule){return(
+thisModule()
+)};
+const _16g1ab = (G, _) => G.input(_);
+const _cayyvt = function _testRuntime(Runtime){return(
+new Runtime()
+)};
+const _1j4p6g3 = function _testModulesLatest(modules,testRuntime){return(
+modules({
+  runtime: testRuntime
+})
+)};
+const _1oq6y7s = function _newModule(testRuntime)
+{
+  const m = testRuntime.module();
+  m.variable().define("greeting", [], () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<h1>New Module</h1>";
+    return div;
+  });
+  return m;
+};
+const _1li1bty = function _test_detectsBuiltin(testModulesLatest)
+{
+  if (![...testModulesLatest.values()].find((m) => m.name == "builtin"))
+    throw Error();
+  return "ok";
+};
+const _vr1kp6 = function _test_detectsNewModule(testModulesLatest,newModule)
+{
+  const rec = testModulesLatest.get(newModule);
+  if (!rec) throw Error("newModule not detected yet");
+  if (rec.title !== "New Module")
+    throw Error(
+      "expected title 'New Module', got " + JSON.stringify(rec.title)
+    );
+  return "ok";
+};
+const _1p0sqk = async function _test_reflectsDelete(Runtime,modules)
+{
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Temp</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.has(m))))
+      throw Error("create not reflected");
+    for (const v of [...rt._variables]) if (v._module === m) v.delete();
+    if (!(await waitFor(() => !snap.has(m))))
+      throw Error("delete not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
+};
+const _1315qaf = async function _test_reflectsTitleUpdate(Runtime,modules)
+{
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    const tv = m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>First</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "First")))
+      throw Error("initial title not detected");
+    tv.define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Second</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "Second")))
+      throw Error("title update not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
+  $def("_s7bl1p", null, ["md"], _s7bl1p);  
+  $def("_1eaa9lr", "currentModules", ["modules"], _1eaa9lr);  
+  $def("_dmem61", "modules", ["runtime","observeVariable","moduleTitle"], _dmem61);  
+  $def("_up9atj", "moduleTitle", ["observeVariable"], _up9atj);  
+  $def("_qpensj", null, ["Inputs","currentModules"], _qpensj);  
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  $def("_1x0q6zt", null, ["md"], _1x0q6zt);  
+  $def("_e0sbyj", null, ["tests","modulesModule"], _e0sbyj);  
+  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
+  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));  
+  $def("_p3rq3v", "viewof modulesModule", ["thisModule"], _p3rq3v);  
+  $def("_16g1ab", "modulesModule", ["Generators","viewof modulesModule"], _16g1ab);  
+  $def("_cayyvt", "testRuntime", ["Runtime"], _cayyvt);  
+  $def("_1j4p6g3", "testModulesLatest", ["modules","testRuntime"], _1j4p6g3);  
+  $def("_1oq6y7s", "newModule", ["testRuntime"], _1oq6y7s);  
+  $def("_1li1bty", "test_detectsBuiltin", ["testModulesLatest"], _1li1bty);  
+  $def("_vr1kp6", "test_detectsNewModule", ["testModulesLatest","newModule"], _vr1kp6);  
+  $def("_1p0sqk", "test_reflectsDelete", ["Runtime","modules"], _1p0sqk);  
+  $def("_1315qaf", "test_reflectsTitleUpdate", ["Runtime","modules"], _1315qaf);
   return main;
 }</script>
 <script id="@tomlarkworthy/observable-runtime/runtime.js.gz" 
@@ -22502,6 +23754,248 @@ export default function define(runtime, observer) {
   $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
   $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
   return main;
+}
+</script>
+
+<script id="@tomlarkworthy/plugin-registry" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1ej2r92 = function _intro(md){return(
+md`# Plugin Registry
+
+A foundational notebook for **decoupled reactive plugin wiring**.
+
+Consumers get a realtime stream of all registered providers under a name. Providers can register themselves under a name. Neither has direct references between each other. This allows you to add more consumers and providers without changing individual providers and consumers. Useful for reactive plugin systems like audio instruments, dyamic menus, LLM tools and entity component systems.
+`
+)};
+const _16jmxgh = function _diagram(htl){return(
+htl.html`<svg viewBox="0 0 720 300" width="100%" style="max-width:720px;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="pr-arr" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="var(--theme-foreground,#333)"></path>
+    </marker>
+    <style>
+      .pr-box{fill:var(--theme-background-alt,#f4f4f6);stroke:var(--theme-foreground-faint,#bbb);stroke-width:1.5}
+      .pr-hub{fill:var(--theme-foreground-faintest,#eef);stroke:var(--theme-foreground,#556);stroke-width:2}
+      .pr-t{fill:var(--theme-foreground,#222);font-size:13px}
+      .pr-s{fill:var(--theme-foreground-muted,#666);font-size:11px}
+      .pr-e{stroke:var(--theme-foreground,#333);stroke-width:1.5;fill:none;marker-end:url(#pr-arr)}
+    </style>
+  </defs>
+
+  <rect class="pr-box" x="10"  y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="52" text-anchor="middle">Provider A</text>
+  <text class="pr-s" x="95" y="68" text-anchor="middle">plugins.add("x", v)</text>
+  <rect class="pr-box" x="10"  y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="142" text-anchor="middle">Provider B</text>
+  <text class="pr-s" x="95" y="158" text-anchor="middle">plugins.add("x", v, {invalidation})</text>
+  <text class="pr-s" x="95" y="215" text-anchor="middle">…N providers</text>
+
+  <rect class="pr-hub" x="270" y="78"  width="180" height="112" rx="10"></rect>
+  <text class="pr-t" x="360" y="104" text-anchor="middle" style="font-weight:600">plugins</text>
+  <text class="pr-s" x="360" y="128" text-anchor="middle">Map&lt;name, Set&lt;value&gt;&gt;</text>
+  <text class="pr-s" x="360" y="150" text-anchor="middle">add(name, value)</text>
+  <text class="pr-s" x="360" y="168" text-anchor="middle">get(name) → Generator</text>
+
+  <rect class="pr-box" x="540" y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="52" text-anchor="middle">Consumer 1</text>
+  <text class="pr-s" x="625" y="68" text-anchor="middle">plugins.get("x")</text>
+  <rect class="pr-box" x="540" y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="142" text-anchor="middle">Consumer 2 (V2)</text>
+  <text class="pr-s" x="625" y="158" text-anchor="middle">plugins.get("x")</text>
+  <text class="pr-s" x="625" y="215" text-anchor="middle">…M consumers</text>
+
+  <path class="pr-e" d="M180,54 C225,54 235,116 268,126"></path>
+  <path class="pr-e" d="M180,144 C225,144 240,138 268,140"></path>
+  <path class="pr-e" d="M452,128 C500,116 510,54 538,54"></path>
+  <path class="pr-e" d="M452,142 C500,144 510,144 538,144"></path>
+</svg>`
+)};
+const _xnvzuh = function _contracts(md){return(
+md`## Contracts
+
+| Guarantee | How |
+|---|---|
+| **Named sets** | \`plugins\` maps a name → a set of values. Providers \`add\`, consumers \`get\`; they coordinate only by name. |
+| **Reactive** | \`get(name)\` is a Generator that yields the current set and re-yields on every add/remove for that name. |
+| **N↔M decoupling** | Providers and consumers share only \`plugins\`. Any number of each; a name is the whole contract. |
+| **Auto-cleanup** | \`add\` returns \`remove()\`. Pass \`{invalidation}\` (a cell's disposal promise) to remove automatically when the provider cell re-runs. |
+| **No leaks** | \`get\`'s Generator unsubscribes on disposal; per-name listeners are dropped when the last consumer leaves. |
+| **Eventual convergence** | Each consumer gets the current set immediately on \`get\`, then a full-set snapshot on every change — so any interleaving of add/remove/get converges. |`
+)};
+const _1ua5hud = function _apiReference(md){return(
+md`## API reference
+
+The whole API is two methods on \`plugins\`.
+
+**\`plugins.add(name, value, options?)\`** → \`remove()\`
+Add \`value\` to the set stored under \`name\` (creating the set on first use). Returns a \`remove()\` function
+that takes this value back out. \`options.invalidation\` (optional, may be null/omitted) is a promise — when
+it settles the value is removed automatically; pass a provider cell's built-in \`invalidation\` so re-running
+the cell replaces rather than duplicates. \`value\` is anything; for shared views it is commonly a factory
+\`() => element\` that each consumer calls to get its own instance.
+
+**\`plugins.get(name)\`** → Generator&lt;value[]&gt;
+Return a reactive Generator of the values currently in \`name\`'s set. It yields the current set immediately
+(so a late consumer still converges), then re-yields the full set on every add/remove. Use it from a cell
+and that cell recomputes on each change. Call it from as many consumers as you like (e.g. a module and its
+V2) — each call is an independent Generator that cleans up when its cell is torn down.`
+)};
+const _1pzt22q = function _createPlugins(Generators)
+{
+  return function createPlugins() {
+    const sets = new Map();
+    // name -> Set<value>
+    const listeners = new Map();
+    // name -> Set<() => void>
+    const notify = name => {
+      const ls = listeners.get(name);
+      if (ls)
+        for (const l of [...ls])
+          l();  // copy: a consumer may (un)subscribe while notifying
+    };
+    const add = (name, value, options) => {
+      let set = sets.get(name);
+      if (!set)
+        sets.set(name, set = new Set());
+      set.add(value);
+      notify(name);
+      const remove = () => {
+        const s = sets.get(name);
+        if (s && s.delete(value)) {
+          if (s.size === 0)
+            sets.delete(name);
+          notify(name);
+        }
+      };
+      const invalidation = options && options.invalidation;
+      if (invalidation)
+        Promise.resolve(invalidation).then(remove, remove);
+      return remove;
+    };
+    const get = name => Generators.observe(change => {
+      const push = () => change([...sets.get(name) ?? []]);
+      push();
+      // current set immediately → converges
+      let ls = listeners.get(name);
+      if (!ls)
+        listeners.set(name, ls = new Set());
+      ls.add(push);
+      return () => {
+        ls.delete(push);
+        if (ls.size === 0)
+          listeners.delete(name);
+      };  // leak-safe
+    });
+    return {
+      add,
+      get,
+      listenerCount: name => listeners.get(name)?.size ?? 0
+    };
+  };
+};
+const _1qu8dwj = function _plugins(createPlugins){return(
+createPlugins()
+)};
+const _a7p1z5 = function _testsHeader(md){return(
+md`## Tests`
+)};
+const _15xl311 = function _test_get_reflects_add(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('new set should start empty');
+  p.add('x', 1);
+  const after = await (await gen.next()).value;
+  if (after.length !== 1 || after[0] !== 1)
+    throw new Error('get did not reflect the add');
+  gen.return();
+  return '\u2705 get(name) yields the named set and updates on add';
+})()
+)};
+const _122zyhz = function _test_multi_provider_and_convergence(createPlugins)
+{
+  return (async () => {
+    const p = createPlugins();
+    const a = p.get('x'), b = p.get('x');
+    // two independent consumers
+    await (await a.next()).value;
+    await (await b.next()).value;
+    p.add('x', 'one');
+    // provider 1
+    p.add('x', 'two');
+    // provider 2
+    const va = (await (await a.next()).value).slice().sort().join(',');
+    const vb = (await (await b.next()).value).slice().sort().join(',');
+    if (va !== 'one,two' || vb !== 'one,two')
+      throw new Error('consumers did not converge to the full set');
+    a.return();
+    b.return();
+    return '\u2705 multiple providers accumulate; all consumers converge';
+  })();
+};
+const _1lojas7 = function _test_remove_and_names_isolated(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gx = p.get('x'), gy = p.get('y');
+  await (await gx.next()).value;
+  await (await gy.next()).value;
+  const remove = p.add('x', 1);
+  p.add('y', 2);
+  if ((await (await gx.next()).value).join() !== '1')
+    throw new Error('x set wrong');
+  if ((await (await gy.next()).value).join() !== '2')
+    throw new Error('names are not isolated');
+  remove();
+  if ((await (await gx.next()).value).length !== 0)
+    throw new Error('remove() did not take the value out');
+  gx.return();
+  gy.return();
+  return '\u2705 remove() works and names are isolated';
+})()
+)};
+const _8240yg = function _test_invalidation_and_no_leak(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  let settle;
+  p.add('x', 1, { invalidation: new Promise(r => settle = r) });
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 1)
+    throw new Error('value should be present before invalidation');
+  if (p.listenerCount('x') !== 1)
+    throw new Error('get should have registered a listener');
+  settle();
+  await Promise.resolve();
+  await Promise.resolve();
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('invalidation did not remove the value');
+  gen.return();
+  if (p.listenerCount('x') !== 0)
+    throw new Error('disposing the Generator leaked a listener');
+  return '\u2705 {invalidation} auto-removes and get() leaks no listeners';
+})()
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  $def("_1ej2r92", "intro", ["md"], _1ej2r92);  
+  $def("_16jmxgh", "diagram", ["htl"], _16jmxgh);  
+  $def("_xnvzuh", "contracts", ["md"], _xnvzuh);  
+  $def("_1ua5hud", "apiReference", ["md"], _1ua5hud);  
+  $def("_1pzt22q", "createPlugins", ["Generators"], _1pzt22q);  
+  $def("_1qu8dwj", "plugins", ["createPlugins"], _1qu8dwj);  
+  $def("_a7p1z5", "testsHeader", ["md"], _a7p1z5);  
+  $def("_15xl311", "test_get_reflects_add", ["createPlugins"], _15xl311);  
+  $def("_122zyhz", "test_multi_provider_and_convergence", ["createPlugins"], _122zyhz);  
+  $def("_1lojas7", "test_remove_and_names_isolated", ["createPlugins"], _1lojas7);  
+  $def("_8240yg", "test_invalidation_and_no_leak", ["createPlugins"], _8240yg);
+  return main;
 }</script>
 <script id="@tomlarkworthy/prosemirror/prosecssbundle%401.js.gz" 
   type="text/plain"
@@ -23043,7 +24537,7 @@ const _nv232r = function _check_for_code_change(runtime_variables,codeChangeList
 const _ya86a1 = function _21(md){return(
 md`### observe(variable)
 
-This was monstrously difficult to develop. Installs a single dispatcher observer per variable holding an explicit listener list; each \`observe\` call adds a listener and returns a cancel that removes it, so attach/cancel can interleave in any order (views remount). A pre-existing observer (e.g. a bootloader Inspector) is kept as a permanent first listener. Delivery of \`["fulfilled", "rejected", "pending"]\` runs in attach order; for element values, a listener with \`detachNodes: true\` detaches the node from its current parent before adopting, so the last-attached view owns the node. When the observer attaches, if the variable is already fulfilled, the observer is signalled.
+This was monstrously difficult to develop. Taps a variable, intercepting all observer calls \`["fulfilled", "rejected", "pending"]\` whilst preserving the behaviour of the existing observer attached to the variable. If \`detachNodes\` is \`true\` and the existing observer hosts a DOM node, the additional variable "steals" it for it's DOM tree. When the observer attaches, if the variable is already fulfilled, the observer is signalled.
 
 Unobserved variables are marked as reachable and become active when observed.`
 )};
@@ -23057,240 +24551,240 @@ const _1hx65vf = function _no_observer(main)
     variable.delete();
     return symbol;
 };
-const _duwj4o = function _observe(Element,Text,trace_variable,$0,no_observer,queueMicrotask)
+const _18fhvl5 = function _observe(Element,Text,trace_variable,$0,no_observer,queueMicrotask)
 {
-    // Multiple views may observe one variable (a lopepage pane + an embedding widget).
-    // Views remount, so cancels arrive in any order. A single dispatcher observer per
-    // variable holds an explicit listener list: attach = push, cancel = splice. Delivery
-    // runs in attach order, so for element values the last-attached view adopts last and
-    // owns the node. (The previous design wrapped observer methods in place and each
-    // cancel restored the methods captured at ITS attach time — correct only for LIFO
-    // cancel order; any remount orphaned the surviving listener.)
-    const DISPATCH = '__observe_listeners__';
-    // cross realm support: no_observer is a Symbol compared by description
-    return function observe(v, observer, {invalidation, detachNodes = false} = {}) {
-        const observe_id = `${ v?._name || '<anon>' }@${ Date.now() }@${ Math.random().toString(16).slice(2) }`;
-        const snapshot = (extra = {}) => ({
-            t: Date.now(),
-            observe_id,
-            var_name: v?._name,
-            var_version: v?._version,
-            var_reachable: v?._reachable,
-            has_observer: v?._observer != null,
-            observer_has_node: !!observer?._node,
-            v_value_defined: v?._value !== undefined,
-            v_value_ctor: v?._value?.constructor?.name,
-            v_value_is_node: v?._value instanceof Element || v?._value instanceof Text || false,
-            v_promise: !!v?._promise,
-            listener_count: v?._observer?.[DISPATCH]?.length,
+  // Multiple views may observe one variable (a lopepage pane + an embedding widget).
+  // Views remount, so cancels arrive in any order. A single dispatcher observer per
+  // variable holds an explicit listener list: attach = push, cancel = splice. Delivery
+  // runs in attach order, so for element values the last-attached view adopts last and
+  // owns the node. (The previous design wrapped observer methods in place and each
+  // cancel restored the methods captured at ITS attach time — correct only for LIFO
+  // cancel order; any remount orphaned the surviving listener.)
+  const DISPATCH = '__observe_listeners__';
+  // cross realm support: no_observer is a Symbol compared by description
+  return function observe(v, observer, {invalidation, detachNodes = false} = {}) {
+    const observe_id = `${ v?._name || '<anon>' }@${ Date.now() }@${ Math.random().toString(16).slice(2) }`;
+    const snapshot = (extra = {}) => ({
+      t: Date.now(),
+      observe_id,
+      var_name: v?._name,
+      var_version: v?._version,
+      var_reachable: v?._reachable,
+      has_observer: v?._observer != null,
+      observer_has_node: !!observer?._node,
+      v_value_defined: v?._value !== undefined,
+      v_value_ctor: v?._value?.constructor?.name,
+      v_value_is_node: v?._value instanceof Element || v?._value instanceof Text || false,
+      v_promise: !!v?._promise,
+      listener_count: v?._observer?.[DISPATCH]?.length,
+      ...extra
+    });
+    const emit = (event, extra = {}) => {
+      if (v?._name !== trace_variable)
+        return;
+      try {
+        $0.value = $0.value.concat([snapshot({
+            event,
             ...extra
-        });
-        const emit = (event, extra = {}) => {
-            if (v?._name !== trace_variable)
-                return;
-            try {
-                $0.value = $0.value.concat([snapshot({
-                        event,
-                        ...extra
-                    })]);
-            } catch {
-            }
-        };
-        emit('observe:begin', { detachNodes });
-        const isNode = value => value instanceof Element || value instanceof Text;
-        // Detach an element value from wherever it currently lives so this listener's
-        // fulfilled can adopt it into its own node.
-        const stealFor = (l, value, reason) => {
-            const canSteal = l.detachNodes && isNode(value) && l.observer?._node && l.observer._node !== value.parentNode;
-            emit('observe:steal_check', {
-                reason,
-                canSteal,
-                value_ctor: value?.constructor?.name,
-                value_parent: value?.parentNode?.constructor?.name
-            });
-            if (canSteal) {
-                try {
-                    value.remove();
-                } catch {
-                }
-                emit('observe:steal_detached', { reason });
-            }
-        };
-        // --- ensure dispatcher installed ---
-        let dispatch = v._observer && v._observer[DISPATCH] ? v._observer : null;
-        if (!dispatch) {
-            const listeners = [];
-            const deliver = type => (...args) => {
-                emit(`observe:deliver:${ type }`, { arg0_ctor: args[0]?.constructor?.name });
-                for (const l of [...listeners]) {
-                    try {
-                        if (type === 'fulfilled') {
-                            stealFor(l, args[0], 'deliver');
-                            l.observer.fulfilled?.(args[0], v?._name);
-                        } else if (type === 'rejected')
-                            l.observer.rejected?.(args[0], v?._name);
-                        else
-                            l.observer.pending?.();
-                    } catch (e) {
-                        emit(`observe:deliver:${ type }:listener_error`, { message: String(e) });
-                    }
-                }
-            };
-            const previous = v._observer;
-            dispatch = {
-                [DISPATCH]: listeners,
-                // Preserve the `variable._observer._node` contract editors (divToVar),
-                // module-map, and observablehq.com key on. The pre-existing observer
-                // (e.g. the notebook Inspector) owns the canonical node; otherwise the
-                // last-attached listener that has one (the view that adopted the value).
-                get _node() {
-                    const base = listeners.find(l => l.base);
-                    if (base?.observer?._node != null)
-                        return base.observer._node;
-                    for (let i = listeners.length - 1; i >= 0; i--) {
-                        const n = listeners[i].observer?._node;
-                        if (n != null)
-                            return n;
-                    }
-                    return undefined;
-                },
-                __restore: () => {
-                    if (v._observer === dispatch)
-                        v._observer = previous;
-                },
-                pending: deliver('pending'),
-                fulfilled: deliver('fulfilled'),
-                rejected: deliver('rejected')
-            };
-            const hasExistingObserver = previous != null && previous?.description !== no_observer.description;
-            if (hasExistingObserver) {
-                // pre-existing real observer (e.g. bootloader Inspector) stays first, permanently
-                listeners.push({
-                    observer: previous,
-                    detachNodes: false,
-                    base: true
-                });
-                emit('observe:attach:base_listener_kept');
-            }
-            if (v && !v._reachable) {
-                v._reachable = true;
-                v._module._runtime._dirty.add(v);
-                v._module._runtime._updates.add(v);
-                emit('observe:attach:marked_reachable');
-            }
-            v._observer = dispatch;
-            emit('observe:attach:dispatcher_installed', { hasExistingObserver });
-        }
-        // --- attach this listener ---
-        const listeners = dispatch[DISPATCH];
-        const entry = {
-            observer,
-            detachNodes
-        };
-        listeners.push(entry);
-        emit('observe:attach:listener_added');
-        let cancelled = false;
-        const cancel = () => {
-            emit('observe:cancel_called');
-            if (cancelled)
-                return;
-            cancelled = true;
-            const i = listeners.indexOf(entry);
-            if (i >= 0)
-                listeners.splice(i, 1);
-            if (!listeners.some(l => !l.base)) {
-                // no external listeners left: hand the variable back
-                dispatch.__restore();
-                emit('observe:cancel:dispatcher_removed');
-            }
-        };
-        if (invalidation)
-            Promise.resolve(invalidation).then(() => {
-                emit('observe:invalidation_fired');
-                cancel();
-            });
-        // --- CATCH-UP REPLAY (BUG FIX) ---
-        // Snapshot version to avoid replaying stale results.
-        const versionAtAttach = v?._version;
-        emit('observe:catchup:scheduled', { versionAtAttach });
-        queueMicrotask(() => {
-            emit('observe:catchup:microtask_start', { cancelled });
-            if (cancelled)
-                return;
-            // mimic inspector: mark pending first
-            try {
-                observer.pending?.();
-                emit('observe:catchup:pending_sent');
-            } catch (e) {
-                emit('observe:catchup:pending_error', { message: String(e) });
-            }
-            // IMPORTANT: read CURRENT value at replay time
-            const valueNow = v?._value;
-            emit('observe:catchup:valueNow_snapshot', {
-                valueNow_defined: valueNow !== undefined,
-                valueNow_ctor: valueNow?.constructor?.name,
-                v_version_now: v?._version,
-                valueNow_outerHTML_prefix: v?._observer?._node?.outerHTML
-            });
-            if (valueNow !== undefined) {
-                if (v?._version !== versionAtAttach) {
-                    emit('observe:catchup:stale_skip_valueNow');
-                    return;
-                }
-                stealFor(entry, valueNow, 'catchup:valueNow');
-                try {
-                    observer.fulfilled?.(valueNow, v?._name);
-                    emit('observe:catchup:fulfilled_sent_valueNow');
-                } catch (e) {
-                    emit('observe:catchup:fulfilled_error_valueNow', { message: String(e) });
-                }
-                return;
-            }
-            // optional fallback: attach-time promise (or current promise)
-            const p = v?._promise;
-            if (!p || typeof p.then !== 'function') {
-                emit('observe:catchup:no_value_no_promise');
-                return;
-            }
-            emit('observe:catchup:await_promise');
-            Promise.resolve(p).then(value => {
-                emit('observe:catchup:promise_fulfilled', {
-                    value_defined: value !== undefined,
-                    value_ctor: value?.constructor?.name,
-                    v_version_now: v?._version
-                });
-                if (cancelled)
-                    return;
-                if (v?._version !== versionAtAttach) {
-                    emit('observe:catchup:stale_skip_promise');
-                    return;
-                }
-                if (value === undefined)
-                    return;
-                stealFor(entry, value, 'catchup:promise');
-                try {
-                    observer.fulfilled?.(value, v?._name);
-                    emit('observe:catchup:fulfilled_sent_promise');
-                } catch (e) {
-                    emit('observe:catchup:fulfilled_error_promise', { message: String(e) });
-                }
-            }, error => {
-                emit('observe:catchup:promise_rejected', { v_version_now: v?._version });
-                if (cancelled)
-                    return;
-                if (v?._version !== versionAtAttach)
-                    return;
-                try {
-                    observer.rejected?.(error, v?._name);
-                    emit('observe:catchup:rejected_sent_promise');
-                } catch (e) {
-                    emit('observe:catchup:rejected_error_promise', { message: String(e) });
-                }
-            });
-        });
-        emit('observe:end');
-        return cancel;
+          })]);
+      } catch {
+      }
     };
+    emit('observe:begin', { detachNodes });
+    const isNode = value => value instanceof Element || value instanceof Text;
+    // Detach an element value from wherever it currently lives so this listener's
+    // fulfilled can adopt it into its own node.
+    const stealFor = (l, value, reason) => {
+      const canSteal = l.detachNodes && isNode(value) && l.observer?._node && l.observer._node !== value.parentNode;
+      emit('observe:steal_check', {
+        reason,
+        canSteal,
+        value_ctor: value?.constructor?.name,
+        value_parent: value?.parentNode?.constructor?.name
+      });
+      if (canSteal) {
+        try {
+          value.remove();
+        } catch {
+        }
+        emit('observe:steal_detached', { reason });
+      }
+    };
+    // --- ensure dispatcher installed ---
+    let dispatch = v._observer && v._observer[DISPATCH] ? v._observer : null;
+    if (!dispatch) {
+      const listeners = [];
+      const deliver = type => (...args) => {
+        emit(`observe:deliver:${ type }`, { arg0_ctor: args[0]?.constructor?.name });
+        for (const l of [...listeners]) {
+          try {
+            if (type === 'fulfilled') {
+              stealFor(l, args[0], 'deliver');
+              l.observer.fulfilled?.(args[0], v?._name);
+            } else if (type === 'rejected')
+              l.observer.rejected?.(args[0], v?._name);
+            else
+              l.observer.pending?.();
+          } catch (e) {
+            emit(`observe:deliver:${ type }:listener_error`, { message: String(e) });
+          }
+        }
+      };
+      const previous = v._observer;
+      dispatch = {
+        [DISPATCH]: listeners,
+        // Preserve the `variable._observer._node` contract editors (divToVar),
+        // module-map, and observablehq.com key on. The pre-existing observer
+        // (e.g. the notebook Inspector) owns the canonical node; otherwise the
+        // last-attached listener that has one (the view that adopted the value).
+        get _node() {
+          const base = listeners.find(l => l.base);
+          if (base?.observer?._node != null)
+            return base.observer._node;
+          for (let i = listeners.length - 1; i >= 0; i--) {
+            const n = listeners[i].observer?._node;
+            if (n != null)
+              return n;
+          }
+          return undefined;
+        },
+        __restore: () => {
+          if (v._observer === dispatch)
+            v._observer = previous;
+        },
+        pending: deliver('pending'),
+        fulfilled: deliver('fulfilled'),
+        rejected: deliver('rejected')
+      };
+      const hasExistingObserver = previous != null && previous?.description !== no_observer.description;
+      if (hasExistingObserver) {
+        // pre-existing real observer (e.g. bootloader Inspector) stays first, permanently
+        listeners.push({
+          observer: previous,
+          detachNodes: false,
+          base: true
+        });
+        emit('observe:attach:base_listener_kept');
+      }
+      if (v && !v._reachable) {
+        v._reachable = true;
+        v._module._runtime._dirty.add(v);
+        v._module._runtime._updates.add(v);
+        emit('observe:attach:marked_reachable');
+      }
+      v._observer = dispatch;
+      emit('observe:attach:dispatcher_installed', { hasExistingObserver });
+    }
+    // --- attach this listener ---
+    const listeners = dispatch[DISPATCH];
+    const entry = {
+      observer,
+      detachNodes
+    };
+    listeners.push(entry);
+    emit('observe:attach:listener_added');
+    let cancelled = false;
+    const cancel = () => {
+      emit('observe:cancel_called');
+      if (cancelled)
+        return;
+      cancelled = true;
+      const i = listeners.indexOf(entry);
+      if (i >= 0)
+        listeners.splice(i, 1);
+      if (!listeners.some(l => !l.base)) {
+        // no external listeners left: hand the variable back
+        dispatch.__restore();
+        emit('observe:cancel:dispatcher_removed');
+      }
+    };
+    if (invalidation)
+      Promise.resolve(invalidation).then(() => {
+        emit('observe:invalidation_fired');
+        cancel();
+      });
+    // --- CATCH-UP REPLAY (BUG FIX) ---
+    // Snapshot version to avoid replaying stale results.
+    const versionAtAttach = v?._version;
+    emit('observe:catchup:scheduled', { versionAtAttach });
+    queueMicrotask(() => {
+      emit('observe:catchup:microtask_start', { cancelled });
+      if (cancelled)
+        return;
+      // mimic inspector: mark pending first
+      try {
+        observer.pending?.();
+        emit('observe:catchup:pending_sent');
+      } catch (e) {
+        emit('observe:catchup:pending_error', { message: String(e) });
+      }
+      // IMPORTANT: read CURRENT value at replay time
+      const valueNow = v?._value;
+      emit('observe:catchup:valueNow_snapshot', {
+        valueNow_defined: valueNow !== undefined,
+        valueNow_ctor: valueNow?.constructor?.name,
+        v_version_now: v?._version,
+        valueNow_outerHTML_prefix: v?._observer?._node?.outerHTML
+      });
+      if (valueNow !== undefined) {
+        if (v?._version !== versionAtAttach) {
+          emit('observe:catchup:stale_skip_valueNow');
+          return;
+        }
+        stealFor(entry, valueNow, 'catchup:valueNow');
+        try {
+          observer.fulfilled?.(valueNow, v?._name);
+          emit('observe:catchup:fulfilled_sent_valueNow');
+        } catch (e) {
+          emit('observe:catchup:fulfilled_error_valueNow', { message: String(e) });
+        }
+        return;
+      }
+      // optional fallback: attach-time promise (or current promise)
+      const p = v?._promise;
+      if (!p || typeof p.then !== 'function') {
+        emit('observe:catchup:no_value_no_promise');
+        return;
+      }
+      emit('observe:catchup:await_promise');
+      Promise.resolve(p).then(value => {
+        emit('observe:catchup:promise_fulfilled', {
+          value_defined: value !== undefined,
+          value_ctor: value?.constructor?.name,
+          v_version_now: v?._version
+        });
+        if (cancelled)
+          return;
+        if (v?._version !== versionAtAttach) {
+          emit('observe:catchup:stale_skip_promise');
+          return;
+        }
+        if (value === undefined)
+          return;
+        stealFor(entry, value, 'catchup:promise');
+        try {
+          observer.fulfilled?.(value, v?._name);
+          emit('observe:catchup:fulfilled_sent_promise');
+        } catch (e) {
+          emit('observe:catchup:fulfilled_error_promise', { message: String(e) });
+        }
+      }, error => {
+        emit('observe:catchup:promise_rejected', { v_version_now: v?._version });
+        if (cancelled)
+          return;
+        if (v?._version !== versionAtAttach)
+          return;
+        try {
+          observer.rejected?.(error, v?._name);
+          emit('observe:catchup:rejected_sent_promise');
+        } catch (e) {
+          emit('observe:catchup:rejected_error_promise', { message: String(e) });
+        }
+      });
+    });
+    emit('observe:end');
+    return cancel;
+  };
 };
 const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObject,queueMicrotask,getPromiseState)
 {
@@ -23301,7 +24795,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
             invalidation.then(onCancel);
         if (v?._name === trace_variable) {
             console.log('observe', trace_variable, v);
-            void 0;
+            debugger;
         }
         if (_.isEqual(v._observer, {}) || v._observer === no_observer) {
             // No existing observer, so we install one
@@ -23325,7 +24819,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
                 const old = v._observer[type];
                 v._observer[type] = (...args) => {
                     if (v?._name === trace_variable) {
-                        void 0;
+                        debugger;
                         console.log(trace_variable, type, ...args);
                     }
                     // The old is often a prototype, so we use Reflect to call it
@@ -23352,7 +24846,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
                 cancels.add(() => v._observer[type] = old);
             });
             if (v?._name === trace_variable) {
-                void 0;
+                debugger;
                 console.log(`checking`, trace_variable, v, toObject(v), v._value);
             }
         }
@@ -23374,7 +24868,7 @@ const _16ohhcn = function _observeOld(trace_variable,_,no_observer,isnode,toObje
             // either in pending or error state, we can check by racing a promise
             getPromiseState(v._promise).then(({state, error, value}) => {
                 if (v?._name === trace_variable) {
-                    void 0;
+                    debugger;
                 }
                 if (state == 'rejected') {
                     if (observer.rejected)
@@ -23514,7 +25008,7 @@ Keep a named cell evaluated without a direct dataflow dependancy. Useful to keep
 const _12v8rf5 = function _keepalive(){return(
 (module, variable_name) => {
     if (variable_name === undefined)
-        void 0;
+        debugger;
     const name = `dynamic observe ${ variable_name }`;
     console.log(`keepalive: ${ name }`);
     if (module._scope.has(name))
@@ -23829,7 +25323,7 @@ export default function define(runtime, observer) {
   $def("_ya86a1", null, ["md"], _ya86a1);  
   $def("_tgfgv9", "trace_variable", [], _tgfgv9);  
   $def("_1hx65vf", "no_observer", ["main"], _1hx65vf);  
-  $def("_duwj4o", "observe", ["Element","Text","trace_variable","mutable trace_history","no_observer","queueMicrotask"], _duwj4o);  
+  $def("_18fhvl5", "observe", ["Element","Text","trace_variable","mutable trace_history","no_observer","queueMicrotask"], _18fhvl5);  
   $def("_16ohhcn", "observeOld", ["trace_variable","_","no_observer","isnode","toObject","queueMicrotask","getPromiseState"], _16ohhcn);  
   $def("_2kni3y", null, ["md"], _2kni3y);  
   $def("_1utnee9", "descendants", [], _1utnee9);  
@@ -25269,11 +26763,13 @@ md`### interval
 
 https://rxjs.dev/api/index/function/interval`
 )};
-const _bz8ib5 = function _interval(Inputs,Event){return(
+const _px7gfx = function _interval(Inputs,Event){return(
 function interval({period = 0, invalidation}) {
   const result = Inputs.input();
   let count = 0;
+  debugger;
   const onTick = () => {
+    debugger;
     result.value = count++;
     result.dispatchEvent(new Event('input'));
   };
@@ -25466,7 +26962,7 @@ export default function define(runtime, observer) {
   $def("_xvoqqz", null, ["md"], _xvoqqz);  
   $def("_1sychb7", null, ["md"], _1sychb7);  
   $def("_1a3sdj9", null, ["md"], _1a3sdj9);  
-  $def("_bz8ib5", "interval", ["Inputs","Event"], _bz8ib5);  
+  $def("_px7gfx", "interval", ["Inputs","Event"], _px7gfx);  
   $def("_11meps1", null, ["md"], _11meps1);  
   $def("_sdzl0o", "map", ["Inputs","Event"], _sdzl0o);  
   $def("_zawuyh", null, ["md"], _zawuyh);  
@@ -25519,10 +27015,14 @@ const _1rosxg0 = function _data(){return(
   instance: new URL("https://google.com")
 }
 )};
-const _ygg2hv = function _summarizeJS(html,inspect,postProcess,MouseEvent){return(
+const _p715nx = function _summarizeJS(Node,html,inspect,postProcess,MouseEvent){return(
 function summarizeJS(value, { max_size = 5000 } = {}) {
   // Render the inspected HTML into a temporary <div>
-  const inspection = html`<div>${inspect(value)}`;
+  const inspected =
+    typeof Node !== "undefined" && value instanceof Node
+      ? value.cloneNode(true)
+      : value;
+  const inspection = html`<div>${inspect(inspected)}`;
   let text = postProcess(inspection);
   let prior = undefined;
 
@@ -25628,7 +27128,7 @@ export default function define(runtime, observer) {
   main.define("Inspector", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("src", ["module @tomlarkworthy/inspector", "@variable"], (_, v) => v.import("src", _));  
   $def("_1rosxg0", "data", [], _1rosxg0);  
-  $def("_ygg2hv", "summarizeJS", ["html","inspect","postProcess","MouseEvent"], _ygg2hv);  
+  $def("_p715nx", "summarizeJS", ["Node","html","inspect","postProcess","MouseEvent"], _p715nx);  
   $def("_wtf5dq", "walked", ["postProcess","inspect","data"], _wtf5dq);  
   $def("_1l6vroc", "postProcess", ["walk"], _1l6vroc);  
   $def("_1brf10r", "TEXT", [], _1brf10r);  
@@ -25964,28 +27464,29 @@ import {themes, theme_properties, css} from "@tomlarkworthy/themes"
 \`\`\`
 `
 )};
-const _1clcodb = function _theme_assets(Inputs,themes,current_theme){return(
+const _x91dc7 = function _theme_assets(Inputs,themes,current_theme){return(
 Inputs.select(themes, {
-    label: 'Theme',
-    value: current_theme || themes.get('near-midnight')
+  label: 'Theme',
+  value: current_theme || themes.get('near-midnight')
 })
 )};
 const _1sdw5pf = (G, _) => G.input(_);
 const _1wzah21 = function _theme_name(themes,theme_assets){return(
 [...themes.entries()].find(([, assets]) => assets === theme_assets)?.[0] ?? 'unknown'
 )};
-const _1mut3rc = function _apply_theme(css,themes,theme_assets,html)
+const _zy6iu8 = function _apply_theme(css,themes,theme_assets,html)
 {
   const view = document.defaultView;
   const sheets = [];
   for (const [url, text] of css) {
-    if (typeof text !== "string") continue;
+    if (typeof text !== 'string')
+      continue;
     try {
       const sheet = new view.CSSStyleSheet();
       sheet.replaceSync(text);
       sheets.push(sheet);
     } catch (e) {
-      console.warn("Could not adopt stylesheet", url, e);
+      console.warn('Could not adopt stylesheet', url, e);
     }
   }
   document.adoptedStyleSheets = sheets;
@@ -25995,101 +27496,106 @@ const _1mut3rc = function _apply_theme(css,themes,theme_assets,html)
   // known theme URLs — leaves unrelated CSS asset blocks alone.
   const knownThemeUrls = new Set();
   for (const list of themes.values())
-    for (const u of list) knownThemeUrls.add(u);
+    for (const u of list)
+      knownThemeUrls.add(u);
   for (const u of knownThemeUrls) {
-    if (!theme_assets.includes(u)) document.getElementById(u)?.remove();
+    if (!theme_assets.includes(u))
+      document.getElementById(u)?.remove();
   }
   for (const [url, text] of css) {
-    if (!url || !url.startsWith("http")) continue;
-    if (!theme_assets.includes(url)) continue;
+    if (!url || !url.startsWith('http'))
+      continue;
+    if (!theme_assets.includes(url))
+      continue;
     let s = document.getElementById(url);
     if (!s) {
-      s = document.createElement("script");
+      s = document.createElement('script');
       s.id = url;
-      s.type = "text/plain";
-      s.setAttribute("data-mime", "text/css");
+      s.type = 'text/plain';
+      s.setAttribute('data-mime', 'text/css');
       document.head.appendChild(s);
     }
     // Always replace text so a freshly-fetched theme overwrites stale cache.
-    if (!s.hasAttribute("data-encoding")) s.textContent = text;
+    if (!s.hasAttribute('data-encoding'))
+      s.textContent = text;
   }
-  return html`<div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted);padding:6px 10px;border:1px solid var(--theme-foreground-faintest);border-radius:4px;display:inline-block">Applied ${sheets.length} stylesheets to the page.</div>`;
+  return html`<div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted);padding:6px 10px;border:1px solid var(--theme-foreground-faintest);border-radius:4px;display:inline-block">Applied ${ sheets.length } stylesheets to the page.</div>`;
 };
-const _11pe38r = function _5(theme_properties,html,htl,theme_name){return(
+const _10zmng3 = function _5(theme_properties,html,htl,theme_name){return(
 (() => {
-    const props = theme_properties;
-    const get = k => props[k] || '';
-    const groups = {
-        Background: [
-            '--theme-background',
-            '--theme-background-a',
-            '--theme-background-b',
-            '--theme-background-raised'
-        ],
-        Foreground: [
-            '--theme-foreground',
-            '--theme-foreground-muted',
-            '--theme-foreground-faint',
-            '--theme-foreground-fainter',
-            '--theme-foreground-faintest',
-            '--theme-foreground-focus',
-            '--theme-foreground-error'
-        ],
-        Syntax: [
-            '--syntax-keyword',
-            '--syntax-string',
-            '--syntax-comment',
-            '--syntax-literal',
-            '--syntax-atom',
-            '--syntax-variable',
-            '--syntax-definition'
-        ]
-    };
-    const fonts = [
-        [
-            '--serif',
-            'Serif'
-        ],
-        [
-            '--sans-serif',
-            'Sans-serif'
-        ],
-        [
-            '--monospace',
-            'Monospace'
-        ]
-    ].filter(([k]) => props[k]);
-    const swatch = key => {
-        const value = get(key);
-        if (!value)
-            return '';
-        return html`<div style="display:flex;align-items:center;gap:8px;padding:4px 6px;border-radius:4px;font:12px/1.4 var(--monospace, ui-monospace, monospace)">
+  const props = theme_properties;
+  const get = k => props[k] || '';
+  const groups = {
+    Background: [
+      '--theme-background',
+      '--theme-background-a',
+      '--theme-background-b',
+      '--theme-background-raised'
+    ],
+    Foreground: [
+      '--theme-foreground',
+      '--theme-foreground-muted',
+      '--theme-foreground-faint',
+      '--theme-foreground-fainter',
+      '--theme-foreground-faintest',
+      '--theme-foreground-focus',
+      '--theme-foreground-error'
+    ],
+    Syntax: [
+      '--syntax-keyword',
+      '--syntax-string',
+      '--syntax-comment',
+      '--syntax-literal',
+      '--syntax-atom',
+      '--syntax-variable',
+      '--syntax-definition'
+    ]
+  };
+  const fonts = [
+    [
+      '--serif',
+      'Serif'
+    ],
+    [
+      '--sans-serif',
+      'Sans-serif'
+    ],
+    [
+      '--monospace',
+      'Monospace'
+    ]
+  ].filter(([k]) => props[k]);
+  const swatch = key => {
+    const value = get(key);
+    if (!value)
+      return '';
+    return html`<div style="display:flex;align-items:center;gap:8px;padding:4px 6px;border-radius:4px;font:12px/1.4 var(--monospace, ui-monospace, monospace)">
             <span style="width:28px;height:28px;border-radius:4px;border:1px solid var(--theme-foreground-faintest);background:var(${ key });flex:none"></span>
             <div style="display:flex;flex-direction:column;min-width:0;flex:1">
                 <code style="color:var(--theme-foreground)">${ key }</code>
                 <span style="color:var(--theme-foreground-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${ value }</span>
             </div>
         </div>`;
-    };
-    const fontSample = ([key, label]) => {
-        const family = get(key);
-        const isMono = /mono/i.test(label) || /mono/i.test(key);
-        return html`<div style="padding:10px 12px;border:1px solid var(--theme-foreground-faintest);border-radius:6px;background:var(--theme-background-a, var(--theme-background))">
+  };
+  const fontSample = ([key, label]) => {
+    const family = get(key);
+    const isMono = /mono/i.test(label) || /mono/i.test(key);
+    return html`<div style="padding:10px 12px;border:1px solid var(--theme-foreground-faintest);border-radius:6px;background:var(--theme-background-a, var(--theme-background))">
             <div style="font:11px/1.2 var(--sans-serif, ui-sans-serif, system-ui);color:var(--theme-foreground-muted);margin-bottom:6px;letter-spacing:0.04em;text-transform:uppercase">${ label }</div>
             <div style="font-family:${ family };font-size:${ isMono ? '14px' : '22px' };line-height:1.3;color:var(--theme-foreground)">
                 ${ isMono ? html`<code>const greeting = "Hello, world";</code>` : 'The quick brown fox jumps over the lazy dog' }
             </div>
             <div style="font:11px/1.4 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-faint);margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${ family }</div>
         </div>`;
-    };
-    const codeSample = html`<pre style="margin:0;padding:12px;border-radius:6px;background:var(--theme-background-a, var(--theme-background));border:1px solid var(--theme-foreground-faintest);font:13px/1.5 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground);overflow-x:auto"><span style="color:var(--syntax-comment)">// fibonacci</span>
+  };
+  const codeSample = html`<pre style="margin:0;padding:12px;border-radius:6px;background:var(--theme-background-a, var(--theme-background));border:1px solid var(--theme-foreground-faintest);font:13px/1.5 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground);overflow-x:auto"><span style="color:var(--syntax-comment)">// fibonacci</span>
 <span style="color:var(--syntax-keyword)">function</span> <span style="color:var(--syntax-definition)">fib</span>(<span style="color:var(--syntax-variable)">n</span>) {
   <span style="color:var(--syntax-keyword)">if</span> (n &lt; <span style="color:var(--syntax-literal)">2</span>) <span style="color:var(--syntax-keyword)">return</span> n;
   <span style="color:var(--syntax-keyword)">return</span> <span style="color:var(--syntax-string)">\`fib(\${n})\`</span>;
 }
 <span style="color:var(--syntax-keyword)">const</span> result = fib(<span style="color:var(--syntax-literal)">10</span>);
 <span style="color:var(--syntax-keyword)">return</span> <span style="color:var(--syntax-atom)">null</span>;</pre>`;
-    return htl.html`<div style="background:var(--theme-background);color:var(--theme-foreground);padding:16px;border-radius:8px;font-family:var(--serif, var(--sans-serif, ui-sans-serif, system-ui))">
+  return htl.html`<div style="background:var(--theme-background);color:var(--theme-foreground);padding:16px;border-radius:8px;font-family:var(--serif, var(--sans-serif, ui-sans-serif, system-ui))">
         <div style="display:flex;align-items:baseline;gap:12px;margin-bottom:14px">
             <h3 style="margin:0;font-family:var(--serif, var(--sans-serif, ui-sans-serif));color:var(--theme-foreground)">${ theme_name }</h3>
             <span style="font:12px/1 var(--monospace, ui-monospace, monospace);color:var(--theme-foreground-muted)">theme preview</span>
@@ -26119,190 +27625,218 @@ md`## All CSS variables
 
 Every CSS custom property parsed from the active theme. \`theme_properties\` is exported as a plain JS object so other notebooks can consume theme values programmatically (canvas colors, chart palettes, inline styles) without parsing CSS.`
 )};
-const _1hu8vay = function _7(htl,theme_properties,html){return(
+const _18nx47m = function _7(htl,theme_properties,html){return(
 htl.html`<details style="background: var(--theme-background); color: var(--theme-foreground); padding: 12px; border-radius: 6px;">
 <summary style="cursor:pointer;font-weight:600">Show all ${ Object.keys(theme_properties).length } properties</summary>
 
 ${ Object.entries(theme_properties).map(([key, value]) => {
-    const isColor = /^(#|rgb|hsl|color-mix)/.test(value) || /^var\(--theme-(foreground|background|error)/.test(value);
-    return html`<p style="margin:4px 0"><span style="width: 16px; height: 16px; border-radius: 3px; border: 1px solid var(--theme-foreground-faintest); background: ${ isColor ? 'var(' + key + ')' : 'transparent' }; display: inline-block; vertical-align: middle;"></span> <code>${ key }</code> <span style="color: var(--theme-foreground-muted)">${ value }</span></p>`;
+  const isColor = /^(#|rgb|hsl|color-mix)/.test(value) || /^var\(--theme-(foreground|background|error)/.test(value);
+  return html`<p style="margin:4px 0"><span style="width: 16px; height: 16px; border-radius: 3px; border: 1px solid var(--theme-foreground-faintest); background: ${ isColor ? 'var(' + key + ')' : 'transparent' }; display: inline-block; vertical-align: middle;"></span> <code>${ key }</code> <span style="color: var(--theme-foreground-muted)">${ value }</span></p>`;
 }) }
 
 </details>
 `
 )};
-const _1k4keny = function _theme_properties(css){return(
+const _ebjyl2 = function _theme_properties(css){return(
 (() => {
-    const props = {};
-    for (const [url, text] of css) {
-        if (typeof text !== 'string')
-            continue;
-        for (const match of text.matchAll(/^\s+(--[a-z0-9-]+)\s*:\s*([^;]+);/gm)) {
-            props[match[1]] = match[2].trim();
-        }
+  const props = {};
+  for (const [url, text] of css) {
+    if (typeof text !== 'string')
+      continue;
+    for (const match of text.matchAll(/^\s+(--[a-z0-9-]+)\s*:\s*([^;]+);/gm)) {
+      props[match[1]] = match[2].trim();
     }
-    return props;
+  }
+  return props;
 })()
 )};
 const _iny180 = function _9(md){return(
 md`## Implementation`
 )};
-const _vhnhz5 = function _themes()
+const _p0at3d = function _themes()
 {
-    const baseURL = 'https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/';
-    return new Map(Object.entries({
-        air: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-air.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        coffee: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-coffee.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        cotton: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-cotton.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        'deep-space': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-deep-space.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        glacier: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-glacier.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        ink: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-ink.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        midnight: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-midnight.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'near-midnight': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-near-midnight.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'ocean-floor': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-ocean-floor.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        parchment: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-parchment.css',
-            baseURL + 'abstract-light.css',
-            baseURL + 'syntax-light.css'
-        ],
-        slate: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-slate.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        stark: [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-stark.css',
-            baseURL + 'syntax-dark.css'
-        ],
-        'sun-faded': [
-            baseURL + 'global.css',
-            baseURL + 'inspector.css',
-            baseURL + 'highlight.css',
-            baseURL + 'plot.css',
-            baseURL + 'index.css',
-            baseURL + 'theme-sun-faded.css',
-            baseURL + 'abstract-dark.css',
-            baseURL + 'syntax-dark.css'
-        ]
-    }));
+  const baseURL = 'https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/';
+  return new Map(Object.entries({
+    air: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-air.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    coffee: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-coffee.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    cotton: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-cotton.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    'deep-space': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-deep-space.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    glacier: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-glacier.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    ink: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-ink.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    midnight: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-midnight.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'near-midnight': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-near-midnight.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'ocean-floor': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-ocean-floor.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    parchment: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-parchment.css',
+      baseURL + 'abstract-light.css',
+      baseURL + 'syntax-light.css'
+    ],
+    slate: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-slate.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    stark: [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-stark.css',
+      baseURL + 'syntax-dark.css'
+    ],
+    'sun-faded': [
+      baseURL + 'global.css',
+      baseURL + 'inspector.css',
+      baseURL + 'highlight.css',
+      baseURL + 'plot.css',
+      baseURL + 'index.css',
+      baseURL + 'theme-sun-faded.css',
+      baseURL + 'abstract-dark.css',
+      baseURL + 'syntax-dark.css'
+    ]
+  }));
 };
-const _iq48k6 = function _cssForTheme(themes,extra_css){return(
+const _m8taeu = function _cssForTheme(themes,extra_css){return(
 async theme => [
-    ...await Promise.all(themes.get(theme).map(async url => [
-        url,
-        await (await fetch(url)).text()
-    ])),
-    extra_css
+  ...await Promise.all(themes.get(theme).map(async url => [
+    url,
+    await (await fetch(url)).text()
+  ])),
+  extra_css
 ]
 )};
-const _e3ckjw = async function _css(theme_assets,extra_css){return(
+const _yqy56c = async function _css(theme_assets,extra_css){return(
 [
-    ...await Promise.all(theme_assets.map(async url => [
-        url,
-        await (await fetch(url)).text()
-    ])),
-    extra_css
+  ...await Promise.all(theme_assets.map(async url => [
+    url,
+    await (await fetch(url)).text()
+  ])),
+  extra_css
 ]
 )};
-const _d7mxvx = function _extra_css(){return(
-[
+const _17wrwba = function _extra_css()
+{
+  // Only on ObservableHQ (the observableusercontent.com sandbox) do we bridge
+  // the theme vars onto the underscore '--syntax_*' vars that Observable's
+  // editor + inspector read. Off Observable we omit it so notebook authors use
+  // the real --theme-* / --syntax-* vars, not these compatibility aliases.
+  // Predicate mirrors @tomlarkworthy/runtime-sdk's isOnObservableCom.
+  const onObservable = window.location.href.includes('observableusercontent.com') && !window.location.href.includes('blob:');
+  const observableSyntaxBridge = onObservable ? `
+:root {
+  /* notebook-kit themes omit --syntax-normal (hyphen), so Observable's
+     "next" inspector falls back to its hardcoded #1b1e23 on
+     .observablehq--function/--gray/--expanded/etc. Alias just this one;
+     the other --syntax-* hyphen vars are already theme-defined (don't
+     re-alias them — that would self-reference). */
+  --syntax-normal: var(--theme-foreground, #1b1e23);
+  --syntax_normal: var(--theme-foreground, #1b1e23);
+  --syntax_comment: var(--syntax-comment, #a9b0bc);
+  --syntax_number: var(--syntax-literal, #20a5ba);
+  --syntax_keyword: var(--syntax-keyword, #c30771);
+  --syntax_atom: var(--syntax-atom, #10a778);
+  --syntax_string: var(--syntax-string, #008ec4);
+  --syntax_error: var(--syntax-invalid, var(--theme-foreground-error, #ffbedc));
+  --syntax_unknown_variable: var(--syntax-variable, #838383);
+  --syntax_known_variable: var(--syntax-definition, #005f87);
+  --syntax_matchbracket: var(--syntax-keyword, #20bbfc);
+  --syntax_key: var(--syntax-definition, #6636b4);
+}
+` : '';
+  return [
     'file://syntax.css',
-    `
+    observableSyntaxBridge + `
 /* Center page */
 .lopecode-visualizer {
     max-width: 1200px;
@@ -26361,8 +27895,8 @@ const _d7mxvx = function _extra_css(){return(
 .hljs-addition {
   color: var(--syntax-string);
 }`
-]
-)};
+  ];
+};
 const _rijq1n = function _current_theme(themes){return(
 [...themes.values()].find(assets => assets.every(url => document.getElementById(url)))
 )};
@@ -26374,19 +27908,19 @@ export default function define(runtime, observer) {
   };
 
   $def("_1yy5rbo", null, ["md"], _1yy5rbo);  
-  $def("_1clcodb", "viewof theme_assets", ["Inputs","themes","current_theme"], _1clcodb);  
+  $def("_x91dc7", "viewof theme_assets", ["Inputs","themes","current_theme"], _x91dc7);  
   $def("_1sdw5pf", "theme_assets", ["Generators","viewof theme_assets"], _1sdw5pf);  
   $def("_1wzah21", "theme_name", ["themes","theme_assets"], _1wzah21);  
-  $def("_1mut3rc", "apply_theme", ["css","themes","theme_assets","html"], _1mut3rc);  
-  $def("_11pe38r", null, ["theme_properties","html","htl","theme_name"], _11pe38r);  
+  $def("_zy6iu8", "apply_theme", ["css","themes","theme_assets","html"], _zy6iu8);  
+  $def("_10zmng3", null, ["theme_properties","html","htl","theme_name"], _10zmng3);  
   $def("_1txjoje", null, ["md"], _1txjoje);  
-  $def("_1hu8vay", null, ["htl","theme_properties","html"], _1hu8vay);  
-  $def("_1k4keny", "theme_properties", ["css"], _1k4keny);  
+  $def("_18nx47m", null, ["htl","theme_properties","html"], _18nx47m);  
+  $def("_ebjyl2", "theme_properties", ["css"], _ebjyl2);  
   $def("_iny180", null, ["md"], _iny180);  
-  $def("_vhnhz5", "themes", [], _vhnhz5);  
-  $def("_iq48k6", "cssForTheme", ["themes","extra_css"], _iq48k6);  
-  $def("_e3ckjw", "css", ["theme_assets","extra_css"], _e3ckjw);  
-  $def("_d7mxvx", "extra_css", [], _d7mxvx);  
+  $def("_p0at3d", "themes", [], _p0at3d);  
+  $def("_m8taeu", "cssForTheme", ["themes","extra_css"], _m8taeu);  
+  $def("_yqy56c", "css", ["theme_assets","extra_css"], _yqy56c);  
+  $def("_17wrwba", "extra_css", [], _17wrwba);  
   $def("_rijq1n", "current_theme", ["themes"], _rijq1n);
   return main;
 }</script>
@@ -28270,7 +29804,7 @@ const _1xdl683 = function _renderImportCell(navHref){return(
   return span;
 }
 )};
-const _17pe3vk = function _syncers(observe,inspectors,$0,liveCellMap,createImportCellHeader,renderImportCell,variablesForCell,visualizers,$1)
+const _bbb3dg = function _syncers(observe,inspectors,$0,liveCellMap,createImportCellHeader,renderImportCell,variablesForCell,visualizers,$1)
 {
   const syncers = this || new Map();
 
@@ -28306,7 +29840,14 @@ const _17pe3vk = function _syncers(observe,inspectors,$0,liveCellMap,createImpor
       root,
       remove: () => {
         observers.delete(v);
-        observer?._node?.remove?.();
+        const node = observer?._node;
+        if (node) {
+          // Detach the variable's live element value
+          const val = v?._value;
+          if (val && val.nodeType && val.parentNode === node)
+            node.removeChild(val);
+          node.remove();
+        }
         unobserve?.();
       }
     };
@@ -28484,7 +30025,7 @@ export default function define(runtime, observer) {
   $def("_zodkh8", "createImportCellHeader", [], _zodkh8);  
   $def("_526jo", "variablesForCell", [], _526jo);  
   $def("_1xdl683", "renderImportCell", ["navHref"], _1xdl683);  
-  $def("_17pe3vk", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _17pe3vk);  
+  $def("_bbb3dg", "syncers", ["observe","inspectors","viewof visualizersToDelete","liveCellMap","createImportCellHeader","renderImportCell","variablesForCell","visualizers","viewof visualizers"], _bbb3dg);  
   $def("_een5pq", null, ["md"], _een5pq);  
   $def("_1wiz55o", "backgroundJobs", ["keepalive","visualizerModule"], _1wiz55o);  
   $def("_1oonsyz", "viewof visualizerModule", ["thisModule"], _1oonsyz);  
@@ -28565,167 +30106,6 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/invoke-variable" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _zkje0r = function _1(md){return(
-md`# \`invokeVariable(<name>, <module>, overrides = {})\`
-
-Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
-)};
-const _kfe4ll = function _invokeVariable(lookupVariable){return(
-async function invokeVariable(name, module, overrides = {}) {
-  if (overrides == null || typeof overrides !== "object")
-    throw new TypeError(
-      "invokeVariable(name, module, {overrides}): overrides must be an object"
-    );
-
-  // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
-  // the caller already holds it); otherwise resolve by (name, module).
-  let variable;
-  if (name && typeof name === "object" && typeof name._definition !== "undefined") {
-    variable = name;
-    module = module ?? variable._module;
-  } else {
-    if (typeof name !== "string" || !name.length)
-      throw new TypeError(
-        "invokeVariable(name, module, …): name must be a non-empty string"
-      );
-    if (!module)
-      throw new TypeError("invokeVariable(name, module, …): module is required");
-    variable = await lookupVariable(name, module);
-    if (!variable)
-      throw new Error(`invokeVariable: variable "${name}" not found in module`);
-  }
-  module = module ?? variable._module;
-  const label = variable._name ?? (typeof name === "string" ? name : "(anonymous)");
-
-  const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
-  const inputNames = inputs.map((v) => v?._name);
-
-  for (const k of Object.keys(overrides)) {
-    if (!inputNames.includes(k)) {
-      throw new Error(
-        `invokeVariable("${label}"): override "${k}" was provided but is not a declared dependency. Declared dependencies: ${inputNames
-          .filter(Boolean)
-          .join(", ")}`
-      );
-    }
-  }
-
-  const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
-
-  const resolveDependency = async (depName) => {
-    if (hasOwn(overrides, depName)) return overrides[depName];
-
-    const scopeVar =
-      module?._scope?.get?.(depName) ??
-      module?._runtime?._builtin?._scope?.get?.(depName);
-
-    if (scopeVar) {
-      if (scopeVar._value !== undefined) return scopeVar._value;
-      if (scopeVar._promise && typeof scopeVar._promise?.then === "function")
-        return await scopeVar._promise;
-    }
-
-    if (typeof module?.value === "function") {
-      try {
-        return await module.value(depName);
-      } catch (e) {}
-    }
-
-    if (module?._runtime && typeof module._runtime._global === "function") {
-      try {
-        const g = module._runtime._global(depName);
-        if (g !== undefined) return g;
-      } catch (e) {}
-    }
-
-    throw new Error(
-      `invokeVariable("${label}"): could not resolve dependency "${depName}" (no override and not found in module/builtins/global)`
-    );
-  };
-
-  const args = [];
-  for (const dep of inputs) {
-    const depName = dep?._name;
-    if (!depName) {
-      args.push(undefined);
-      continue;
-    }
-    args.push(await resolveDependency(depName));
-  }
-
-  const def = variable._definition;
-  if (typeof def !== "function") {
-    throw new Error(
-      `invokeVariable("${label}"): target variable does not have an invokable function definition`
-    );
-  }
-  return def(...args);
-}
-)};
-const _jtrr9m = function _3(md){return(
-md`### Example
-
-let c = a + b`
-)};
-const _1v2c0s1 = function _a(){return(
-1
-)};
-const _ywl8oh = function _b(){return(
-3
-)};
-const _1mc3tpl = function _c(a,b){return(
-a + b
-)};
-const _o5e50u = function _7(md){return(
-md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
-)};
-const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule)
-)};
-const _smh5by = function _9(md){return(
-md`But we can set b to 20, and then we get the answer 21.`
-)};
-const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule, { b: 20 })
-)};
-const _qh0yhm = function _11(md){return(
-md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
-)};
-const _1hy0qcz = function _invokeVariableModule(thisModule){return(
-thisModule()
-)};
-const _jno7wc = (G, _) => G.input(_);
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_zkje0r", null, ["md"], _zkje0r);  
-  $def("_kfe4ll", "invokeVariable", ["lookupVariable"], _kfe4ll);  
-  $def("_jtrr9m", null, ["md"], _jtrr9m);  
-  $def("_1v2c0s1", "a", [], _1v2c0s1);  
-  $def("_ywl8oh", "b", [], _ywl8oh);  
-  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
-  $def("_o5e50u", null, ["md"], _o5e50u);  
-  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
-  $def("_smh5by", null, ["md"], _smh5by);  
-  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
-  $def("_qh0yhm", null, ["md"], _qh0yhm);  
-  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
-  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
-  return main;
-}
-</script>
-
 <!-- Bootloader -->
 <script id="bootconf.json"
         type="text/plain"
@@ -28790,68 +30170,68 @@ function _define_builtins(__ojs_runtime,stdlib,library,inputs)
 
 function _boot(define_builtins,conf,__ojs_runtime,location,__ojs_observer)
 {
-  define_builtins;
-  const tickMode = conf.tick;
-  if (tickMode && tickMode !== 'raf') {
-    let tick;
-    if (tickMode === 'messageChannel') {
-      const ch = new window.MessageChannel();
-      const q = [];
-      ch.port1.onmessage = () => {
-        const f = q.shift();
-        if (f)
-          f();
-      };
-      tick = cb => {
-        q.push(cb);
-        ch.port2.postMessage(0);
-      };
-    } else if (tickMode === 'microtask') {
-      tick = cb => window.queueMicrotask(cb);
-    } else if (tickMode === 'timeout') {
-      const delay = Number(conf.tickDelayMs) || 0;
-      tick = cb => setTimeout(cb, delay);
-    } else {
-      console.warn('[bootloader] unknown tick mode: ' + tickMode);
-    }
-    if (tick) {
-      const Runtime = Object.getPrototypeOf(__ojs_runtime).constructor;
-      Runtime.prototype._computeSoon = function () {
-        return new Promise(tick).then(() => this._disposed ? undefined : this._computeNow());
-      };
-      const suffix = tickMode === 'timeout' ? ' delayMs=' + (Number(conf.tickDelayMs) || 0) : '';
-      console.log('[bootloader] tick=' + tickMode + suffix);
-    }
-  }
-  if (conf.hash && !location.hash) {
-    location.hash = conf.hash;
-  }
-  const observer = conf.headless ? () => ({}) : __ojs_observer;
-  __ojs_runtime.mains = new Map();
-  window.__ojs_runtime = __ojs_runtime;
-  conf.mains.map(async name => {
-    console.log(`Bootloader: loading ${ name }`);
-    const module = await import(name);
-    const ojs_module = __ojs_runtime.module(module.default, observer);
-    if (conf.headless) {
-        // runtime.module() applies the observer only on first instantiation; if another main
-        // imported this module as a dependency first (e.g. save-in-place imports lopepage-2),
-        // the dedup drops the observer and the page's output cell is never observed -> blank
-        // page. Re-observe the module's unobserved cells IN PLACE (set the observer + mark
-        // dirty so the reachability pass enqueues them) so the mount is reachable regardless
-        // of load order, without adding synthetic variables the exporter would serialize.
-        let __reobserved = false;
-        for (const __v of __ojs_runtime._variables) {
-            if (__v._module === ojs_module && typeof __v._observer === 'symbol') {
-                __v._observer = observer(__v._name);
-                __ojs_runtime._dirty.add(__v);
-                __reobserved = true;
-            }
+    define_builtins;
+    const tickMode = conf.tick;
+    if (tickMode && tickMode !== 'raf') {
+        let tick;
+        if (tickMode === 'messageChannel') {
+            const ch = new window.MessageChannel();
+            const q = [];
+            ch.port1.onmessage = () => {
+                const f = q.shift();
+                if (f)
+                    f();
+            };
+            tick = cb => {
+                q.push(cb);
+                ch.port2.postMessage(0);
+            };
+        } else if (tickMode === 'microtask') {
+            tick = cb => window.queueMicrotask(cb);
+        } else if (tickMode === 'timeout') {
+            const delay = Number(conf.tickDelayMs) || 0;
+            tick = cb => setTimeout(cb, delay);
+        } else {
+            console.warn('[bootloader] unknown tick mode: ' + tickMode);
         }
-        if (__reobserved) __ojs_runtime._compute();
+        if (tick) {
+            const Runtime = Object.getPrototypeOf(__ojs_runtime).constructor;
+            Runtime.prototype._computeSoon = function () {
+                return new Promise(tick).then(() => this._disposed ? undefined : this._computeNow());
+            };
+            const suffix = tickMode === 'timeout' ? ' delayMs=' + (Number(conf.tickDelayMs) || 0) : '';
+            console.log('[bootloader] tick=' + tickMode + suffix);
+        }
     }
-    __ojs_runtime.mains.set(name, ojs_module);
-  });
+    if (conf.hash && !location.hash) {
+        location.hash = conf.hash;
+    }
+    const observer = conf.headless ? () => ({}) : __ojs_observer;
+    __ojs_runtime.mains = new Map();
+    window.__ojs_runtime = __ojs_runtime;
+    conf.mains.map(async name => {
+        console.log(`Bootloader: loading ${ name }`);
+        const module = await import(name);
+        const ojs_module = __ojs_runtime.module(module.default, observer);
+        if (conf.headless) {
+            // runtime.module() applies the observer only on first instantiation; if another main
+            // imported this module as a dependency first (e.g. save-in-place imports lopepage-2),
+            // the dedup drops the observer and the page's output cell is never observed -> blank
+            // page. Re-observe the module's unobserved cells IN PLACE (set the observer + mark
+            // dirty so the reachability pass enqueues them) so the mount is reachable regardless
+            // of load order, without adding synthetic variables the exporter would serialize.
+            let __reobserved = false;
+            for (const __v of __ojs_runtime._variables) {
+                if (__v._module === ojs_module && typeof __v._observer === 'symbol') {
+                    __v._observer = observer(__v._name);
+                    __ojs_runtime._dirty.add(__v);
+                    __reobserved = true;
+                }
+            }
+            if (__reobserved) __ojs_runtime._compute();
+        }
+        __ojs_runtime.mains.set(name, ojs_module);
+    });
 }
 
 
@@ -29038,31 +30418,6 @@ export default function define(runtime, observer) {
 }
 </script>
 
-<script type="module" id="main">
-  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").text().then(src => {
-    const script = document.createElement('script');
-    script.textContent = src;
-    document.head.appendChild(script);
-  });
-
-  const style0 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css", { with: { type: 'css' } });
-  const style1 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/inspector.css", { with: { type: 'css' } });
-  const style2 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/highlight.css", { with: { type: 'css' } });
-  const style3 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/plot.css", { with: { type: 'css' } });
-  const style4 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/index.css", { with: { type: 'css' } });
-  const style5 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/theme-parchment.css", { with: { type: 'css' } });
-  const style6 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-light.css", { with: { type: 'css' } });
-  const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-light.css", { with: { type: 'css' } });
-  const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
-  document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
-
-  const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
-  const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
-  const notebook = document.querySelector("notebook");
-  const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
-  const observer = Inspector.into(document.body);
-  const {default: define} = await importShim("@tomlarkworthy/bootloader");
-  runtime.bootloader = runtime.module(define, () => ({}));
-</script>
+<script id="streaming_sentinel">window.__lopeStreaming = false;</script>
 </body>
 </html>

--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -5405,6 +5405,13 @@ import {md} from "@tomlarkworthy/editable-md"
 
 Template interpolation works! You can bring other notebook values into the text with \`\${<expr>}\`. For example, the value of the slider is: ${control}
 
+GFM tables are editable too — click a cell, TAB moves to the next one:
+
+| feature | editable | notes |
+| :--- | :---: | ---: |
+| paragraphs | yes | since v1 |
+| tables | yes | alignment survives |
+
 After an update (keyboard shortcut SHIFT + ENTER), the markdown is parsed back into the tagged template representation and pushed back into the runtime. Runtime serializers like [exporter](https://observablehq.com/@tomlarkworthy/exporter-3) and [Lopecode](https://github.com/tomlarkworthy/lopecode) will pick up the changes next export.`
 )};
 const _1drzw1m = function _control(Inputs){return(
@@ -5426,7 +5433,7 @@ md`## Known Issues
 
 - escaped tagged template literal lose their escaping if they are not in a code block. This is due to \`prosemirror.defaultMarkdownParser.parse(markdown)\` removing redundant escapes. We should probably make template placeholders a 1st class concept but as there is an easy work around of putting them in a code fence it is enough for now. (see [\`test_defaultMarkdownParser_preserves_escapes\`](#test_defaultMarkdownParser_preserves_escapes))`
 )};
-const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,originalMd,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,linkifyPastedUrl,invalidation)
+const _1z4iyw = function _md(editor_theme_css,prosemirror,editableSchema,Element,randstr,originalMd,editableMarkdownSerializer,markdownToMdTagged,compile,runtime,decompile,mdCellSourceToMarkdown,editableMarkdownParser,linkifyPastedUrl,invalidation)
 {
   // Force the theme override stylesheet to be evaluated and inserted.
   editor_theme_css;
@@ -5436,7 +5443,7 @@ const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,origin
   //       for a URL/data URL which isn't reachable from inside a lopecode
   //       notebook; a working version would attach the picked image as a
   //       file-attachment and emit an `${FileAttachment(...)}` placeholder.
-  const menuItems = prosemirror.buildMenuItems(prosemirror.schema);
+  const menuItems = prosemirror.buildMenuItems(editableSchema);
   const insertMenu = new prosemirror.Dropdown([menuItems.insertHorizontalRule].filter(Boolean), { label: 'Insert' });
   const menuContent = menuItems.inlineMenu.concat([[
       insertMenu,
@@ -5470,8 +5477,13 @@ const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,origin
     return prosemirror.inputRules({ rules });
   };
   const editorPlugins = [
-    buildEditorInputRules(prosemirror.schema),
-    prosemirror.keymap(prosemirror.buildKeymap(prosemirror.schema)),
+    // Table cell navigation must beat baseKeymap, so it goes first.
+    prosemirror.keymap({
+      Tab: prosemirror.goToNextCell(1),
+      'Shift-Tab': prosemirror.goToNextCell(-1)
+    }),
+    buildEditorInputRules(editableSchema),
+    prosemirror.keymap(prosemirror.buildKeymap(editableSchema)),
     prosemirror.keymap(prosemirror.baseKeymap),
     prosemirror.dropCursor(),
     prosemirror.gapCursor(),
@@ -5480,6 +5492,7 @@ const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,origin
       content: menuContent
     }),
     prosemirror.history(),
+    prosemirror.tableEditing(),
     new prosemirror.Plugin({ props: { attributes: { class: 'ProseMirror-example-setup-style' } } })
   ];
   const isInteractiveTarget = (event, root) => {
@@ -5520,7 +5533,7 @@ const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,origin
     let view;
     let self;
     function saveAndRender() {
-      const markdown = prosemirror.defaultMarkdownSerializer.serialize(view.state.doc);
+      const markdown = editableMarkdownSerializer.serialize(view.state.doc);
       const template = markdownToMdTagged(markdown);
       const variables = compile(template);
       self._inputs = variables[0]._inputs.map(n => self._module._resolve(n));
@@ -5545,10 +5558,10 @@ const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,origin
           dom.addEventListener('focusout', lostFocus);
           const ojs_source = await decompile([self]);
           const markdown = mdCellSourceToMarkdown(ojs_source);
-          const doc = prosemirror.defaultMarkdownParser.parse(markdown);
+          const doc = editableMarkdownParser.parse(markdown);
           const state = prosemirror.EditorState.create({
             doc,
-            schema: prosemirror.schema,
+            schema: editableSchema,
             plugins: editorPlugins
           });
           dom.innerHTML = '';
@@ -5594,6 +5607,99 @@ const _1z4iyw = function _md(editor_theme_css,prosemirror,Element,randstr,origin
     Object.defineProperty(dom, 'markdown', { get: () => selfPromise.then(self => decompile([self])).then(ojs_source => mdCellSourceToMarkdown(ojs_source)) });
     return dom;
   };
+};
+const _1t782yk = function _editableSchema(prosemirror){return(
+new prosemirror.Schema({
+  nodes: prosemirror.schema.spec.nodes.append(
+    prosemirror.tableNodes({
+      tableGroup: "block",
+      cellContent: "inline*",
+      cellAttributes: {
+        align: {
+          default: null,
+          getFromDOM: (dom) => dom.style.textAlign || null,
+          setDOMAttr: (value, attrs) => {
+            if (value) attrs.style = "text-align:" + value;
+          }
+        }
+      }
+    })
+  ),
+  marks: prosemirror.schema.spec.marks
+})
+)};
+const _ug01ne = function _editableMarkdownParser(prosemirror,editableSchema)
+{
+  // The default parser runs markdown-it's commonmark preset, which has no table
+  // rule, so a GFM pipe table collapses into one paragraph of softbreaks.
+  const MarkdownIt = prosemirror.defaultMarkdownParser.tokenizer.constructor;
+  const tokenizer = new MarkdownIt("commonmark", { html: false }).enable("table");
+  const alignOf = (tok) => {
+    const style = tok.attrGet && tok.attrGet("style");
+    const m = style && /text-align\s*:\s*(left|center|right)/.exec(style);
+    return m ? m[1] : null;
+  };
+  const tokens = Object.assign({}, prosemirror.defaultMarkdownParser.tokens, {
+    table: { block: "table" },
+    thead: { ignore: true },
+    tbody: { ignore: true },
+    tr: { block: "table_row" },
+    th: { block: "table_header", getAttrs: (tok) => ({ align: alignOf(tok) }) },
+    td: { block: "table_cell", getAttrs: (tok) => ({ align: alignOf(tok) }) }
+  });
+  return new prosemirror.MarkdownParser(editableSchema, tokenizer, tokens);
+};
+const _o4sxix = function _editableMarkdownSerializer(prosemirror)
+{
+  // Render a cell's inline content to a string by borrowing the live state's
+  // output buffer, then rewinding it. delim is suppressed so a table nested in a
+  // blockquote/list does not pick up the "> " prefix mid-cell.
+  const cellText = (state, cell) => {
+    const delim = state.delim;
+    state.delim = "";
+    const start = state.out.length;
+    state.renderInline(cell);
+    const text = state.out.slice(start);
+    state.out = state.out.slice(0, start);
+    state.delim = delim;
+    return text.replace(/\n/g, " ").replace(/\|/g, "\\|").trim();
+  };
+  const nodes = Object.assign({}, prosemirror.defaultMarkdownSerializer.nodes, {
+    table(state, node) {
+      // Flush the pending block separator before measuring cells, otherwise it
+      // lands inside the first cell's text and is rewound away.
+      state.flushClose();
+      const rows = [];
+      node.forEach((row) => {
+        const cells = [];
+        row.forEach((cell) =>
+          cells.push({ text: cellText(state, cell), align: cell.attrs.align })
+        );
+        rows.push(cells);
+      });
+      if (!rows.length) return;
+      const width = Math.max(...rows.map((r) => r.length));
+      const line = (cells) =>
+        "| " +
+        Array.from({ length: width }, (_, i) => (cells[i] && cells[i].text) || " ").join(" | ") +
+        " |";
+      const rule = Array.from({ length: width }, (_, i) => {
+        const a = rows[0][i] && rows[0][i].align;
+        return a === "center" ? ":---:" : a === "right" ? "---:" : a === "left" ? ":---" : "---";
+      });
+      const lines = [line(rows[0]), "| " + rule.join(" | ") + " |"].concat(
+        rows.slice(1).map(line)
+      );
+      // Write line by line so a nested table picks up the block delimiter on
+      // each row; no trailing newline, closeBlock owns the block separation.
+      lines.forEach((l, i) => state.write(i < lines.length - 1 ? l + "\n" : l));
+      state.closeBlock(node);
+    },
+    table_row() {},
+    table_cell() {},
+    table_header() {}
+  });
+  return new prosemirror.MarkdownSerializer(nodes, prosemirror.defaultMarkdownSerializer.marks);
 };
 const _etlb83 = function _irToEditableText(){return(
 function irToEditableText(ir) {
@@ -5772,11 +5878,12 @@ function isPasteableUrl(text) {
   return /^(https?:\/\/|mailto:)\S+$/i.test(s);
 }
 )};
-const _2mqz8v = function _linkifyPastedUrl(prosemirror,isPasteableUrl){return(
+const _2mqz8v = function _linkifyPastedUrl(isPasteableUrl){return(
 function linkifyPastedUrl(view, event) {
   // Pasting a URL over a selection links the selection instead of replacing it.
   // Returns true when handled, so prosemirror skips its default paste.
-  const linkType = prosemirror.schema.marks.link;
+  // Mark types are per-schema, so take it from the view's own schema.
+  const linkType = view.state.schema.marks.link;
   if (!linkType) return false;
   const text = event.clipboardData && event.clipboardData.getData("text/plain");
   if (!isPasteableUrl(text)) return false;
@@ -5794,7 +5901,8 @@ const _3kmqp1 = function _escapeMarkdownInline(){return(
 function escapeMarkdownInline(text) {
   // Mirrors the character set prosemirror's defaultMarkdownSerializer escapes inline,
   // so escape/unescape are exact inverses across a parse+serialize round trip.
-  return text.replace(/[\\`*~\[\]_]/g, (c) => "\\" + c);
+  // `|` is included so a placeholder inside a table cell is not split at a pipe.
+  return text.replace(/[\\`*~\[\]_|]/g, (c) => "\\" + c);
 }
 )};
 const _9wq3vz = function _unescapeMarkdownInline(){return(
@@ -5896,6 +6004,31 @@ const _9lnk2b = function _test_link_survives_round_trip(expect,mdCellSourceToMar
   expect(template).toBe("md`see [the docs](https://example.com/a_b) here`");
   expect(compile(template)[0]._inputs).toContain("md");
 };
+const _1g67rxt = function _test_table_round_trip(mdCellSourceToMarkdown,editableMarkdownParser,expect,editableMarkdownSerializer,markdownToMdTagged)
+{
+  // The reported bug: a GFM table came back as a single paragraph of pipes
+  // because the default parser has no table rule, destroying the table.
+  const CELL = "t = md`Before\n\n| a | b |\n| :-- | --: |\n| 1 | *x* |\n\nAfter`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const doc = editableMarkdownParser.parse(markdown);
+  expect(doc.content.content.map((n) => n.type.name)).toEqual(["paragraph", "table", "paragraph"]);
+  const serialized = editableMarkdownSerializer.serialize(doc);
+  expect(serialized).toBe("Before\n\n| a | b |\n| :--- | ---: |\n| 1 | *x* |\n\nAfter");
+  // Stable under a second round trip, so repeated edits do not drift.
+  expect(editableMarkdownSerializer.serialize(editableMarkdownParser.parse(serialized))).toBe(serialized);
+  expect(markdownToMdTagged(serialized)).toBe("md`" + serialized + "`");
+};
+const _5f1lir = function _test_table_placeholder_round_trip(mdCellSourceToMarkdown,editableMarkdownSerializer,editableMarkdownParser,markdownToMdTagged,expect,compile)
+{
+  // A `${...}` placeholder inside a table cell must survive, pipes and all.
+  const CELL = "t = md`| v | expr |\n| --- | --- |\n| ${a || b} | ${f(x, [y])} |`";
+  const markdown = mdCellSourceToMarkdown(CELL);
+  const serialized = editableMarkdownSerializer.serialize(editableMarkdownParser.parse(markdown));
+  const template = markdownToMdTagged(serialized);
+  expect(template).toBe("md`| v | expr |\n| --- | --- |\n| ${a || b} | ${f(x, [y])} |`");
+  expect(compile(template)[0]._inputs).toContain("a");
+  expect(compile(template)[0]._inputs).toContain("f");
+};
 const _2dh7y5 = function _test_defaultMarkdownParser_preserves_escapes(prosemirror,expect)
 {
   const result = prosemirror.defaultMarkdownParser.parse("\\${}");
@@ -5971,8 +6104,11 @@ export default function define(runtime, observer) {
   $def("_t5sezz", null, ["md"], _t5sezz);  
   $def("_1lfncpk", null, ["title"], _1lfncpk);  
   $def("_u4o7gp", null, ["md"], _u4o7gp);  
-  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","Element","randstr","originalMd","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","linkifyPastedUrl","invalidation"], _1z4iyw);
-  $def("_etlb83", "irToEditableText", [], _etlb83);  
+  $def("_1z4iyw", "md", ["editor_theme_css","prosemirror","editableSchema","Element","randstr","originalMd","editableMarkdownSerializer","markdownToMdTagged","compile","runtime","decompile","mdCellSourceToMarkdown","editableMarkdownParser","linkifyPastedUrl","invalidation"], _1z4iyw);
+  $def("_1t782yk", "editableSchema", ["prosemirror"], _1t782yk);
+  $def("_ug01ne", "editableMarkdownParser", ["prosemirror","editableSchema"], _ug01ne);
+  $def("_o4sxix", "editableMarkdownSerializer", ["prosemirror"], _o4sxix);
+  $def("_etlb83", "irToEditableText", [], _etlb83);
   $def("_bpew19", "replaceArgPlaceholders", [], _bpew19);  
   main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
   $def("_n2jvwt", null, ["md"], _n2jvwt);  
@@ -5983,7 +6119,7 @@ export default function define(runtime, observer) {
   $def("_1060b9b", "tokenizeMarkdownTemplate", ["unescapeMarkdownInline"], _1060b9b);
   $def("_8wivof", "escapeTemplateChunk", [], _8wivof);
   $def("_7pk3xw", "isPasteableUrl", [], _7pk3xw);
-  $def("_2mqz8v", "linkifyPastedUrl", ["prosemirror","isPasteableUrl"], _2mqz8v);
+  $def("_2mqz8v", "linkifyPastedUrl", ["isPasteableUrl"], _2mqz8v);
   $def("_3kmqp1", "escapeMarkdownInline", [], _3kmqp1);
   $def("_9wq3vz", "unescapeMarkdownInline", [], _9wq3vz);
   $def("_150iump", "randstr", [], _150iump);
@@ -5998,6 +6134,8 @@ export default function define(runtime, observer) {
   $def("_5vqw7d", "test_escapeMarkdownInline_inverse", ["expect","escapeMarkdownInline","unescapeMarkdownInline"], _5vqw7d);
   $def("_9lnk1a", "test_isPasteableUrl", ["expect","isPasteableUrl"], _9lnk1a);
   $def("_9lnk2b", "test_link_survives_round_trip", ["expect","mdCellSourceToMarkdown","prosemirror","markdownToMdTagged","compile"], _9lnk2b);
+  $def("_1g67rxt", "test_table_round_trip", ["mdCellSourceToMarkdown","editableMarkdownParser","expect","editableMarkdownSerializer","markdownToMdTagged"], _1g67rxt);
+  $def("_5f1lir", "test_table_placeholder_round_trip", ["mdCellSourceToMarkdown","editableMarkdownSerializer","editableMarkdownParser","markdownToMdTagged","expect","compile"], _5f1lir);
   $def("_2dh7y5", "test_defaultMarkdownParser_preserves_escapes", ["prosemirror","expect"], _2dh7y5);
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("originalMd", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("md", "originalMd", _));  

--- a/notebooks/@tomlarkworthy_editable-md.json
+++ b/notebooks/@tomlarkworthy_editable-md.json
@@ -22,6 +22,31 @@
     "@observablehq/inspector@5.0.1": {
       "hash": "5658858e85affa2e1e5cd1052924c622"
     },
+    "@tomlarkworthy/editable-md": {
+      "hash": "6e1ff9ab9923273c21b822022c3d538f",
+      "dependsOn": [
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/observablejs-toolchain",
+        "@tomlarkworthy/prosemirror",
+        "@tomlarkworthy/jest-expect-standalone"
+      ]
+    },
+    "@tomlarkworthy/lopepage": {
+      "hash": "633f78d13e1da2ee746dc2c8598b5a24",
+      "dependsOn": [
+        "@tomlarkworthy/golden-layout-2-6-0",
+        "@tomlarkworthy/visualizer",
+        "@tomlarkworthy/module-selection",
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3",
+        "d/57d79353bac56631@44",
+        "@tomlarkworthy/local-change-history",
+        "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/command-palette"
+      ]
+    },
     "@mbostock/safe-local-storage": {
       "hash": "937d252019887842c8c48c634b76179a",
       "dependedBy": [
@@ -35,9 +60,10 @@
       ]
     },
     "@tomlarkworthy/acorn-8-11-3": {
-      "hash": "cfbb603f9923f42e480bcc24ea214eb4",
+      "hash": "7d7821979f30fc573f0305942ef16d3a",
       "files": [
-        "acorn-8.11.3.js.gz"
+        "acorn-8.11.3.js.gz",
+        "acorn-walk-8.3.2.js.gz"
       ],
       "dependedBy": [
         "@tomlarkworthy/observablejs-toolchain"
@@ -63,13 +89,13 @@
       ]
     },
     "@tomlarkworthy/cells-to-clipboard": {
-      "hash": "eee8d9f598d697409bb1296662d8bc06",
+      "hash": "7af7898b237728b52ea24b568ad2fd32",
       "dependedBy": [
         "@tomlarkworthy/editor-5"
       ]
     },
     "@tomlarkworthy/claude-code-pairing": {
-      "hash": "9ef62cada1525cf5d4987907f0362236",
+      "hash": "8cdd769d2694a74bad1003b20625a618",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -94,11 +120,13 @@
       ]
     },
     "@tomlarkworthy/command-palette": {
-      "hash": "4b7ce022a1bc9a4affa98c47552f828d",
+      "hash": "a3617c1f57904cbab42a34b069bf092a",
       "dependsOn": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
-        "@tomlarkworthy/themes"
+        "@tomlarkworthy/themes",
+        "@tomlarkworthy/module-map",
+        "@tomlarkworthy/plugin-registry"
       ],
       "dependedBy": [
         "@tomlarkworthy/lopepage"
@@ -123,23 +151,14 @@
         "@tomlarkworthy/exporter-3"
       ]
     },
-    "@tomlarkworthy/editable-md": {
-      "hash": "1b4d30b426b3ad056b86b40860efd44f",
-      "dependsOn": [
-        "@tomlarkworthy/exporter-3",
-        "@tomlarkworthy/runtime-sdk",
-        "@tomlarkworthy/observablejs-toolchain",
-        "@tomlarkworthy/prosemirror",
-        "@tomlarkworthy/jest-expect-standalone"
-      ]
-    },
     "@tomlarkworthy/editor-5": {
-      "hash": "4175071d83af3ca54082813e24fd9f11",
+      "hash": "e6e33733479672bd1d82a0fb15e4eb11",
       "files": [
         "cell_options.json"
       ],
       "dependsOn": [
         "@tomlarkworthy/visualizer",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/reversible-attachment",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
@@ -168,8 +187,9 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "3872a7ba7029de95ffba3cdc17c0ce52",
+      "hash": "8ebd5648d99d2f74c7921378b12d21bb",
       "dependsOn": [
+        "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/cell-map",
@@ -192,7 +212,7 @@
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "adcaf784830574cbacb4c069959714d6",
+      "hash": "089777c0a995824b4a16291c5ab6412b",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -241,7 +261,7 @@
       ]
     },
     "@tomlarkworthy/import-notebook": {
-      "hash": "b6c52cc7de8b52cdf491eb76049236cc",
+      "hash": "b6b75803b1a4b7006005a06e0495ee65",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk"
       ],
@@ -260,6 +280,15 @@
         "@tomlarkworthy/summarizejs",
         "@tomlarkworthy/tests",
         "@tomlarkworthy/visualizer"
+      ]
+    },
+    "@tomlarkworthy/invoke-variable": {
+      "hash": "eb72dd569c9e7f0de6e0b518cbe12fb4",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/module-map"
       ]
     },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
@@ -303,7 +332,7 @@
       ]
     },
     "@tomlarkworthy/local-change-history": {
-      "hash": "78e3a01016d8128ecc0537e7c756eaa3",
+      "hash": "052efa3aa9b37e17ea391c4a4dbde687",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/lightning-fs-4-6-0",
@@ -328,21 +357,6 @@
         "@tomlarkworthy/exporter-3"
       ]
     },
-    "@tomlarkworthy/lopepage": {
-      "hash": "58fc5d7eb298cc0fe3d8ffd2debe9e36",
-      "dependsOn": [
-        "@tomlarkworthy/golden-layout-2-6-0",
-        "@tomlarkworthy/visualizer",
-        "@tomlarkworthy/module-selection",
-        "@tomlarkworthy/runtime-sdk",
-        "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/exporter-3",
-        "d/57d79353bac56631@44",
-        "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/claude-code-pairing",
-        "@tomlarkworthy/command-palette"
-      ]
-    },
     "@tomlarkworthy/lopepage-urls": {
       "hash": "28f1a31190b2a69e3c9d3ac522c41bd4",
       "dependsOn": [
@@ -353,6 +367,7 @@
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/module-selection",
         "@tomlarkworthy/tests",
@@ -360,17 +375,19 @@
       ]
     },
     "@tomlarkworthy/module-map": {
-      "hash": "ddf9b08467025d702a130fbeab912da7",
+      "hash": "18f327c993e00ae2ab3ab0cb21a27492",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/flow-queue",
         "@tomlarkworthy/observablejs-toolchain",
         "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/spectral-layout"
       ],
       "dependedBy": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/file-sync",
@@ -395,6 +412,17 @@
         "@tomlarkworthy/lopepage"
       ]
     },
+    "@tomlarkworthy/modules": {
+      "hash": "383efc0f630704ea804c5ddf05ab44eb",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/tests",
+        "@tomlarkworthy/observable-runtime-v6"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/editor-5"
+      ]
+    },
     "@tomlarkworthy/observable-runtime": {
       "hash": "4b60a23333fcadbc20650feae24d4039",
       "files": [
@@ -407,7 +435,8 @@
     "@tomlarkworthy/observable-runtime-v6": {
       "hash": "6bc9db7b1881559c4d30c39f692e3969",
       "dependedBy": [
-        "@tomlarkworthy/exporter-3"
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/modules"
       ]
     },
     "@tomlarkworthy/observablehq-lezer": {
@@ -444,6 +473,12 @@
         "@tomlarkworthy/module-selection"
       ]
     },
+    "@tomlarkworthy/plugin-registry": {
+      "hash": "428298afcf9c9c8bb13c412d7c23b191",
+      "dependedBy": [
+        "@tomlarkworthy/command-palette"
+      ]
+    },
     "@tomlarkworthy/prosemirror": {
       "hash": "cda535d6f78a454cb59074b5599d8070",
       "files": [
@@ -465,7 +500,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "d6da0322104cb2ad8a836559a8e6cf15",
+      "hash": "9e3e70971cde0b4ebf012f3c1a280cc6",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -479,11 +514,13 @@
         "@tomlarkworthy/file-sync",
         "@tomlarkworthy/fileattachments",
         "@tomlarkworthy/import-notebook",
+        "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/local-change-history",
         "@tomlarkworthy/lopepage",
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/module-selection",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/tests",
         "@tomlarkworthy/visualizer"
       ]
@@ -498,13 +535,13 @@
       ]
     },
     "@tomlarkworthy/stream-operators": {
-      "hash": "60e01583a36fc0e1abe3f5fa7b71efd7",
+      "hash": "e36abaedab4dca730a68bbd8fa2a72f5",
       "dependedBy": [
         "@tomlarkworthy/tests"
       ]
     },
     "@tomlarkworthy/summarizejs": {
-      "hash": "d5ca198f066bde101db6eed6086d55ed",
+      "hash": "6012d7554a1be7b899eb3e061154b130",
       "dependsOn": [
         "@tomlarkworthy/inspector"
       ],
@@ -524,11 +561,12 @@
       "dependedBy": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
+        "@tomlarkworthy/modules",
         "@tomlarkworthy/observablejs-toolchain"
       ]
     },
     "@tomlarkworthy/themes": {
-      "hash": "165aee9edb066ab5989674d9a2faefa5",
+      "hash": "e805ad68c19cf214655218d6cb106d70",
       "dependedBy": [
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/exporter-3"
@@ -542,7 +580,7 @@
       ]
     },
     "@tomlarkworthy/visualizer": {
-      "hash": "006c7bdb86aaefd18519862f541538d9",
+      "hash": "72308ea706602b6b9d1d4836c0c3eea6",
       "dependsOn": [
         "@tomlarkworthy/inspector",
         "@tomlarkworthy/runtime-sdk",
@@ -558,7 +596,7 @@
       "hash": "913f1f6b56a3bbdfca30148905419a98"
     },
     "@tomlarkworthy/bootloader": {
-      "hash": "c54b8a089b467872c8065bac24d1a9ff"
+      "hash": "8f696c43527a8ceadc35bd1192292b4e"
     }
   },
   "upstreams": {
@@ -566,6 +604,6 @@
       "@tomlarkworthy/editable-md": "https://observablehq.com/@tomlarkworthy/editable-md"
     }
   },
-  "observable_version": 844,
-  "observable_update_time": "2026-05-19T18:22:36.638Z"
+  "observable_version": 870,
+  "observable_update_time": "2026-07-22T18:10:22.599Z"
 }


### PR DESCRIPTION
**This PR is a proposal** — the canonical HTML has been updated with the new cells, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Reported symptom

Markdown tables are reformatted in such a way as to break them as recognizable tables.

## Root cause

`@tomlarkworthy/editable-md` mounted ProseMirror with `prosemirror.defaultMarkdownParser` / `defaultMarkdownSerializer` / `prosemirror.schema`. The default parser runs markdown-it's **commonmark** preset, which has no `table` rule, and the default prosemirror-markdown schema has no table nodes. A GFM pipe table therefore parsed as a single paragraph whose line breaks became softbreaks (rendered as spaces). On commit, that paragraph serialized back as one line, so the table was permanently destroyed:

```
| a | b |          ->   | a | b | | --- | --- | | 1 | 2 |
| --- | --- |
| 1 | 2 |
```

## Fix

The vendored `@tomlarkworthy/prosemirror` bundle already ships `prosemirror-tables` (nodes, plugin, CSS) — it just was not wired up. Three new cells do that:

- **`editableSchema`** — base schema plus `tableNodes({tableGroup: "block", cellContent: "inline*"})` with an `align` cell attribute so column alignment survives.
- **`editableMarkdownParser`** — a `MarkdownParser` over a markdown-it instance with `.enable("table")` and token handlers for `table` / `thead` / `tbody` / `tr` / `th` / `td`; alignment is read off markdown-it's `text-align` style attr.
- **`editableMarkdownSerializer`** — a `MarkdownSerializer` that emits GFM pipe tables. It flushes the pending block separator before measuring cells, suppresses `delim` while rendering cell inlines (so a table inside a blockquote/list does not pick up `> ` mid-cell), escapes `|` inside cell text, and lets `closeBlock` own block separation.

`md` now uses those three, and additionally gets `tableEditing()` plus a Tab / Shift-Tab `goToNextCell` keymap ordered ahead of `baseKeymap`.

Two supporting changes:

- `escapeMarkdownInline` now escapes `|`, so a `${...}` placeholder inside a table cell is not split at a pipe. `unescapeMarkdownInline` already reverses any ASCII-punctuation escape, so the pair stays an exact inverse.
- `linkifyPastedUrl` takes the link mark from `view.state.schema` instead of `prosemirror.schema`. Mark types are per-schema instances; with the extended schema the old lookup would apply a foreign mark type.

The intro prose gains a small table so the feature is documented and acts as a live canary.

New tests: `test_table_round_trip` (structure, exact serialization, second-round-trip stability, tagged-template form) and `test_table_placeholder_round_trip` (`${a || b}` and `${f(x, [y])}` inside cells survive and still compile to the right inputs).

## Targeted QA (live runtime, clean reload of the committed HTML)

- ✅ Table renders, and clicking a cell mounts ProseMirror with a real `<table>` (3 `<tr>`), not a paragraph of pipes.
- ✅ Typing in a cell, Tab to the next cell, SHIFT+ENTER commit → decompiled source retains the table with `| :--- | :---: | ---: |` alignment intact.
- ✅ Round trips are stable (`serialize(parse(x)) === x`) for: table with leading/trailing paragraphs, single-column table, table inside a blockquote, table inside a list item, table after a heading.
- ✅ Escaped `\|` inside a cell survives.
- ✅ Regression — drag-select inside prose still does not mount the editor and keeps the highlight.
- ✅ Regression — pasting a URL over a selection still linkifies it (verified with the extended schema).
- ✅ All 12 other module tests pass. `test_defaultMarkdownParser_preserves_escapes` fails both before and after this change — pre-existing, documented in the Known Issues cell; verified against the unmodified notebook.
- Console: clean (only pre-existing boot chatter).