### PR TITLE
Re-jumpgate editable-md with the fixed Observable toolchain

### DIFF
--- a/notebooks/@tomlarkworthy_editable-md.html
+++ b/notebooks/@tomlarkworthy_editable-md.html
@@ -10842,7 +10842,7 @@ const _4zsqot = function _actionHandler(Inputs,getSourceModule,notebook_name,_ru
     }
   };
 };
-const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
+const _lb3gzc = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
     return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
@@ -10865,7 +10865,7 @@ const _dxt3kg = function _exportToHTML(_runtime, cssForTheme, css, location, kee
             options.tickDelayMs = conf.tickDelayMs;
         }
         if (options.prerender == null) {
-            options.prerender = conf.prerender;
+            options.prerender = conf.prerender !== false;
         }
         if (options.prerender && runtime === _runtime && options.prerenderHTML == null) {
             try {
@@ -12326,7 +12326,7 @@ export default function define(runtime, observer) {
   $def("_1u2ju69", "forkAnchor", ["exportAnchor"], _1u2ju69);  
   $def("_1a8n42w", "downloadAnchor", ["exportAnchor"], _1a8n42w);  
   $def("_4zsqot", "actionHandler", ["Inputs","getSourceModule","notebook_name","_runtime","exportToHTML","htmlToConsoleSnippet","copyTextToClipboard","view","linkTo","location","getCompactISODate"], _4zsqot);  
-  $def("_dxt3kg", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _dxt3kg);  
+  $def("_lb3gzc", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _lb3gzc);  
   $def("_43zr7", "getSourceModule", ["notebook_name","main","_runtime"], _43zr7);  
   $def("_tpv4tl", "createShowable", ["variable","view"], _tpv4tl);  
   $def("_rnq9mt", "reportValidity", [], _rnq9mt);  
@@ -20441,13 +20441,6 @@ export default function define(runtime, observer) {
   $def("_104y7ux", "observable_lezer_parser", ["lezerhighlight","lr"], _104y7ux);
   return main;
 }</script>
-<script id="@tomlarkworthy/observablejs-toolchain/acorn-walk-8.3.2.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC5mydonhQbDnRjC17JRkmh+S/n5bkm2zHITsvjNWt7v76olYrM3779o311rrMaRjj0JourG/8GsfkiVk5J3Rm3aZxnGfW06H7/sQ9sBANrXvMOGbW06/uwYl76Er5z4zMCEWxFZEYn1pjmiVjFKSM7j+j+Pu/f3OP3MNxSLgYy7WbfOMgJQWvU+vT53uwha272xvrmYi5FS4oSkiA4nhhzTDFDAmAJjXzHetjyrBFaJSyBAmS0lNrLkTGT8fj5+dn9xsPFXg3SJOxcmCfM7Iv1e4XaveVIrA9fhPlNJA6LGELBzvUYU46eqHLpU39ZOQ02MBwyOjlCTEL+WS5ZK5YZNijD+hR8cTIwfC9t4cLymgFKtW/lRbcNCI1Ef/h0VtnDek93EelNSfz2Y7vkwfixpjOwKODRy/b2yNulvO5zUYOfeANOFzB0ZTlkgB+R+9OM7sHHu3Co+eRDYTl8ikloTUZnTJvpwFT7R69kAfYgRXER0UTSjs2tDNbjF4YFjmju1wwSMyu70uRNLLEebnNxuUmC/vAX52K5bJilrydyWolAaZ+xQJzoxcxJ9ylaYh94ahvLqByfLzyKhik4+QWCfCa8SWQCra3Z2NF4EDwWU9UUWmwritPYXdU9ncMowj0KKOZz6usBz1ZD8ysZ49KGFClDVRIJd3JgArQnMDMfQMjLzASDQDkbCQDAh7ZZOQJtngxcXJQqnAGflYFh0S2TfM49n0saRB7Js58PAI0mkwlGdPwd58CET0Ej0oVoO7IQe57BIEqJYkdAPyRmLP02aL42UqlHuUV/A2QCOay2ACPgEYB+mggqywdFZUlPC0qVnUIsjoEkCjwm4L7EAci89UNQF+iZAB27MKB33GB+Uz5QRoponYm4bfwI4Uf/VP8wT/AX+DVIHvdKZ3x8d5eAbuN2mu4tvopF/KmC+rkecXulj9Oy5WscqUI/ahbnNpN6Ye9Ay7qNqFoijOS/smqAj73a+/AqC7ThnsOrzFHuvFIa9T/PP2GA+EGDEPXsaEAIPRwTdmSC40G4I7oA3v0BfypXKt1xdp/SJ9SWjN+lAzV9BL/ZeUl7heWzhhK/MS9jNPg+53sdAmmAgjymwSKbDRIqaLC40+gKwh3moYLj52lRW/x2C/+gUSQAkaQ2K307oL7jtat7cSw+iPJxKIm/ZCkHxnDnIPJJqQviMHHHHPyPxzWW4BzNUeENihtwGWcbOHiapdEVssANDB8E9UG20qktMBctOUcyQhSyvHfOci1HHaEi2KBGQWKrI/Gsh0asP8BTTFMUOtBNDyRUe9RcQmVY2TyKqWC0BybIf4LhplhX1NVib3erjF9BxNSsEErjG8BIwmMebSj22sXVoA45t3K0nOFrC6PqJTIwJLe5FQqEajkPmkkykNnvNSLiorlMHh1KrZ27QrwdLwSFQQxDKHyqoawxaG5VZlvJva/BMfmObh4RkQMnAMoPjbLpXhRisWq7yjcy95qdATgo/CPeGNhDmpli+H6mMqO0z1DcySfFkzDLhbQ34ATyRcDdISCVy176vNKXilXMcp7s5ghaIVaifqUCr4gIQ/rcNn/NYe3QDNS12mLtFUrWWPlz5StVyhcQkmRVPkl5UHgBj5V+IYrFDbkWVg1KP29JbYbozSB8HlDK41x1IIpqfACnIutTZOuid3/IEbQNMbXOIghnZK3K18D6io/19fjqd7eqdJrPM1nM8zMlvlnYaKhceAYKN8Krtbag2jj1RrWe/n6bqE7RFt/ynoDT0Kzsvtqpx2Q0pG+wgsLUVNtp+upM8WHOl4lu2rku3ljnzdxnbYroRDvVsJNCHtIRDBrF4BTVUll+3T3I06mmDUsdYT0jlqkmLUaKSixyLIxdquJ5xbO4JZ9tI4NyF8whhbr3G3HHWtDG65RdYOahqQlPY2+1lTG0gwzQTbc2btf9L6FjCzRkbXlzZxkucChvsy/40VPGyDuE4pzbACFlDUCWuvUevqDuDKGTJWUe3jrG5fpXQ4gfZk/gUrEKqEq/AO37E9mwDh7dRK2MDiUB7NllOfanCIY3Py9nJ4OKGcjNcwEeJuQVFsHO0InFPc4yWI49R8IJBLFG+38nSNOBqNQShCQQC1k5AyVYqQQQw9kGFl5rmWhfKWILYwAflVX60CgNs1Pl6Sj80M6kz9zblBaXrede7X3xlVdBr5nVAIxq6Mir2sLTXPmALXWFrxRQiJ1bPTjlS+wDtt4dbXNf8LP5nsSxUM4SGQri7AL455hqkwgH7XrseJsVfXtG2mb55ow+mrVGxZ9YYB1ysQnlOCwOaOUjGscoTwWQ+OLMbBogw1CYbPHRn3HLpeGCIwV542L/rTtHE9zFhRzq/5e79hFHA9jx2pbGalyJZ8Zw+pvEh2e1491PMOBmkgGe9NrrG6oik3idyUQv3ZDZbnLkDnjGQqwwapmK/kDDSNPkCmDVnZq2Q/vEQzVYdUpNxx0NOs9yKql9/aQGHFu1q0ivep3IalQ7W7oev2wKwtRTgtKrCjGaj3wmqltXcL6J39nK3uFmKdwtCI5yusolMNLL7HHSbNh9A1iQo9hekM1kRkJ8fTxecEW4pb85ZbDe8RJ5GqKOHYC+QV4wk9piC8iiKOTGSSW5jR0uEETTt5cX2KIEHaIouVx7KDy66I0GElKgr6Da/KL4SBnnDzBu0IuOYFSxCVWK9Slb8n/MPDejMf/svTx+YiyjNDZ19sP/pgn42gSTN4fTw7fhYfRydFheHz07t0xOkYBmh5hdDJ5Nwl/C8LjSXR4go6O8WSCDkHz++gwPJkERweBm6Ds/8t9I8syHQAA
-</script>
 <script id="@tomlarkworthy/observablejs-toolchain/parser-6.1.0.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -20594,11 +20587,11 @@ Promise.all(
     })
 )
 )};
-const _18xo2td = function _test_all_cells_roundtrippable(roundtripped)
+const _1shi9or = function _test_all_cells_roundtrippable(roundtripped)
 {
   const errored = roundtripped.filter((cell) => cell.error);
   if (errored.length > 0) throw JSON.stringify(errored, null, 2);
-  return `${roundtripped} cells decompiled, recompiled and decompiled again without error`;
+  return `${roundtripped.length} cells decompiled, recompiled and decompiled again without error`;
 };
 const _14nox99 = function _21(md){return(
 md`## Reference Data`
@@ -21149,7 +21142,7 @@ const _1v1d8m3 = async function _test_decompile_import_variable(decompile,import
   expect(decompiled).toEqual(`import {dep} from "@tomlarkworthy/dependancy"`);
   return "ok";
 };
-const _fiyb80 = async function _test_decompile_dollar_in_string_literal(decompile,expect)
+const _1ybjsqg = async function _test_decompile_dollar_in_string_literal(decompile,expect)
 {
   // Regression: $N inside a string/regex/template literal must NOT be substituted
   // with `viewof X` / `mutable X`. This is the cc_ws bug — regex backref $1
@@ -21163,7 +21156,7 @@ const _fiyb80 = async function _test_decompile_dollar_in_string_literal(decompil
       _inputs: ["viewof a", "viewof b"]
     }
   ]);
-  expect(decompiled).toEqual(`demo = 'x'.replace(/x/, '$1y')`);
+  expect(decompiled).toEqual(`demo = "x".replace(/x/, '$1y')`);
   return "ok";
 };
 const _wgfrtq = async function _test_decompile_import_variable_alias(decompile,importFake,expect)
@@ -21293,20 +21286,18 @@ const _v4p1js = async function _test_decompile_constant(decompile,expect)
   expect(decompiled).toEqual(`v = 1`);
   return "ok";
 };
-const _pcs4h = async function _test_decompile_string_literal(decompile,expect)
+const _1puzspw = async function _test_decompile_string_literal(decompile,expect)
 {
   const decompiled = await decompile([
     {
       _name: "v",
-      _definition: function _3() {
-        ("");
-      },
+      _definition: `function _3() {\n  ("");\n}`,
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`v = {
-  '';
-}`);
+  // decompile preserves the original expression verbatim (source-slicing), so the
+  // parenthesized string and quote style survive — no escodegen re-quoting.
+  expect(decompiled).toEqual(`v = {\n  ("");\n}`);
   return "ok";
 };
 const _a2zh99 = async function _test_decompile_html_cell(decompile,expect)
@@ -21321,7 +21312,7 @@ const _a2zh99 = async function _test_decompile_html_cell(decompile,expect)
   expect(decompiled).toEqual(`html = htl.html\`<div>\``);
   return "ok";
 };
-const _pyp280 = async function _test_decompile_class(decompile,expect)
+const _1pt67ao = async function _test_decompile_class(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21332,8 +21323,7 @@ class myclass {}
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`myclass = class myclass {
-}`);
+  expect(decompiled).toEqual(`myclass = class myclass {}`);
   return "ok";
 };
 const _kf8c3f = function _test_decompile_class_with_property(decompile){return(
@@ -21374,7 +21364,7 @@ x
   expect(decompiled).toEqual(`v = x`);
   return "ok";
 };
-const _4rsshj = async function _test_decompile_block(decompile,expect)
+const _14nvmno = async function _test_decompile_block(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21388,12 +21378,12 @@ const _4rsshj = async function _test_decompile_block(decompile,expect)
     }
   ]);
   expect(decompiled).toEqual(`v = {
-  '';
+  ("");
   return x + y;
 }`);
   return "ok";
 };
-const _o7o1wl = async function _test_decompile_comments(decompile,expect)
+const _5kd9if = async function _test_decompile_comments(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21408,7 +21398,7 @@ const _o7o1wl = async function _test_decompile_comments(decompile,expect)
   ]);
   expect(decompiled).toEqual(`comments = {
   // a comment
-  return '';
+  return "";
 }`);
   return "ok";
 };
@@ -21429,7 +21419,7 @@ const _1yn35e3 = async function _test_decompile_generator(decompile,expect)
 }`);
   return "ok";
 };
-const _135eswd = async function _test_decompile_function(decompile,expect)
+const _10wf7cf = async function _test_decompile_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21440,11 +21430,10 @@ function () {}
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`_function = function () {
-}`);
+  expect(decompiled).toEqual(`_function = function () {}`);
   return "ok";
 };
-const _1pitq2 = async function _test_decompile_async_function(decompile,expect)
+const _1191zxm = async function _test_decompile_async_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21455,11 +21444,10 @@ async function () {}
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`asyncfunction = async function () {
-}`);
+  expect(decompiled).toEqual(`asyncfunction = async function () {}`);
   return "ok";
 };
-const _1kxe1b2 = async function _test_decompile_named_function(decompile,expect)
+const _vpu09i = async function _test_decompile_named_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21470,8 +21458,7 @@ function foo() {}
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`named_function = function foo() {
-}`);
+  expect(decompiled).toEqual(`named_function = function foo() {}`);
   return "ok";
 };
 const _1pghf4f = async function _test_decompile_this_reference(decompile,expect)
@@ -21488,7 +21475,7 @@ const _1pghf4f = async function _test_decompile_this_reference(decompile,expect)
   expect(decompiled).toEqual(`thisReference = (this || 0) + 1`);
   return "ok";
 };
-const _4aeghn = async function _test_decompile_lambda(decompile,expect)
+const _rajn7p = async function _test_decompile_lambda(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21499,8 +21486,7 @@ const _4aeghn = async function _test_decompile_lambda(decompile,expect)
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`lambda = () => {
-}`);
+  expect(decompiled).toEqual(`lambda = () => {}`);
   return "ok";
 };
 const _12ec5zd = async function _test_decompile_error(decompile,expect)
@@ -21520,7 +21506,7 @@ const _12ec5zd = async function _test_decompile_error(decompile,expect)
 }`);
   return "ok";
 };
-const _3bj09h = async function _test_decompile_error_object(decompile,expect)
+const _1c93ef9 = async function _test_decompile_error_object(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21533,7 +21519,7 @@ const _3bj09h = async function _test_decompile_error_object(decompile,expect)
     }
   ]);
   expect(decompiled).toEqual(`error_obj = {
-  throw { foo: 'bar' };
+  throw { foo: "bar" };
 }`);
   return "ok";
 };
@@ -21595,7 +21581,7 @@ _
   expect(decompiled).toEqual(`inbuilt = _`);
   return "ok";
 };
-const _1uv76xx = async function _test_decompile_fileattachment(decompile,expect)
+const _4z1dnp = async function _test_decompile_fileattachment(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21606,7 +21592,7 @@ FileAttachment("empty")
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`file = FileAttachment('empty')`);
+  expect(decompiled).toEqual(`file = FileAttachment("empty")`);
   return "ok";
 };
 const _g4z6de = async function _test_decompile_mutable_dependancy(decompile,expect)
@@ -21679,7 +21665,7 @@ view
   expect(decompiled).toEqual(`viewofdatadep = view`);
   return "ok";
 };
-const _ehz2xk = async function _test_decompile_viewof_param(decompile,expect)
+const _b0y8zg = async function _test_decompile_viewof_param(decompile,expect)
 {
   // Lopecode compiled form uses viewof_X as parameter name instead of $N
   const decompiled = await decompile([
@@ -21695,7 +21681,7 @@ const _ehz2xk = async function _test_decompile_viewof_param(decompile,expect)
   ]);
   expect(decompiled).toEqual(`foo = {
   viewof bar.value = x;
-  viewof bar.dispatchEvent(new Event('input'));
+  viewof bar.dispatchEvent(new Event("input"));
 }`);
   return "ok";
 };
@@ -21712,7 +21698,7 @@ dep
   expect(decompiled).toEqual(`dep`);
   return "ok";
 };
-const _1jggajo = async function _test_decompile_import_mutable(decompile,expect)
+const _1eqf4jq = async function _test_decompile_import_mutable(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21722,11 +21708,11 @@ const _1jggajo = async function _test_decompile_import_mutable(decompile,expect)
     }
   ]);
   expect(decompiled).toEqual(
-    `mutable mutabledep = v.import('mutable mutabledep', _)`
+    `mutable mutabledep = v.import("mutable mutabledep", _)`
   );
   return "ok";
 };
-const _di0abi = async function _test_decompile_import_viewof(decompile,expect)
+const _3damo4 = async function _test_decompile_import_viewof(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21735,10 +21721,10 @@ const _di0abi = async function _test_decompile_import_viewof(decompile,expect)
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`viewof viewdep = v.import('viewof viewdep', _)`);
+  expect(decompiled).toEqual(`viewof viewdep = v.import("viewof viewdep", _)`);
   return "ok";
 };
-const _14o5oio = async function _test_decompile_viewof_data(decompile,expect)
+const _1l9xqsw = async function _test_decompile_viewof_data(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21747,10 +21733,10 @@ const _14o5oio = async function _test_decompile_viewof_data(decompile,expect)
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`viewdep = v.import('viewdep', _)`);
+  expect(decompiled).toEqual(`viewdep = v.import("viewdep", _)`);
   return "ok";
 };
-const _1lv4syw = async function _test_decompile_import_alias(decompile,expect)
+const _1cggvdk = async function _test_decompile_import_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21759,10 +21745,10 @@ const _1lv4syw = async function _test_decompile_import_alias(decompile,expect)
       _inputs: []
     }
   ]);
-  expect(decompiled).toEqual(`dep_alias = v.import('dep', 'dep_alias', _)`);
+  expect(decompiled).toEqual(`dep_alias = v.import("dep", "dep_alias", _)`);
   return "ok";
 };
-const _l8b8hu = async function _test_decompile_import_mutable_alias(decompile,expect)
+const _xcwq4 = async function _test_decompile_import_mutable_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21772,11 +21758,11 @@ const _l8b8hu = async function _test_decompile_import_mutable_alias(decompile,ex
     }
   ]);
   expect(decompiled).toEqual(
-    `mutable aslias_mutabledep = v.import('mutable mutabledep', 'mutable aslias_mutabledep', _)`
+    `mutable aslias_mutabledep = v.import("mutable mutabledep", "mutable aslias_mutabledep", _)`
   );
   return "ok";
 };
-const _1g5n3sa = async function _test_decompile_import_mutable_data_alias(decompile,expect)
+const _1868h0w = async function _test_decompile_import_mutable_data_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21786,11 +21772,11 @@ const _1g5n3sa = async function _test_decompile_import_mutable_data_alias(decomp
     }
   ]);
   expect(decompiled).toEqual(
-    `aslias_mutabledep = v.import('mutabledep', 'aslias_mutabledep', _)`
+    `aslias_mutabledep = v.import("mutabledep", "aslias_mutabledep", _)`
   );
   return "ok";
 };
-const _1lnngk6 = async function _test_decompile_import_viewof_alias(decompile,expect)
+const _1afcxhk = async function _test_decompile_import_viewof_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21800,11 +21786,11 @@ const _1lnngk6 = async function _test_decompile_import_viewof_alias(decompile,ex
     }
   ]);
   expect(decompiled).toEqual(
-    `viewof aslias_viewdep = v.import('viewof viewdep', 'viewof aslias_viewdep', _)`
+    `viewof aslias_viewdep = v.import("viewof viewdep", "viewof aslias_viewdep", _)`
   );
   return "ok";
 };
-const _1na1e5i = async function _test_decompile_import_viewof_data_alias(decompile,expect)
+const _1sl510 = async function _test_decompile_import_viewof_data_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -21814,7 +21800,7 @@ const _1na1e5i = async function _test_decompile_import_viewof_data_alias(decompi
     }
   ]);
   expect(decompiled).toEqual(
-    `aslias_viewdep = v.import('viewdep', 'aslias_viewdep', _)`
+    `aslias_viewdep = v.import("viewdep", "aslias_viewdep", _)`
   );
   return "ok";
 };
@@ -21836,9 +21822,8 @@ const _1g89k6a = function _escodegenOptions(escodegen){return(
   }
 }
 )};
-const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acorn,escodegen,escodegenOptions)
-{
-  return async function decompile(variables) {
+const _2d5g1 = function _decompile(decompileImport,formatImportDeclaration,acorn){return(
+async function decompile(variables) {
     if (!variables || variables.length === 0)
       throw new Error("no variables to decompile");
     const importInfo = await decompileImport(variables);
@@ -21864,14 +21849,13 @@ const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acor
     const wrappedCode = "(" + compiled + ")";
     const comments = [],
       tokens = [];
-    let parsed = acorn.parse(wrappedCode, {
+    const parsed = acorn.parse(wrappedCode, {
       ecmaVersion: 2022,
       sourceType: "module",
       ranges: true,
       onComment: comments,
       onToken: tokens
     });
-    parsed = escodegen.attachComments(parsed, comments, tokens);
     const functionExpression = parsed.body[0].expression;
     const body = functionExpression.body;
     // Extract parameter names from AST for underscore-encoded name fixup
@@ -21890,101 +21874,127 @@ const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acor
         varName = name.replace(/^viewof /, "");
       }
     }
-    // Build $N → placeholder map. Walking the AST and renaming Identifier nodes
-    // BEFORE escodegen.generate keeps us out of string literals, regex literals,
-    // and template element cooked text — which is where naive replaceAll on $N
-    // used to corrupt regex backreferences (e.g. '$1cc=' + token).
-    const placeholders = [];
-    {
-      let id = 0;
-      inputs.forEach((input) => {
-        if (input && input.startsWith("mutable ")) {
-          placeholders.push({
-            key: `$${id++}`,
-            ph: `__OJS_DOLLAR_${placeholders.length}__`,
-            value: input,
-            mutable: true
-          });
-        } else if (
-          input &&
-          (input.startsWith("viewof ") || input === "@variable")
-        ) {
-          placeholders.push({
-            key: `$${id++}`,
-            ph: `__OJS_DOLLAR_${placeholders.length}__`,
-            value: input,
-            mutable: false
-          });
-        }
-      });
-    }
-    const byKey = new Map(placeholders.map((p) => [p.key, p]));
-    const renameDollarIdentifiers = (node) => {
-      if (!node || typeof node !== "object") return;
-      if (node.type === "Identifier") {
-        const p = byKey.get(node.name);
-        if (p) node.name = p.ph;
-        return;
-      }
-      for (const k in node) {
-        if (k === "loc" || k === "range") continue;
-        const c = node[k];
-        if (Array.isArray(c)) c.forEach(renameDollarIdentifiers);
-        else if (c && typeof c === "object" && c.type)
-          renameDollarIdentifiers(c);
-      }
-    };
-    renameDollarIdentifiers(body);
-    let expression = "";
+    // Pick the source range to return: the single returned expression for a
+    // normal `{ return <expr> }` cell, otherwise the whole body. We SLICE the
+    // original text rather than regenerate via escodegen, so comments, quote
+    // style, whitespace, ASI-sensitive grouping and class fields all survive
+    // byte-for-byte. (Regeneration was the root of the ASI, quote-drift and
+    // class-property-shim-gap bugs.)
+    let sliceNode = body;
+    let wrapObjectLiteral = false;
     if (
       body.type === "BlockStatement" &&
       body.body.length === 1 &&
       body.body[0].type === "ReturnStatement" &&
-      comments.length === 0
+      body.body[0].argument
     ) {
-      if (wrappedCode[body.body[0].argument.start] === "{") {
-        expression = `(${escodegen.generate(
-          body.body[0].argument,
-          escodegenOptions
-        )})`;
-      } else {
-        expression = escodegen.generate(
-          body.body[0].argument,
-          escodegenOptions
-        );
-      }
-    } else {
-      expression = escodegen.generate(body, escodegenOptions);
-    }
-    let source = `${varName ? `${prefix}${varName} = ` : ""}${expression}`;
-    // Substitute placeholders back to Observable-flavored names. Placeholders are
-    // unique tokens we just inserted, so this string-level substitution is safe.
-    for (const p of placeholders) {
-      if (p.mutable) {
-        source = source.replaceAll(`${p.ph}.value`, p.value);
-      } else {
-        source = source.replaceAll(p.ph, p.value);
+      const arg = body.body[0].argument;
+      // Unwrap `{ return <arg> }` to <arg> only when every comment lives INSIDE
+      // <arg>, so it survives the arg slice (a returned function's own comments
+      // are kept this way). A comment anywhere else in the block — before
+      // `return`, in the compiler's `return( … )` auto-wrap slot, or trailing
+      // after the value — would be dropped by unwrapping, so keep the (ASI-safe)
+      // block form to preserve it and round-trip exactly.
+      const hasCommentOutsideArg = comments.some(
+        (c) =>
+          c.start >= body.start &&
+          c.end <= body.end &&
+          (c.end <= arg.start || c.start >= arg.end)
+      );
+      if (!hasCommentOutsideArg) {
+        sliceNode = arg;
+        wrapObjectLiteral = wrappedCode[arg.start] === "{";
       }
     }
-    // Restore any unconsumed placeholders (bare $N reference to a mutable input).
-    for (const p of placeholders) {
-      if (p.mutable) source = source.replaceAll(p.ph, p.key);
+    const sliceStart = sliceNode.start;
+    const sliceEnd = sliceNode.end;
+
+    // $N → Observable name. Positional over the qualifying inputs, matching the
+    // compiler's convention (same counting the old placeholder pass used).
+    const dollarValue = new Map();
+    {
+      let id = 0;
+      inputs.forEach((input) => {
+        if (input && input.startsWith("mutable ")) {
+          dollarValue.set(`$${id++}`, { name: input, mutable: true });
+        } else if (
+          input &&
+          (input.startsWith("viewof ") || input === "@variable")
+        ) {
+          dollarValue.set(`$${id++}`, { name: input, mutable: false });
+        }
+      });
     }
-    // Fix underscore-encoded viewof/mutable parameter names (lopecode compiled form)
+    // Underscore-encoded viewof/mutable params (lopecode compiled form) → spaced.
+    const underscoreParam = new Map();
     inputs.forEach((input, i) => {
       if (
         input &&
         (input.startsWith("viewof ") || input.startsWith("mutable "))
       ) {
         const underscoreForm = input.replace(" ", "_");
-        if (params[i] === underscoreForm) {
-          source = source.replaceAll(underscoreForm, input);
-        }
+        if (params[i] === underscoreForm) underscoreParam.set(underscoreForm, input);
       }
     });
+
+    // Collect identifier-node range rewrites within the sliced expression only.
+    // Keyed on Identifier/MemberExpression nodes, so string, regex and template
+    // text is never touched (this is what the old string replaceAll corrupted).
+    const edits = [];
+    const consumed = new Set();
+    const collect = (node) => {
+      if (!node || typeof node !== "object" || typeof node.type !== "string")
+        return;
+      // mutable `$N.value` → `mutable foo` (replace the whole member expression)
+      if (
+        node.type === "MemberExpression" &&
+        !node.computed &&
+        node.object &&
+        node.object.type === "Identifier" &&
+        node.property &&
+        node.property.type === "Identifier" &&
+        node.property.name === "value"
+      ) {
+        const dv = dollarValue.get(node.object.name);
+        if (dv && dv.mutable) {
+          edits.push({ start: node.start, end: node.end, text: dv.name });
+          consumed.add(node.object);
+        }
+      } else if (node.type === "Identifier" && !consumed.has(node)) {
+        const dv = dollarValue.get(node.name);
+        if (dv) {
+          // Non-mutable $N → input name. Bare mutable $N (no `.value`) stays $N.
+          if (!dv.mutable) edits.push({ start: node.start, end: node.end, text: dv.name });
+        } else if (underscoreParam.has(node.name)) {
+          edits.push({ start: node.start, end: node.end, text: underscoreParam.get(node.name) });
+        }
+      }
+      for (const k in node) {
+        if (k === "loc" || k === "range" || k === "start" || k === "end")
+          continue;
+        const c = node[k];
+        if (Array.isArray(c)) c.forEach(collect);
+        else if (c && typeof c === "object" && typeof c.type === "string")
+          collect(c);
+      }
+    };
+    collect(sliceNode);
+
+    // Apply edits right-to-left (descending start) so offsets stay valid.
+    let expression = wrappedCode.slice(sliceStart, sliceEnd);
+    edits
+      .sort((a, b) => b.start - a.start)
+      .forEach((e) => {
+        const s = e.start - sliceStart;
+        const t = e.end - sliceStart;
+        expression = expression.slice(0, s) + e.text + expression.slice(t);
+      });
+    if (wrapObjectLiteral) expression = `(${expression})`;
+
+    const source = `${varName ? `${prefix}${varName} = ` : ""}${expression}`;
     return source;
-  };
-};
+  }
+)};
 const _1pvis67 = function _85(md){return(
 md`### \`extractModuleInfo\` 
 static analysis of module imports`
@@ -22516,14 +22526,14 @@ const _x7zc8w = async function _test_compile_integer(compile,expect)
   ]);
   return "ok";
 };
-const _1u7hlem = async function _test_compile_string(compile,expect)
+const _1qp2ggw = async function _test_compile_string(compile,expect)
 {
   const compiled = await compile(`""`);
   expect(compiled).toEqual([
     {
       _name: null,
       _inputs: [],
-      _definition: "function _anonymous() {return ('');}"
+      _definition: `function _anonymous() {return ("");}`
     }
   ]);
   return "ok";
@@ -22540,14 +22550,14 @@ const _151bijp = async function _test_compile_obj_literal(compile,expect)
   ]);
   return "ok";
 };
-const _ti9okn = async function _test_compile_assignment(compile,expect)
+const _17z4vyt = async function _test_compile_assignment(compile,expect)
 {
   const compiled = await compile(`x = ""`);
   expect(compiled).toEqual([
     {
       _name: "x",
       _inputs: [],
-      _definition: "function _x() {return ('');}"
+      _definition: `function _x() {return ("");}`
     }
   ]);
   return "ok";
@@ -22564,7 +22574,7 @@ const _1eb8vq = async function _test_compile_dependancy(compile,expect)
   ]);
   return "ok";
 };
-const _acs4l0 = async function _test_compile_block_dependancy(compile,expect)
+const _5b8x33 = async function _test_compile_block_dependancy(compile,expect)
 {
   const compiled = await compile(`z = {
   ("");
@@ -22574,12 +22584,12 @@ const _acs4l0 = async function _test_compile_block_dependancy(compile,expect)
     {
       _name: "z",
       _inputs: ["x", "y"],
-      _definition: "function _z(x,y) {\n    '';\n    return x + y;\n}"
+      _definition: `function _z(x,y) {\n  ("");\n  return x + y;\n}`
     }
   ]);
   return "ok";
 };
-const _125ljg9 = async function _test_compile_comments(compile,expect)
+const _9s1umz = async function _test_compile_comments(compile,expect)
 {
   const compiled = await compile(`comments = {
   // a comment
@@ -22589,12 +22599,12 @@ const _125ljg9 = async function _test_compile_comments(compile,expect)
     {
       _name: "comments",
       _inputs: [],
-      _definition: "function _comments() {\n    // a comment\n    return '';\n}"
+      _definition: `function _comments() {\n  // a comment\n  return "";\n}`
     }
   ]);
   return "ok";
 };
-const _li37je = async function _test_compile_generator(compile,expect)
+const _1rbs7b6 = async function _test_compile_generator(compile,expect)
 {
   const compiled = await compile(`generator = {
   yield x + y;
@@ -22603,24 +22613,24 @@ const _li37je = async function _test_compile_generator(compile,expect)
     {
       _name: "generator",
       _inputs: ["x", "y"],
-      _definition: "function* _generator(x,y) {\n    yield x + y;\n}"
+      _definition: "function* _generator(x,y) {\n  yield x + y;\n}"
     }
   ]);
   return "ok";
 };
-const _em4em6 = async function _test_compile_function(compile,expect)
+const _1gaxmhs = async function _test_compile_function(compile,expect)
 {
   const compiled = await compile(`_function = function () {}`);
   expect(compiled).toEqual([
     {
       _name: "_function",
       _inputs: [],
-      _definition: "function __function() {return (function () {\n});}"
+      _definition: "function __function() {return (function () {});}"
     }
   ]);
   return "ok";
 };
-const _w3atfb = async function _test_compile_async_function(compile,expect)
+const _2ozyn1 = async function _test_compile_async_function(compile,expect)
 {
   const compiled = await compile(`asyncfunction = async function () {}`);
   expect(compiled).toEqual([
@@ -22628,19 +22638,19 @@ const _w3atfb = async function _test_compile_async_function(compile,expect)
       _name: "asyncfunction",
       _inputs: [],
       _definition:
-        "function _asyncfunction() {return (async function () {\n});}"
+        "function _asyncfunction() {return (async function () {});}"
     }
   ]);
   return "ok";
 };
-const _14gl6yr = async function _test_compile_named_function(compile,expect)
+const _1jn3lk9 = async function _test_compile_named_function(compile,expect)
 {
   const compiled = await compile(`named_function = function foo() {}`);
   expect(compiled).toEqual([
     {
       _name: "named_function",
       _inputs: [],
-      _definition: "function _named_function() {return (function foo() {\n});}"
+      _definition: "function _named_function() {return (function foo() {});}"
     }
   ]);
   return "ok";
@@ -22657,19 +22667,19 @@ const _z3bqb8 = async function _test_compile_this_reference(compile,expect)
   ]);
   return "ok";
 };
-const _1sou7t0 = async function _test_compile_lambda(compile,expect)
+const _1lyze5m = async function _test_compile_lambda(compile,expect)
 {
   const compiled = await compile(`lambda = () => {}`);
   expect(compiled).toEqual([
     {
       _name: "lambda",
       _inputs: [],
-      _definition: "function _lambda() {return (() => {\n});}"
+      _definition: "function _lambda() {return (() => {});}"
     }
   ]);
   return "ok";
 };
-const _1o1u737 = async function _test_compile_error(compile,expect)
+const _12k1xub = async function _test_compile_error(compile,expect)
 {
   const compiled = await compile(`error = {
   throw new Error();
@@ -22678,7 +22688,7 @@ const _1o1u737 = async function _test_compile_error(compile,expect)
     {
       _name: "error",
       _inputs: [],
-      _definition: "function _error() {\n    throw new Error();\n}"
+      _definition: "function _error() {\n  throw new Error();\n}"
     }
   ]);
   return "ok";
@@ -22756,7 +22766,7 @@ const _78egw8 = async function _test_compile_builtin(compile,expect)
   ]);
   return "ok";
 };
-const _lflzev = async function _test_compile_fileattachment(compile,expect)
+const _1o65727 = async function _test_compile_fileattachment(compile,expect)
 {
   const compiled = await compile(`file = FileAttachment("empty")`);
   expect(compiled).toEqual([
@@ -22764,12 +22774,12 @@ const _lflzev = async function _test_compile_fileattachment(compile,expect)
       _name: "file",
       _inputs: ["FileAttachment"],
       _definition:
-        "function _file(FileAttachment) {return (FileAttachment('empty'));}"
+        `function _file(FileAttachment) {return (FileAttachment("empty"));}`
     }
   ]);
   return "ok";
 };
-const _1e555b1 = async function _test_compile_mutable_dep(compile,expect)
+const _14c9yxp = async function _test_compile_mutable_dep(compile,expect)
 {
   const compiled = await compile(`mutable_dep = {
   viewof view;
@@ -22782,12 +22792,12 @@ const _1e555b1 = async function _test_compile_mutable_dep(compile,expect)
       _name: "mutable_dep",
       _inputs: ["viewof view", "lambda", "mutable q"],
       _definition:
-        "function _mutable_dep($0,lambda,$1) {\n    $0;\n    lambda;\n    $1.value;\n    return $1.value;\n}"
+        "function _mutable_dep($0,lambda,$1) {\n  $0;\n  lambda;\n  $1.value;\n  return $1.value;\n}"
     }
   ]);
   return "ok";
 };
-const _1a2af6 = async function _test_compile_mutable_dep2(compile,expect)
+const _133w84q = async function _test_compile_mutable_dep2(compile,expect)
 {
   const compiled = await compile(`mutable_dep_2 = {
   file;
@@ -22798,7 +22808,7 @@ const _1a2af6 = async function _test_compile_mutable_dep2(compile,expect)
       _name: "mutable_dep_2",
       _inputs: ["file", "q"],
       _definition:
-        "function _mutable_dep_2(file,q) {\n    file;\n    return q + 1;\n}"
+        "function _mutable_dep_2(file,q) {\n  file;\n  return q + 1;\n}"
     }
   ]);
   return "ok";
@@ -22839,14 +22849,14 @@ const _1y1h47u = async function _test_compile_dep(compile,expect)
   ]);
   return "ok";
 };
-const _kwdsyz = async function _test_compile_class(compile,expect)
+const _1r711sh = async function _test_compile_class(compile,expect)
 {
   const compiled = await compile(`v = class {}`);
   expect(compiled).toEqual([
     {
       _name: "v",
       _inputs: [],
-      _definition: `function _v() {return (class {\n});}`
+      _definition: `function _v() {return (class {});}`
     }
   ]);
   return "ok";
@@ -23073,7 +23083,7 @@ JSON.stringify(
 const _eom91x = function _158(compile,test_case){return(
 compile(test_case.value)
 )};
-const _ttos3c = function _compile(parser,observableToJs){return(
+const _mliwy8 = function _compile(parser,observableToJs){return(
 function compile(source, {
   anonymousName = '_anonymous'
 } = {}) {
@@ -23260,9 +23270,9 @@ function compile(source, {
     if (!_definition) {
       let functionBody;
       if (cell.body.type === 'BlockStatement') {
-        functionBody = observableToJs(cell.body, inputToArgMap, comments, tokens);
+        functionBody = observableToJs(cell.body, inputToArgMap, source);
       } else {
-        const bodyCode = observableToJs(cell.body, inputToArgMap, comments, tokens);
+        const bodyCode = observableToJs(cell.body, inputToArgMap, source);
         functionBody = `{return (${ bodyCode });}`;
       }
       _definition = `${ cell.async ? 'async ' : '' }function${ cell.generator ? '*' : '' } ${ v.functionName }(${ v.inputs.join(',') }) ${ functionBody }`;
@@ -23275,31 +23285,35 @@ function compile(source, {
   });
 }
 )};
-const _1v1i7wl = function _observableToJs(acorn_walk,parser,escodegen){return(
-(ast, inputMap, comments, tokens) => {
-  // Replace ViewExpression with their id so they are removed from
-  // source and replaced with a JS compatible one
-  const offset = 0;
+const _16p8atj = function _observableToJs(acorn_walk,parser){return(
+(ast, inputMap, source) => {
+  // Source-preserving: slice the original body text verbatim and splice only the
+  // Observable-specific macro ranges (`viewof foo` → $N, `mutable foo` →
+  // $N.value). Regenerating via escodegen used to drop the ASI-protecting paren
+  // in `return( … )`, normalize quotes, respace `${ x }`, and reindent — all
+  // avoided by never regenerating. Ranges are offsets into `source`.
+  const edits = [];
   acorn_walk.ancestor(
     ast,
     {
-      ViewExpression(node, ancestors) {
-        const reference = "viewof " + node.id.name;
-        node.type = "Identifier";
-        node.name = inputMap[node.id.name];
+      ViewExpression(node) {
+        edits.push({ start: node.start, end: node.end, text: inputMap[node.id.name] });
       },
-      MutableExpression(node, ancestors) {
-        const reference = "mutable " + node.id.name;
-        node.type = "Identifier";
-        // hack as ".value" is not valid identifier, but escodegen allows it
-        node.name = inputMap[node.id.name] + ".value";
+      MutableExpression(node) {
+        // ".value" is not a valid identifier but is valid member access here.
+        edits.push({ start: node.start, end: node.end, text: inputMap[node.id.name] + ".value" });
       }
     },
     parser.walk
   );
-  escodegen.attachComments(ast, comments, tokens);
-  const js = escodegen.generate(ast, { comment: true });
-  return js;
+  const base = ast.start;
+  let out = source.slice(ast.start, ast.end);
+  edits
+    .sort((a, b) => b.start - a.start)
+    .forEach((e) => {
+      out = out.slice(0, e.start - base) + e.text + out.slice(e.end - base);
+    });
+  return out;
 }
 )};
 const _1ayjluu = function _161(md){return(
@@ -23345,12 +23359,6 @@ const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url
         '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
     }));
 };
-const _1hiclbb = function _acorn_walk(acorn_walk_url) {
-    return import(acorn_walk_url);
-};
-const _1cz8oe9 = function _acorn_walk_url(decompress_url,FileAttachment){return(
-decompress_url(FileAttachment("acorn-walk-8.3.2.js.gz"))
-)};
 const _1rc67k0 = function _stageB_importFake()
 {
   return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
@@ -23543,13 +23551,143 @@ const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_
   expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
   return 'ok';
 };
+const _r2e0wl = function _test_extractModuleInfo_new_id_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com d/<id>@<ver> import with resolutions=.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)'
+    )
+  ).toEqual({ id: "e1c39d41e8e944b0", version: "939" });
+  return "ok";
+};
+const _1pg1y6s = function _test_extractModuleInfo_new_slug_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com slug import carries a resolutions= param.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)'
+    )
+  ).toEqual({ namespace: "mootari", notebook: "access-runtime", version: "1392" });
+  return "ok";
+};
+const _1vh26m0 = function _test_findModuleName_classic_bundle(expect,findModuleName)
+{
+  // classic observablehq.com bundles imports; the holder def is a bare slug import.
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("@tomlarkworthy/flow-queue")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@tomlarkworthy/flow-queue");
+  return "ok";
+};
+const _1ltqcwj = function _test_findModuleName_kit_slug(expect,findModuleName)
+{
+  // Notebook Kit compiles observable imports to import("https://api.observablehq.com/@u/nb.js?v=4").
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async (__ojs_runtime) => __ojs_runtime.module((await import("https://api.observablehq.com/@d3/color-legend.js?v=4")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@d3/color-legend");
+  return "ok";
+};
+const _wq4poo = function _test_findModuleName_new_id(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("d/e1c39d41e8e944b0@939");
+  return "ok";
+};
+const _1j0hksu = function _test_findModuleName_new_slug(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@mootari/access-runtime");
+  return "ok";
+};
+const _3en7eq = async function _test_decompile_leading_comment(decompile,expect,compile)
+{
+  // Regression: a comment in the compiler's auto-wrap slot (`return( // note\n42 )`)
+  // is preserved in ASI-safe block form — never the hazardous `return` + comment
+  // + newline WITHOUT the paren that evaluated to undefined on ObservableHQ.
+  const src = await decompile([
+    { _name: "c", _definition: `function _c(){return( // note\n42\n)}`, _inputs: [] }
+  ]);
+  expect(src).toEqual(`c = {return( // note\n42\n)}`);
+  // It keeps the ASI-protecting paren and round-trips through compile to 42.
+  const cell = compile(src);
+  const first = Array.isArray(cell) ? cell[0] : cell;
+  const def = first._definition || (first.cells && first.cells[0]._definition);
+  expect(eval(`(${def})`)()).toEqual(42);
+  return "ok";
+};
+const _z17nwa = async function _test_decompile_trailing_comment(decompile,expect)
+{
+  // Regression: a comment that survives compile inside the block (trailing on the
+  // return line, or before the closing brace) must survive decompile too — don't
+  // unwrap a single-return block when a comment sits outside the returned value.
+  const trailing = await decompile([
+    { _name: "x", _definition: `function _x(){\n  return 1; // done\n}`, _inputs: [] }
+  ]);
+  expect(trailing).toEqual(`x = {\n  return 1; // done\n}`);
+  const tail = await decompile([
+    { _name: "y", _definition: `function _y(){\n  return 1;\n  // tail\n}`, _inputs: [] }
+  ]);
+  expect(tail).toEqual(`y = {\n  return 1;\n  // tail\n}`);
+  return "ok";
+};
+const _q5y9bo = async function _test_decompile_param_in_string(decompile,expect)
+{
+  // Regression: renaming an underscore-encoded viewof/mutable param must rewrite
+  // only identifier references, never same-spelled text inside a string literal
+  // (range-based splice, not the old source.replaceAll).
+  const decompiled = await decompile([
+    {
+      _name: "u",
+      _definition: `function _u(viewof_x){return(\n"viewof_x literal" + viewof_x\n)}`,
+      _inputs: ["viewof x"]
+    }
+  ]);
+  expect(decompiled).toEqual(`u = "viewof_x literal" + viewof x`);
+  return "ok";
+};
+const _fm2sgc = async function _test_decompile_class_property_field(decompile,expect)
+{
+  // Regression: a class field declaration must decompile cleanly. Source-slicing
+  // sidesteps the escodegen shim gap that threw "this[d] is not a function".
+  const decompiled = await decompile([
+    {
+      _name: "Cls",
+      _definition: `function _Cls(){return(\nclass Cls {\n  d;\n}\n)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`Cls = class Cls {\n  d;\n}`);
+  return "ok";
+};
+const _1xp8nli = async function _test_compile_preserves_formatting(compile,expect)
+{
+  // Source-preserving compile keeps quote style and template spacing verbatim;
+  // escodegen used to re-quote ("h1" -> 'h1') and respace (${s} -> ${ s }).
+  const compiled = await compile('x = { const s = "h1"; return `${s}`; }');
+  expect(compiled[0]._definition).toEqual('function _x() { const s = "h1"; return `${s}`; }');
+  return "ok";
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map(["acorn-walk-8.3.2.js.gz","parser-6.1.0.js.gz"].map((name) => {
+  const fileAttachments = new Map(["parser-6.1.0.js.gz"].map((name) => {
     const module_name = "@tomlarkworthy/observablejs-toolchain";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
@@ -23585,7 +23723,7 @@ export default function define(runtime, observer) {
   $def("_x55zzr", "test_decompiled_cells_recompilable", ["all_compiled"], _x55zzr);  
   $def("_100n7xr", null, ["md"], _100n7xr);  
   $def("_1nm57o2", "roundtripped", ["all_compiled","decompile"], _1nm57o2);  
-  $def("_18xo2td", "test_all_cells_roundtrippable", ["roundtripped"], _18xo2td);  
+  $def("_1shi9or", "test_all_cells_roundtrippable", ["roundtripped"], _1shi9or);  
   $def("_14nox99", null, ["md"], _14nox99);  
   $def("_1d3zr3i", null, ["md"], _1d3zr3i);  
   $def("_12sqt9", "dependancy_document", [], _12sqt9);  
@@ -23605,52 +23743,52 @@ export default function define(runtime, observer) {
   $def("_25tjxa", "test_decompile_syntax_error_roundtrip", ["compile","decompile","expect"], _25tjxa);  
   $def("_1jyrnzq", "test_decompile_$variable", ["decompile","expect"], _1jyrnzq);  
   $def("_1v1d8m3", "test_decompile_import_variable", ["decompile","importFake","expect"], _1v1d8m3);  
-  $def("_fiyb80", "test_decompile_dollar_in_string_literal", ["decompile","expect"], _fiyb80);  
+  $def("_1ybjsqg", "test_decompile_dollar_in_string_literal", ["decompile","expect"], _1ybjsqg);  
   $def("_wgfrtq", "test_decompile_import_variable_alias", ["decompile","importFake","expect"], _wgfrtq);  
   $def("_1a8gnrc", "test_decompile_import_many", ["decompile","importFake","expect"], _1a8gnrc);  
   $def("_7stpu3", "test_decompile_markdown_cell", ["decompile","expect"], _7stpu3);  
   $def("_v4p1js", "test_decompile_constant", ["decompile","expect"], _v4p1js);  
-  $def("_pcs4h", "test_decompile_string_literal", ["decompile","expect"], _pcs4h);  
+  $def("_1puzspw", "test_decompile_string_literal", ["decompile","expect"], _1puzspw);  
   $def("_a2zh99", "test_decompile_html_cell", ["decompile","expect"], _a2zh99);  
-  $def("_pyp280", "test_decompile_class", ["decompile","expect"], _pyp280);  
+  $def("_1pt67ao", "test_decompile_class", ["decompile","expect"], _1pt67ao);  
   $def("_kf8c3f", "test_decompile_class_with_property", ["decompile"], _kf8c3f);  
   $def("_4vunhm", "test_decompile_object_literal", ["decompile","expect"], _4vunhm);  
   $def("_s14e29", "test_decompile_reference", ["decompile","expect"], _s14e29);  
-  $def("_4rsshj", "test_decompile_block", ["decompile","expect"], _4rsshj);  
-  $def("_o7o1wl", "test_decompile_comments", ["decompile","expect"], _o7o1wl);  
+  $def("_14nvmno", "test_decompile_block", ["decompile","expect"], _14nvmno);  
+  $def("_5kd9if", "test_decompile_comments", ["decompile","expect"], _5kd9if);  
   $def("_1yn35e3", "test_decompile_generator", ["decompile","expect"], _1yn35e3);  
-  $def("_135eswd", "test_decompile_function", ["decompile","expect"], _135eswd);  
-  $def("_1pitq2", "test_decompile_async_function", ["decompile","expect"], _1pitq2);  
-  $def("_1kxe1b2", "test_decompile_named_function", ["decompile","expect"], _1kxe1b2);  
+  $def("_10wf7cf", "test_decompile_function", ["decompile","expect"], _10wf7cf);  
+  $def("_1191zxm", "test_decompile_async_function", ["decompile","expect"], _1191zxm);  
+  $def("_vpu09i", "test_decompile_named_function", ["decompile","expect"], _vpu09i);  
   $def("_1pghf4f", "test_decompile_this_reference", ["decompile","expect"], _1pghf4f);  
-  $def("_4aeghn", "test_decompile_lambda", ["decompile","expect"], _4aeghn);  
+  $def("_rajn7p", "test_decompile_lambda", ["decompile","expect"], _rajn7p);  
   $def("_12ec5zd", "test_decompile_error", ["decompile","expect"], _12ec5zd);  
-  $def("_3bj09h", "test_decompile_error_object", ["decompile","expect"], _3bj09h);  
+  $def("_1c93ef9", "test_decompile_error_object", ["decompile","expect"], _1c93ef9);  
   $def("_6iufw4", null, ["md"], _6iufw4);  
   $def("_15idqib", "test_decompile_anon_error_dep", ["decompile","expect"], _15idqib);  
   $def("_mhm98c", "test_decompile_viewof", ["decompile","expect"], _mhm98c);  
   $def("_15kgqrr", "test_decompile_mutable", ["decompile","expect"], _15kgqrr);  
   $def("_1onyv5c", "test_decompile_builtin", ["decompile","expect"], _1onyv5c);  
-  $def("_1uv76xx", "test_decompile_fileattachment", ["decompile","expect"], _1uv76xx);  
+  $def("_4z1dnp", "test_decompile_fileattachment", ["decompile","expect"], _4z1dnp);  
   $def("_g4z6de", "test_decompile_mutable_dependancy", ["decompile","expect"], _g4z6de);  
   $def("_qo8sdl", "test_decompile_mutable_dependancy_2", ["decompile","expect"], _qo8sdl);  
   $def("_15kwaz1", "test_decompile_viewof_dep", ["decompile","expect"], _15kwaz1);  
   $def("_1qjzk2s", "test_decompile_viewof_data_dep", ["decompile","expect"], _1qjzk2s);  
-  $def("_ehz2xk", "test_decompile_viewof_param", ["decompile","expect"], _ehz2xk);  
+  $def("_b0y8zg", "test_decompile_viewof_param", ["decompile","expect"], _b0y8zg);  
   $def("_oilkc0", "test_decompile_anon_dep", ["decompile","expect"], _oilkc0);  
-  $def("_1jggajo", "test_decompile_import_mutable", ["decompile","expect"], _1jggajo);  
-  $def("_di0abi", "test_decompile_import_viewof", ["decompile","expect"], _di0abi);  
-  $def("_14o5oio", "test_decompile_viewof_data", ["decompile","expect"], _14o5oio);  
-  $def("_1lv4syw", "test_decompile_import_alias", ["decompile","expect"], _1lv4syw);  
-  $def("_l8b8hu", "test_decompile_import_mutable_alias", ["decompile","expect"], _l8b8hu);  
-  $def("_1g5n3sa", "test_decompile_import_mutable_data_alias", ["decompile","expect"], _1g5n3sa);  
-  $def("_1lnngk6", "test_decompile_import_viewof_alias", ["decompile","expect"], _1lnngk6);  
-  $def("_1na1e5i", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1na1e5i);  
+  $def("_1eqf4jq", "test_decompile_import_mutable", ["decompile","expect"], _1eqf4jq);  
+  $def("_3damo4", "test_decompile_import_viewof", ["decompile","expect"], _3damo4);  
+  $def("_1l9xqsw", "test_decompile_viewof_data", ["decompile","expect"], _1l9xqsw);  
+  $def("_1cggvdk", "test_decompile_import_alias", ["decompile","expect"], _1cggvdk);  
+  $def("_xcwq4", "test_decompile_import_mutable_alias", ["decompile","expect"], _xcwq4);  
+  $def("_1868h0w", "test_decompile_import_mutable_data_alias", ["decompile","expect"], _1868h0w);  
+  $def("_1afcxhk", "test_decompile_import_viewof_alias", ["decompile","expect"], _1afcxhk);  
+  $def("_1sl510", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1sl510);  
   $def("_17dwb6r", null, ["md"], _17dwb6r);  
   main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
   $def("_1vs6mei", null, ["md"], _1vs6mei);  
   $def("_1g89k6a", "escodegenOptions", ["escodegen"], _1g89k6a);  
-  $def("_llvq9s", "decompile", ["decompileImport","formatImportDeclaration","acorn","escodegen","escodegenOptions"], _llvq9s);  
+  $def("_2d5g1", "decompile", ["decompileImport","formatImportDeclaration","acorn"], _2d5g1);  
   $def("_1pvis67", null, ["md"], _1pvis67);  
   $def("_183j58u", "extractModuleInfo", [], _183j58u);  
   $def("_w445v0", "test_extractModuleInfo_notebook_resolution", ["expect","extractModuleInfo"], _w445v0);  
@@ -23685,30 +23823,30 @@ export default function define(runtime, observer) {
   $def("_69vyub", "test_compile_syntax_error_anonymous", ["compile","expect"], _69vyub);  
   $def("_1c9p3om", "test_compile_syntax_error_named", ["compile","expect"], _1c9p3om);  
   $def("_x7zc8w", "test_compile_integer", ["compile","expect"], _x7zc8w);  
-  $def("_1u7hlem", "test_compile_string", ["compile","expect"], _1u7hlem);  
+  $def("_1qp2ggw", "test_compile_string", ["compile","expect"], _1qp2ggw);  
   $def("_151bijp", "test_compile_obj_literal", ["compile","expect"], _151bijp);  
-  $def("_ti9okn", "test_compile_assignment", ["compile","expect"], _ti9okn);  
+  $def("_17z4vyt", "test_compile_assignment", ["compile","expect"], _17z4vyt);  
   $def("_1eb8vq", "test_compile_dependancy", ["compile","expect"], _1eb8vq);  
-  $def("_acs4l0", "test_compile_block_dependancy", ["compile","expect"], _acs4l0);  
-  $def("_125ljg9", "test_compile_comments", ["compile","expect"], _125ljg9);  
-  $def("_li37je", "test_compile_generator", ["compile","expect"], _li37je);  
-  $def("_em4em6", "test_compile_function", ["compile","expect"], _em4em6);  
-  $def("_w3atfb", "test_compile_async_function", ["compile","expect"], _w3atfb);  
-  $def("_14gl6yr", "test_compile_named_function", ["compile","expect"], _14gl6yr);  
+  $def("_5b8x33", "test_compile_block_dependancy", ["compile","expect"], _5b8x33);  
+  $def("_9s1umz", "test_compile_comments", ["compile","expect"], _9s1umz);  
+  $def("_1rbs7b6", "test_compile_generator", ["compile","expect"], _1rbs7b6);  
+  $def("_1gaxmhs", "test_compile_function", ["compile","expect"], _1gaxmhs);  
+  $def("_2ozyn1", "test_compile_async_function", ["compile","expect"], _2ozyn1);  
+  $def("_1jn3lk9", "test_compile_named_function", ["compile","expect"], _1jn3lk9);  
   $def("_z3bqb8", "test_compile_this_reference", ["compile","expect"], _z3bqb8);  
-  $def("_1sou7t0", "test_compile_lambda", ["compile","expect"], _1sou7t0);  
-  $def("_1o1u737", "test_compile_error", ["compile","expect"], _1o1u737);  
+  $def("_1lyze5m", "test_compile_lambda", ["compile","expect"], _1lyze5m);  
+  $def("_12k1xub", "test_compile_error", ["compile","expect"], _12k1xub);  
   $def("_y271kb", "test_compile_viewof", ["compile","expect"], _y271kb);  
   $def("_1q4asyp", "test_compile_viewof_and_value_coexist", ["compile","expect"], _1q4asyp);  
   $def("_189jvkd", "test_compile_mutable", ["compile","expect"], _189jvkd);  
   $def("_78egw8", "test_compile_builtin", ["compile","expect"], _78egw8);  
-  $def("_lflzev", "test_compile_fileattachment", ["compile","expect"], _lflzev);  
-  $def("_1e555b1", "test_compile_mutable_dep", ["compile","expect"], _1e555b1);  
-  $def("_1a2af6", "test_compile_mutable_dep2", ["compile","expect"], _1a2af6);  
+  $def("_1o65727", "test_compile_fileattachment", ["compile","expect"], _1o65727);  
+  $def("_14c9yxp", "test_compile_mutable_dep", ["compile","expect"], _14c9yxp);  
+  $def("_133w84q", "test_compile_mutable_dep2", ["compile","expect"], _133w84q);  
   $def("_ql80wk", "test_compile_inline_viewof", ["compile","expect"], _ql80wk);  
   $def("_1k420gu", "test_compile_view_dep", ["compile","expect"], _1k420gu);  
   $def("_1y1h47u", "test_compile_dep", ["compile","expect"], _1y1h47u);  
-  $def("_kwdsyz", "test_compile_class", ["compile","expect"], _kwdsyz);  
+  $def("_1r711sh", "test_compile_class", ["compile","expect"], _1r711sh);  
   $def("_33oop5", "test_compile_event", ["compile","expect"], _33oop5);  
   $def("_9phvzk", "test_compile_tagged_literal", ["compile","expect"], _9phvzk);  
   $def("_1q0pie3", "compile_unit_test_template", ["Inputs","test_case","compiled"], _1q0pie3);  
@@ -23728,15 +23866,15 @@ export default function define(runtime, observer) {
   $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
   $def("_1klx74n", null, ["compiled_selector","normalizeJavascriptSource"], _1klx74n);  
   $def("_eom91x", null, ["compile","test_case"], _eom91x);  
-  $def("_ttos3c", "compile", ["parser","observableToJs"], _ttos3c);  
-  $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser","escodegen"], _1v1i7wl);  
+  $def("_mliwy8", "compile", ["parser","observableToJs"], _mliwy8);  
+  $def("_16p8atj", "observableToJs", ["acorn_walk","parser"], _16p8atj);  
   $def("_1ayjluu", null, ["md"], _1ayjluu);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
   $def("_s9w7ha", "parser", ["decompress_url","FileAttachment","acorn_url","acorn_walk_url"], _s9w7ha);  
-  $def("_1hiclbb", "acorn_walk", ["acorn_walk_url"], _1hiclbb);  
   main.define("acorn", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn", _));  
   main.define("acorn_url", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_url", _));  
-  $def("_1cz8oe9", "acorn_walk_url", ["decompress_url","FileAttachment"], _1cz8oe9);  
+  main.define("acorn_walk", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_walk", _));  
+  main.define("acorn_walk_url", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn_walk_url", _));  
   main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
   main.define("Runtime", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
@@ -23752,10 +23890,20 @@ export default function define(runtime, observer) {
   $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
   $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
   $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
-  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);  
+  $def("_r2e0wl", "test_extractModuleInfo_new_id_resolutions", ["expect","extractModuleInfo"], _r2e0wl);  
+  $def("_1pg1y6s", "test_extractModuleInfo_new_slug_resolutions", ["expect","extractModuleInfo"], _1pg1y6s);  
+  $def("_1vh26m0", "test_findModuleName_classic_bundle", ["expect","findModuleName"], _1vh26m0);  
+  $def("_1ltqcwj", "test_findModuleName_kit_slug", ["expect","findModuleName"], _1ltqcwj);  
+  $def("_wq4poo", "test_findModuleName_new_id", ["expect","findModuleName"], _wq4poo);  
+  $def("_1j0hksu", "test_findModuleName_new_slug", ["expect","findModuleName"], _1j0hksu);  
+  $def("_3en7eq", "test_decompile_leading_comment", ["decompile","expect","compile"], _3en7eq);  
+  $def("_z17nwa", "test_decompile_trailing_comment", ["decompile","expect"], _z17nwa);  
+  $def("_q5y9bo", "test_decompile_param_in_string", ["decompile","expect"], _q5y9bo);  
+  $def("_fm2sgc", "test_decompile_class_property_field", ["decompile","expect"], _fm2sgc);  
+  $def("_1xp8nli", "test_compile_preserves_formatting", ["compile","expect"], _1xp8nli);
   return main;
-}
-</script>
+}</script>
 
 <script id="@tomlarkworthy/plugin-registry" 
   type="text/plain"
@@ -30114,7 +30262,8 @@ export default function define(runtime, observer) {
 {
   "mains": ["@tomlarkworthy/lopepage","@tomlarkworthy/editable-md"],
   "hash": "#view=S100(@tomlarkworthy/editable-md,@tomlarkworthy/module-selection)",
-  "headless": true
+  "headless": true,
+  "prerender": true
 }
 </script>
 <script id="@tomlarkworthy/bootloader" 

--- a/notebooks/@tomlarkworthy_editable-md.json
+++ b/notebooks/@tomlarkworthy_editable-md.json
@@ -7,7 +7,8 @@
       "@tomlarkworthy/editable-md"
     ],
     "hash": "#view=S100(@tomlarkworthy/editable-md,@tomlarkworthy/module-selection)",
-    "headless": true
+    "headless": true,
+    "prerender": true
   },
   "files": [
     "syntax.css"
@@ -187,7 +188,7 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "8ebd5648d99d2f74c7921378b12d21bb",
+      "hash": "5a9e633da6399dfd1cfcc35308262bca",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
@@ -450,9 +451,8 @@
       ]
     },
     "@tomlarkworthy/observablejs-toolchain": {
-      "hash": "c966316acf0555f9b3780691ef4ce73c",
+      "hash": "51012bee759fa75116e593e6ba9477d1",
       "files": [
-        "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
       ],
       "dependsOn": [


### PR DESCRIPTION
Follow-up to #119.

#119 had to ship with `@tomlarkworthy/observablejs-toolchain` hand-restored from the pre-jumpgate bundle: the copy on ObservableHQ had a stale `compile` that still called `observableToJs(cell.body, inputToArgMap, comments, tokens)` after the source-preserving refactor changed the signature to `(ast, inputMap, source)`. `source` was therefore the comments array, `source.slice(start, end)` returned `[]`, and every expression cell compiled to `function _t(md) {return ();}` — which broke editable-md's commit path on *any* edit.

`compile` has since been pushed to Observable (notebook now at v7827), so this is a clean jumpgate with no hand-restored blocks.

## What moves relative to main

- **`@tomlarkworthy/observablejs-toolchain`** — now the genuine Observable copy rather than the restored older one.
- **`@tomlarkworthy/exporter-3`** — an unrelated upstream edit that landed on Observable between the two jumpgate runs: `options.prerender = conf.prerender` → `options.prerender = conf.prerender !== false`, i.e. prerender now defaults on unless explicitly disabled. Flagging it because it rides along with the bundle rather than being part of this change.

The `@tomlarkworthy/editable-md` module itself is byte-identical to main (same Observable v870).

## Verification (this exact file, clean load)

- ✅ `compile("t = md`| a |\n| --- |\n| 1 |`")` returns `function _t(md) {return (md`…`);}` — a real body.
- ✅ 12/13 tests pass, including `test_table_round_trip` and `test_table_placeholder_round_trip`. (`test_defaultMarkdownParser_preserves_escapes` is the known pre-existing failure, unchanged.)
- ✅ Click a table cell → type → TAB → SHIFT+ENTER commits cleanly:
  ```
  | feature | editable | notes |
  | :--- | :---: | ---: |
  | paragraphs | yes | since v1 JG |
  | TABBED | yes | alignment survives |
  ```
- ✅ Console clean, no `SyntaxError` from `saveAndRender`.